### PR TITLE
fix(api): reject tokens presented as the wrong type

### DIFF
--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -61,14 +61,19 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
 
 
-def verify_token(token: str) -> Optional[dict]:
+def verify_token(token: str, expected_type: Optional[str] = None) -> Optional[dict]:
     """Decode and verify a JWT, returning its claims or None.
 
     ``algorithms`` is an allow-list, so a token whose header advertises
     ``none`` — or any algorithm other than HS256 — is rejected outright.
+
+    ``expected_type`` checks the ``type`` claim that user_service.create_token
+    stamps on every token. Without it a 30-day refresh token authenticated
+    every bearer-protected route, which defeats the point of issuing a
+    60-minute access token alongside it.
     """
     try:
-        return jwt.decode(
+        payload = jwt.decode(
             token,
             settings.SECRET_KEY,
             algorithms=[ALGORITHM],
@@ -77,16 +82,21 @@ def verify_token(token: str) -> Optional[dict]:
     except jwt.PyJWTError:
         return None
 
+    if expected_type is not None and payload.get("type") != expected_type:
+        return None
+
+    return payload
+
 
 def get_current_user(token: str) -> str:
-    """Return the subject claim of a valid token, or raise 401."""
+    """Return the subject of a valid *access* token, or raise 401."""
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    payload = verify_token(token)
+    payload = verify_token(token, expected_type="access")
     if payload is None:
         raise credentials_exception
 

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.exceptions import UnauthorizedError, ValidationError
-from app.core.security import verify_token
+from app.core.security import get_password_hash, verify_token
 from app.models.token import TokenType
 from app.models.user import UserStatus
 from app.schemas.user import PasswordResetConfirm, PasswordResetRequest, TokenResponse, UserLogin
@@ -38,13 +38,12 @@ class AuthService:
     # the seed script, so nothing needs a public signup path.
 
     def refresh_token(self, refresh_token: str) -> TokenResponse:
-        """Refresh access token using refresh token"""
-        # Verify refresh token
-        token_data = verify_token(refresh_token)
-        if not token_data or token_data.get("type") != TokenType.REFRESH.value:
+        """Exchange a refresh token for a new token pair."""
+        token_data = verify_token(refresh_token, expected_type=TokenType.REFRESH.value)
+        if not token_data:
             raise UnauthorizedError("Invalid refresh token")
 
-        user_id = int(token_data.get("sub"))
+        user_id = int(token_data["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user or not user.is_active:
             raise UnauthorizedError("User not found or inactive")
@@ -92,14 +91,18 @@ class AuthService:
         token = self.user_service.get_valid_token(request.token, TokenType.RESET_PASSWORD)
         if not token:
             raise ValidationError("Invalid or expired reset token")
-        
-        user_id = int(verify_token(request.token).get("sub"))
+
+        payload = verify_token(request.token, expected_type=TokenType.RESET_PASSWORD.value)
+        if not payload:
+            raise ValidationError("Invalid or expired reset token")
+
+        user_id = int(payload["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user:
             raise ValidationError("User not found")
-        
+
         # Update password
-        user.hashed_password = self.user_service.get_password_hash(request.new_password)
+        user.hashed_password = get_password_hash(request.new_password)
         user.updated_at = datetime.now(timezone.utc)
         self.db.commit()
         
@@ -114,8 +117,12 @@ class AuthService:
         token_obj = self.user_service.get_valid_token(token, TokenType.EMAIL_VERIFICATION)
         if not token_obj:
             raise ValidationError("Invalid or expired verification token")
-        
-        user_id = int(verify_token(token).get("sub"))
+
+        payload = verify_token(token, expected_type=TokenType.EMAIL_VERIFICATION.value)
+        if not payload:
+            raise ValidationError("Invalid or expired verification token")
+
+        user_id = int(payload["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user:
             raise ValidationError("User not found")

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -17,6 +17,7 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core.security import create_access_token
 from app.main import app
 
 client = TestClient(app)
@@ -83,6 +84,17 @@ def test_alg_none_token_is_rejected():
 
 def test_malformed_token_is_rejected():
     r = _call("post", "/api/v1/projects/", headers={"Authorization": "Bearer garbage.token.here"})
+    assert r.status_code in (401, 403)
+
+
+def test_refresh_token_cannot_be_used_as_an_access_token():
+    """A refresh token lives for 30 days; an access token for 60 minutes.
+
+    Without a check on the `type` claim the long-lived one authenticated every
+    protected route, which made the short access-token lifetime meaningless.
+    """
+    refresh = create_access_token({"sub": "1", "type": "refresh"})
+    r = _call("post", "/api/v1/projects/", headers={"Authorization": f"Bearer {refresh}"})
     assert r.status_code in (401, 403)
 
 


### PR DESCRIPTION
Second of five stacked PRs splitting the API security hardening. **Base is `phase-1-access-control` (#10), not `main`** — review that one first; GitHub will retarget this to `main` once #10 merges.

## What was wrong

Every token this API issues carries a `type` claim, and nothing checked it. `verify_token()` returned the claims of any correctly-signed token, so:

- A **refresh token authenticated every bearer-protected route.** It lives 30 days; the access token lives 60 minutes. The short lifetime bought nothing, because the long-lived token was accepted everywhere the short one was.
- Password-reset and email-verification tokens were interchangeable with each other and with access tokens.

## The fix

`verify_token()` grows an optional `expected_type` and returns `None` on mismatch. `get_current_user()` passes `"access"`; the reset and verification paths pass theirs. The `algorithms` allow-list is untouched.

## Two crashes found in the same code paths

Both reachable from unauthenticated endpoints, both fixed here because they live in the lines this PR was already rewriting:

- **Password reset was entirely broken.** `reset_password()` called `self.user_service.get_password_hash(...)` — `UserService` has no such method. Anyone who got as far as a valid reset token got an `AttributeError`. Now calls `get_password_hash` from `app.core.security`, which `user_service.py` already imports and uses.
- `int(verify_token(t).get("sub"))` raised `AttributeError` instead of returning 4xx when the token failed to decode. Both call sites now check the payload before subscripting.

## Verification

`test_refresh_token_cannot_be_used_as_an_access_token` forges a refresh token and asserts a protected route rejects it. 23 tests pass, ruff clean. No CI in this repo, so that was run locally.

Note the crash fixes are not directly covered — reaching them needs a valid reset token, which needs a seeded user and a live mail path. They are asserted by reading, not by test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
