### PR TITLE
fix: restore mobile nav, page metadata and static assets

### DIFF
--- a/portfolio/.gitignore
+++ b/portfolio/.gitignore
@@ -151,7 +151,9 @@ next-env.d.ts
 
 # Gatsby files
 .cache/
-public
+# NOTE: no bare `public` here. Gatsby *builds into* public/, but this repo is Vite,
+# where public/ holds committed source assets (favicon, CV). A bare `public` rule
+# silently kept every static asset out of git.
 
 # Storybook build outputs
 .out

--- a/portfolio/frontend/.gitignore
+++ b/portfolio/frontend/.gitignore
@@ -58,3 +58,6 @@ next-env.d.ts
 
 # Local Netlify folder
 .netlify
+# CV / resume PDFs are hosted externally, never committed: they carry a personal
+# phone number and a public git history cannot be un-published. Set VITE_CV_URL.
+public/assets/*.pdf

--- a/portfolio/frontend/env.example
+++ b/portfolio/frontend/env.example
@@ -7,4 +7,10 @@ VITE_APP_VERSION=1.0.0
 
 # Development Settings
 VITE_DEBUG=true
-VITE_ENVIRONMENT=development 
+VITE_ENVIRONMENT=development
+
+# Public URL of the CV PDF. The file is intentionally not committed (it contains a
+# personal phone number), so this MUST be set in the Vercel project settings or the
+# "Download CV" button will 404 in production. Locally, drop the PDF at
+# frontend/public/assets/CV_PhamDangKhoi_Internship.pdf and leave this blank.
+VITE_CV_URL=

--- a/portfolio/frontend/index.html
+++ b/portfolio/frontend/index.html
@@ -3,9 +3,29 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Vite + React + TS</title>
+
+  <title>Phạm Đăng Khôi — Full Stack Developer</title>
+  <meta name="description"
+    content="Portfolio of Phạm Đăng Khôi, a full stack developer based in Vietnam. Java, Spring Boot, React and TypeScript projects, plus certificates and career history." />
+  <meta name="author" content="Phạm Đăng Khôi" />
+  <!-- No canonical / og:url yet: the only URL available today is a generated Vercel
+       one, and pointing canonical at a URL that later rots is worse than omitting it.
+       Both get set once the custom domain is attached. -->
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="theme-color" content="#4F46E5" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Phạm Đăng Khôi" />
+  <meta property="og:title" content="Phạm Đăng Khôi — Full Stack Developer" />
+  <meta property="og:description"
+    content="Java, Spring Boot, React and TypeScript projects, plus certificates and career history." />
+
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Phạm Đăng Khôi — Full Stack Developer" />
+  <meta name="twitter:description"
+    content="Java, Spring Boot, React and TypeScript projects, plus certificates and career history." />
 </head>
 
 <body>

--- a/portfolio/frontend/public/favicon.svg
+++ b/portfolio/frontend/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#4F46E5" />
+  <path d="M20 16v32M20 33l16-17M27 30l17 18"
+        stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+</svg>

--- a/portfolio/frontend/src/App.tsx
+++ b/portfolio/frontend/src/App.tsx
@@ -1,17 +1,14 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Home from "./pages/Home";
 import NotFound from "./pages/NotFound";
-import StarBackground from "./components/StarBackground";
-import NatureBackground from "./components/NatureBackground";
 import CareerJourney from "./pages/CareerJourney";
 import Certificates from "./pages/Certificates";
-import { useTheme } from "./components/ThemeContext";
 
 function App() {
-  const { isDarkMode } = useTheme();
+  // The animated background is rendered by each page, not here — rendering it in
+  // both places mounted two layers with two rAF loops running at the same time.
   return (
     <>
-      {isDarkMode ? <StarBackground /> : <NatureBackground />}
       <BrowserRouter>
         <Routes>
           <Route index element={<Home />} />

--- a/portfolio/frontend/src/components/AboutMeSection.tsx
+++ b/portfolio/frontend/src/components/AboutMeSection.tsx
@@ -1,6 +1,12 @@
 import { Briefcase, Code, Sparkles, UserCircle } from "lucide-react";
 import { motion } from "framer-motion";
 
+// The CV is deliberately NOT committed — it carries a personal phone number and a
+// public git history is forever. It is hosted externally and pointed at via env.
+// Locally it falls back to public/assets/, which is gitignored.
+const CV_URL =
+  import.meta.env.VITE_CV_URL || "/assets/CV_PhamDangKhoi_Internship.pdf";
+
 const AboutMeSection = () => {
   return (
     <section id="about" className="py-24 px-4 relative overflow-hidden">
@@ -106,7 +112,7 @@ const AboutMeSection = () => {
               </a>
 
               <a
-                href="/assets/CV_PhamDangKhoi_Internship.pdf"
+                href={CV_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-8 py-3 rounded-full border-2 border-primary text-primary hover:bg-primary/10 transition-all duration-300 relative overflow-hidden group transform hover:scale-105"

--- a/portfolio/frontend/src/components/Footer.tsx
+++ b/portfolio/frontend/src/components/Footer.tsx
@@ -23,7 +23,7 @@ const Footer = () => {
           <div className="flex justify-center gap-6">
             <motion.a
               whileHover={{ scale: 1.1, y: -5 }}
-              href="https://github.com/dangkhoi2204"
+              href="https://github.com/dangkhoipham80"
               target="_blank"
               rel="noopener noreferrer"
               className="p-3 rounded-xl bg-primary/10 hover:bg-primary/20 transition-all duration-300"

--- a/portfolio/frontend/src/components/MainSection.tsx
+++ b/portfolio/frontend/src/components/MainSection.tsx
@@ -239,7 +239,7 @@ const MainSection = () => {
         className="container max-w-4xl mx-auto text-center z-10 mt-16"
       >
         <motion.div variants={itemVariants} className="space-y-8">
-          <motion.h1 className="text-4xl md:text-6xl font-bold tracking-tight font-mono flex items-center justify-center gap-4">
+          <motion.h1 className="text-2xl sm:text-4xl md:text-6xl font-bold tracking-tight font-mono flex flex-wrap items-center justify-center gap-x-3 gap-y-2 md:gap-4">
             <motion.div
               initial={{ scale: 0, rotate: -180 }}
               animate={{ scale: 1, rotate: 0 }}
@@ -266,7 +266,10 @@ const MainSection = () => {
             </motion.div>
             <span className="inline-block">Hi,</span>{" "}
             <span className="inline-block">I'm&nbsp;</span>
-            <span className="bg-gradient-to-r from-primary via-primary/80 to-primary/60 bg-clip-text text-transparent min-w-[16ch] h-[1.2em] flex items-center relative whitespace-nowrap">
+            {/* min-w reserves room so the typewriter does not reflow the line on every
+                keystroke — but 16ch of mono type overflows a phone, so only reserve it
+                once there is room for it. */}
+            <span className="bg-gradient-to-r from-primary via-primary/80 to-primary/60 bg-clip-text text-transparent sm:min-w-[16ch] h-[1.2em] flex items-center relative whitespace-nowrap">
               {displayed}
               <span className="inline-block animate-pulse">|</span>
               <span className="absolute -bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-primary/60 via-primary to-primary/60 rounded-full"></span>

