### PR TITLE
Add dynamic scroll indicator

### DIFF
--- a/portfolio/src/components/Footer.tsx
+++ b/portfolio/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-const Footer = () => {
-  return <div>Footer</div>;
-};
+const Footer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function Footer(props, ref) {
+  return <div ref={ref} {...props}>Footer</div>;
+});
 
 export default Footer;

--- a/portfolio/src/components/MainSection.tsx
+++ b/portfolio/src/components/MainSection.tsx
@@ -1,5 +1,3 @@
-import { ArrowDown } from "lucide-react";
-
 const MainSection = () => {
   return (
     <section
@@ -48,10 +46,6 @@ const MainSection = () => {
         </div>
       </div>
 
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 flex flex-col items-center animate-bounce">
-        <span className="text-sm text-muted-foreground mb-2"> Scroll </span>
-        <ArrowDown className="h-5 w-5 text-primary" />
-      </div>
     </section>
   );
 };

--- a/portfolio/src/components/ScrollIndicator.tsx
+++ b/portfolio/src/components/ScrollIndicator.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { ArrowDown } from "lucide-react";
+import { cn } from "../lib/utils";
+
+interface ScrollIndicatorProps {
+  footerRef: React.RefObject<HTMLElement>;
+  targetId?: string;
+}
+
+const ScrollIndicator = ({ footerRef, targetId }: ScrollIndicatorProps) => {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!footerRef.current) return;
+      const footerTop = footerRef.current.getBoundingClientRect().top;
+      const windowHeight = window.innerHeight;
+      setHidden(footerTop <= windowHeight);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll();
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [footerRef]);
+
+  const handleClick = () => {
+    if (targetId) {
+      const el = document.querySelector(targetId);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth" });
+        return;
+      }
+    }
+    window.scrollBy({ top: window.innerHeight, behavior: "smooth" });
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label="Scroll down"
+      className={cn(
+        "fixed bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center animate-bounce transition-opacity duration-300",
+        hidden ? "opacity-0" : "opacity-100"
+      )}
+    >
+      <span className="text-sm text-muted-foreground mb-2">Scroll</span>
+      <ArrowDown className="h-5 w-5 text-primary" />
+    </button>
+  );
+};
+
+export default ScrollIndicator;

--- a/portfolio/src/pages/Home.tsx
+++ b/portfolio/src/pages/Home.tsx
@@ -5,8 +5,11 @@ import MainSection from "../components/MainSection";
 import AboutMeSection from "../components/AboutMeSection";
 import SkillsSection from "../components/SkillsSection";
 import Footer from "../components/Footer";
+import ScrollIndicator from "../components/ScrollIndicator";
+import { useRef } from "react";
 
 const Home = () => {
+  const footerRef = useRef<HTMLDivElement>(null);
   return (
     <div className="min-h-screen bg-background text-foreground overflow-hidden">
       {/* Theme Toggle */}
@@ -26,7 +29,10 @@ const Home = () => {
       </main>
 
       {/* Footer */}
-      <Footer />
+      <Footer ref={footerRef} />
+
+      {/* Scroll Indicator */}
+      <ScrollIndicator footerRef={footerRef} targetId="#about" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide MainSection scroll hint and add a new fixed ScrollIndicator component
- forward ref in Footer for visibility check
- show ScrollIndicator at screen bottom and hide when footer reaches viewport
- integrate ScrollIndicator into Home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its types)*

------
https://chatgpt.com/codex/tasks/task_b_683d435dc31483258d4680c9d4e6e035