--- a/portfolio/frontend/src/components/Navbar.tsx
+++ b/portfolio/frontend/src/components/Navbar.tsx
@@ -14,16 +14,17 @@ const navItems = [
     path: "#",
     items: [
       { name: "Career Journey", path: "/career-journey" },
-      { name: "Achievements and Awards", path: "/achievements" },
-      { name: "Blog", path: "/blog" },
-      { name: "Testimonials", path: "/testimonials" },
-      { name: "Resume", path: "/resume" },
-      { name: "Contact", path: "/#contact" },
-      { name: "Activity", path: "/activity" },
       { name: "Certificates", path: "/certificates" },
+      { name: "Contact", path: "/#contact" },
     ],
   },
 ];
+
+// The mobile menu has no room for a dropdown, so the "More" group is flattened
+// into the same single-level list.
+const mobileNavItems = navItems.flatMap((item) =>
+  item.items ? item.items : [{ name: item.name, path: item.path }]
+);
 
 const Navbar = () => {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -32,6 +33,7 @@ const Navbar = () => {
   const [displayText, setDisplayText] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const fullText = "Phạm Đăng Khôi";
   const location = useLocation();
 
@@ -57,6 +59,58 @@ const Navbar = () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, []);
+
+  // While the mobile menu is open: trap Tab inside it, close on Escape, freeze the
+  // page behind it, and hand focus over (then hand it back to the trigger on close).
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    const menu = menuRef.current;
+    const trigger = document.activeElement as HTMLElement | null;
+    const focusables = () =>
+      Array.from(
+        menu?.querySelectorAll<HTMLElement>("a[href], button:not([disabled])") ?? []
+      );
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsMenuOpen(false);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const items = focusables();
+      if (items.length === 0) return;
+
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && (active === first || !menu?.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+    focusables()[0]?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+      trigger?.focus?.();
+    };
+  }, [isMenuOpen]);
+
+  // Close the mobile menu whenever the route changes.
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => {
     let timeout: NodeJS.Timeout;
@@ -87,9 +141,8 @@ const Navbar = () => {
       initial={{ y: -100 }}
       animate={{ y: 0 }}
       transition={{ duration: 0.5 }}
-      // Add 'hidden' for mobile, and 'md:block' to show on medium and larger screens
       className={cn(
-        "fixed w-full z-40 transition-all duration-300 hidden md:block", // <-- Changed here
+        "fixed w-full z-40 transition-all duration-300",
         isScrolled
           ? "py-3 bg-background/80 backdrop-blur-lg border-b border-foreground/10 shadow-lg"
           : "py-5"
@@ -98,7 +151,7 @@ const Navbar = () => {
       <div className="container flex items-center justify-between">
         <motion.a
           whileHover={{ scale: 1.02 }}
-          className="text-xl font-bold flex items-center gap-2"
+          className="text-base sm:text-xl font-bold flex items-center gap-2"
           href="/"
         >
           <span className="relative">
@@ -110,11 +163,14 @@ const Navbar = () => {
                 className="inline-block w-[2px] h-[1em] bg-primary ml-[2px]"
               />
             </span>
-            <span className="text-foreground/80 ml-2">Portfolio</span>
+            {/* Dropped on phones so the brand cannot run under the floating theme toggle. */}
+            <span className="hidden sm:inline text-foreground/80 ml-2">
+              Portfolio
+            </span>
           </span>
         </motion.a>
 
-        {/* desktop navigation (already hidden on mobile by the parent 'nav' element) */}
+        {/* desktop navigation */}
         <div className="hidden md:flex items-center space-x-8">
           {navItems.map((item, key) =>
             item.items ? (
@@ -156,11 +212,7 @@ const Navbar = () => {
                         return (
                           <Link
                             key={subKey}
-                            to={
-                              location.pathname === "/"
-                                ? location.hash
-                                : subItem.path
-                            }
+                            to={subItem.path}
                             className="block px-4 py-2 text-sm text-foreground hover:bg-primary/10 hover:text-primary transition-colors duration-200"
                             onClick={(e) => {
                               setIsDropdownOpen(false);
@@ -207,7 +259,7 @@ const Navbar = () => {
             ) : item.path.startsWith("/#") ? (
               <Link
                 key={key}
-                to={location.pathname === "/" ? location.hash : item.path}
+                to={item.path}
                 className="text-lg text-foreground hover:text-primary transition-colors duration-300"
                 onClick={(e) => {
                   if (location.pathname === "/") {
@@ -230,37 +282,59 @@ const Navbar = () => {
           )}
         </div>
 
-        {/* mobile menu button and overlay (these will now never be visible because the parent 'nav' is hidden on mobile) */}
-        {/* You can remove these if you want to keep your code clean, as they are effectively not used */}
+        {/* mobile menu button */}
         <button
           onClick={() => setIsMenuOpen((prev) => !prev)}
-          className="md:hidden p-2 text-foreground z-50 hidden" // Added 'hidden'
-          aria-label={isMenuOpen ? "Close Menu" : "Open Menu"}
+          className="md:hidden p-2 text-foreground z-50"
+          aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={isMenuOpen}
+          aria-controls="mobile-menu"
         >
-          {isMenuOpen ? <X size={24} /> : <Menu size={24} />}{" "}
+          {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
 
+        {/* mobile menu overlay */}
         <div
+          id="mobile-menu"
+          ref={menuRef}
+          hidden={!isMenuOpen}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Site navigation"
           className={cn(
-            "fixed inset-0 bg-background/95 backdrop-blur-md z-40 flex flex-col items-center justify-center hidden", // Added 'hidden'
-            "transition-all duration-300 md:hidden",
-            isMenuOpen
-              ? "opacity-100 pointer-events-auto"
-              : "opacity-0 pointer-events-none"
+            "fixed inset-0 bg-background/95 backdrop-blur-md z-40 md:hidden",
+            "flex flex-col items-center justify-center"
           )}
         >
-          <div className="flex flex-col space-y-8 text-xl">
-            {navItems.map((item, key) => (
-              <a
-                key={key}
-                href={item.path || "#"}
-                className="text-foreground/80 hover:text-primary transition-colors duration-300"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                {item.name}
-              </a>
-            ))}
-          </div>
+          <nav className="flex flex-col items-center space-y-6 text-xl">
+            {mobileNavItems.map((item) =>
+              item.path.startsWith("/#") ? (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  className="text-foreground/80 hover:text-primary transition-colors duration-300"
+                  onClick={(e) => {
+                    setIsMenuOpen(false);
+                    if (location.pathname === "/") {
+                      e.preventDefault();
+                      window.location.hash = item.path.replace("/#", "#");
+                    }
+                  }}
+                >
+                  {item.name}
+                </Link>
+              ) : (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  className="text-foreground/80 hover:text-primary transition-colors duration-300"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  {item.name}
+                </Link>
+              )
+            )}
+          </nav>
         </div>
       </div>
     </motion.nav>

--- a/portfolio/frontend/src/components/ThemeToggle.tsx
+++ b/portfolio/frontend/src/components/ThemeToggle.tsx
@@ -8,9 +8,12 @@ const ThemeToggle = () => {
   return (
     <button
       onClick={toggleTheme}
+      aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
       className={cn(
-        "fixed max-sm:hidden top-5 right-5 z-50 p-2 rounded-full transition-colors duration-300",
-        "focus:outline-hidden"
+        "fixed z-50 p-2 rounded-full transition-colors duration-300",
+        // On mobile the hamburger sits in the top-right corner, so sit just left of it.
+        "top-5 right-5 max-sm:top-4 max-sm:right-20",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
       )}
     >
       {isDarkMode ? (


### PR DESCRIPTION
First slice of the full-stack rebuild. Scope is deliberately narrow: fix what is
broken on the **currently deployed site** without touching anything the Next.js
migration will rewrite anyway. The Vite app stays in production until the new
frontend passes smoke tests.

## What was broken

| | Before |
|---|---|
| Mobile navigation | None at all — `<nav>` was `hidden md:block`, and the hamburger *and* overlay were hardcoded `hidden`, with a leftover comment saying "you can remove these" |
| Page title | `Vite + React + TS` |
| SEO / social | No description, no OG, no Twitter tags |
| Favicon | `/vite.svg` did not exist; the SPA rewrite served `index.html` for it |
| Static assets | **Never committed.** A bare `public` rule from a Gatsby boilerplate ignored the whole directory |
| CV download | Only worked because a stale Vercel build still served it — the next deploy from this repo would have 404'd it |
| Background | Rendered twice on every route (`App.tsx` + each page) → two concurrent `requestAnimationFrame` loops |
| Nav "More" menu | 5 of 8 links (`/achievements`, `/blog`, `/testimonials`, `/resume`, `/activity`) had no routes and fell to the 404 page |
| Theme toggle | `max-sm:hidden` — mobile users could not switch theme |
| Footer GitHub | `github.com/dangkhoi2204` → 404 |
| Hero on mobile | `min-w-[16ch]` + `whitespace-nowrap` clipped the name on both sides |

## Root cause worth calling out

`portfolio/.gitignore` carried a bare `public` entry inside a "# Gatsby files"
block. Gatsby *builds into* `public/`; Vite uses it as **source**. That single
line is why no static asset was ever in this repo.

## The CV is intentionally not committed

Security review found the PDF carries a real phone number. A public git history
cannot be un-published, so the file is gitignored and referenced via
`VITE_CV_URL`, with a local `public/assets/` fallback for dev.

> [!IMPORTANT]
> **Set `VITE_CV_URL` in the Vercel project before the next deploy**, or the
> "Download CV" button will 404. Upload the PDF to Vercel Blob / Cloudinary and
> point the variable at it.

## Review

Two subagents reviewed the diff (security, and correctness/a11y).

Acted on:
- Theme toggle overlapped the brand text by **40px @320 / 27px @375** — measured, then fixed by shrinking the brand and dropping its "Portfolio" suffix below `sm`. Now 0px at every width.
- No focus trap on the mobile menu — added, plus `role="dialog"`, `aria-modal`, focus-in on open and focus-restore on close.
- `canonical`/`og:url` pointed at a generated Vercel URL that will rot — removed until the custom domain lands.
- Hash links passed `to={location.hash}` (the *current* hash, not the target) and only worked because `onClick` called `preventDefault`.

Rejected, with evidence:
- One reviewer raised a CRITICAL that `hidden={!isMenuOpen}` is a no-op because the `.flex` utility layer outranks base-layer `[hidden]`, leaving the overlay permanently covering the page. **False.** Tailwind v4 preflight emits `[hidden]:where(:not([hidden=until-found])){display:none!important}` — verified in the built CSS — and Playwright confirms `display:none`, height 0, and a clickable hamburger at 320/375/414.

Deferred to the rewrite: typewriter reflow jitter, missing `og:image`, and the undefined `--color-secondary` used by `Certificates.tsx`.

## Verification

`tsc -b && vite build` clean. Playwright at 320/375/414/768/1440 in both themes — 22/22 pass: menu opens/closes/traps focus, no ghost links, one background layer, one `h1`, CV and favicon resolve, no horizontal overflow, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)