### PR TITLE
fix(api): make logout actually revoke, and stop storing tokens in the clear

### DIFF
--- a/apps/api/app/api/v1/dependencies.py
+++ b/apps/api/app/api/v1/dependencies.py
@@ -13,34 +13,51 @@ from app.services.user_service import UserService
 # Security scheme
 security = HTTPBearer()
 
+_UNAUTHORIZED = HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED,
+    detail=ErrorMessages.UNAUTHORIZED,
+    headers={"WWW-Authenticate": "Bearer"},
+)
+
+
 def get_current_user_dependency(
     credentials: HTTPAuthorizationCredentials = Depends(security),
     db: Session = Depends(get_db)
 ):
-    """Dependency to get current authenticated user"""
+    """Resolve the caller from a bearer access token."""
+    token = credentials.credentials
+
+    # Raises 401 on a bad signature, a wrong/missing type claim, or expiry.
+    user_id = get_current_user(token)
+
     try:
-        user_id = get_current_user(credentials.credentials)
-        user_service = UserService(db)
-        user = user_service.get_user_by_id(int(user_id))
-        if not user:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=ErrorMessages.UNAUTHORIZED
-            )
-        
-        # Check if user is active
-        if not user.is_active:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="User account is deactivated"
-            )
-        
-        return user
-    except HTTPException:
+        user_pk = int(user_id)
+    except (TypeError, ValueError):
+        # A forged token could carry a non-numeric `sub`; that is a rejected
+        # credential, not a 500.
+        raise _UNAUTHORIZED from None
+
+    user_service = UserService(db)
+
+    # Logout marks the row revoked. Checking only the JWT meant a stolen token
+    # kept working for its full lifetime after the user logged out, which made
+    # logout purely cosmetic.
+    if not user_service.get_valid_token(token, TokenType.ACCESS):
+        raise _UNAUTHORIZED
+
+    user = user_service.get_user_by_id(user_pk)
+    if not user:
+        raise _UNAUTHORIZED
+
+    if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ErrorMessages.UNAUTHORIZED
+            detail="User account is deactivated",
+            headers={"WWW-Authenticate": "Bearer"},
         )
+
+    return user
+
 
 def get_optional_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -43,6 +43,13 @@ class AuthService:
         if not token_data:
             raise UnauthorizedError("Invalid refresh token")
 
+        # The signature alone is not enough: logout() and reset_password() revoke
+        # the row, not the JWT. Checking only the signature here left the other
+        # half of the logout hole open — a stolen refresh token kept minting
+        # fresh access tokens for its full 30 days after the user logged out.
+        if not self.user_service.get_valid_token(refresh_token, TokenType.REFRESH):
+            raise UnauthorizedError("Invalid refresh token")
+
         user_id = int(token_data["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user or not user.is_active:

--- a/apps/api/app/services/user_service.py
+++ b/apps/api/app/services/user_service.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
@@ -185,22 +187,43 @@ class UserService:
         return user
 
     # Token management
+    @staticmethod
+    def hash_token(token_string: str) -> str:
+        """Digest a token for storage.
+
+        The column is named token_hash but used to hold the raw JWT, with a
+        "# In production, hash this" note next to it. That meant read access to
+        the database handed over every live access, refresh and reset token in
+        directly usable form. A digest is enough: lookups are exact-match, so
+        there is nothing to compare fuzzily and no need to be reversible.
+        """
+        return hashlib.sha256(token_string.encode("utf-8")).hexdigest()
+
     def create_token(self, user_id: int, token_type: TokenType, expires_in_minutes: int = 30, metadata: Dict[str, Any] = None) -> str:
         """Create a new token"""
 
         expires_at = datetime.now(timezone.utc) + timedelta(minutes=expires_in_minutes)
-        token_data = {"sub": str(user_id), "type": token_type.value}
+
+        # `jti` makes the JWT unique. Without it the payload is just sub/type/exp/iat,
+        # and exp/iat have one-second resolution — so two logins inside the same
+        # second produced byte-identical tokens and therefore two rows with the same
+        # hash. revoke_token() updates .first() of those, so logout would flip one row
+        # while get_valid_token() went on matching the other: the token stayed live.
+        token_data = {
+            "sub": str(user_id),
+            "type": token_type.value,
+            "jti": secrets.token_urlsafe(16),
+        }
 
         if metadata:
             token_data.update(metadata)
 
         token_string = create_access_token(token_data, timedelta(minutes=expires_in_minutes))
 
-        # Store token in database
         token = Token(
             user_id=user_id,
             token_type=token_type,
-            token_hash=token_string,  # In production, hash this
+            token_hash=self.hash_token(token_string),
             expires_at=expires_at,
             token_metadata=json.dumps(metadata) if metadata else None
         )
@@ -210,12 +233,14 @@ class UserService:
 
         return token_string
 
-    def revoke_token(self, token_hash: str) -> bool:
-        """Revoke a token"""
-        token = self.db.query(Token).filter(Token.token_hash == token_hash).first()
+    def revoke_token(self, token_string: str) -> bool:
+        """Revoke a token, given the token itself."""
+        token = self.db.query(Token).filter(
+            Token.token_hash == self.hash_token(token_string)
+        ).first()
         if not token:
             return False
-        
+
         token.is_revoked = True
         self.db.commit()
         return True
@@ -233,11 +258,11 @@ class UserService:
         self.db.commit()
         return True
 
-    def get_valid_token(self, token_hash: str, token_type: TokenType) -> Optional[Token]:
-        """Get a valid token"""
+    def get_valid_token(self, token_string: str, token_type: TokenType) -> Optional[Token]:
+        """Look up a token by its value; None if unknown, revoked or expired."""
         token = self.db.query(Token).filter(
             and_(
-                Token.token_hash == token_hash,
+                Token.token_hash == self.hash_token(token_string),
                 Token.token_type == token_type,
                 Token.is_revoked.is_(False),
                 Token.expires_at > datetime.now(timezone.utc)

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -98,6 +98,24 @@ def test_refresh_token_cannot_be_used_as_an_access_token():
     assert r.status_code in (401, 403)
 
 
+def test_token_not_present_in_the_database_is_rejected():
+    """Logout revokes the row, so authentication has to consult it.
+
+    A correctly signed token that was never issued — or was issued and then
+    revoked — must not authenticate.
+    """
+    orphan = create_access_token({"sub": "1", "type": "access"})
+    r = _call("post", "/api/v1/projects/", headers={"Authorization": f"Bearer {orphan}"})
+    assert r.status_code in (401, 403)
+
+
+def test_non_numeric_subject_is_rejected_not_a_crash():
+    """`int(sub)` used to raise ValueError straight out of the dependency."""
+    weird = create_access_token({"sub": "not-a-number", "type": "access"})
+    r = _call("post", "/api/v1/projects/", headers={"Authorization": f"Bearer {weird}"})
+    assert r.status_code in (401, 403), r.status_code
+
+
 @pytest.mark.parametrize("path", ["/api/v1/auth/register", "/api/v1/auth/google"])
 def test_public_signup_surface_is_gone(path):
     """Single-owner API: the admin comes from the seed script, not signup."""

--- a/apps/api/tests/test_token_lifecycle.py
+++ b/apps/api/tests/test_token_lifecycle.py
@@ -1,0 +1,166 @@
+"""Token issue/revoke behaviour, exercised against the database.
+
+test_security.py drives HTTP and can only assert "rejected". These cases go
+through the service layer with a real session, because the interesting part of
+revocation is what happens to a token that *is* correctly signed — a request
+test cannot tell "rejected because revoked" apart from "rejected because the
+signature was bad".
+
+Needs whatever ``DATABASE_URL`` points at; each test cleans up the row it made.
+"""
+
+import pytest
+
+from app.core.database import SessionLocal
+from app.core.exceptions import UnauthorizedError
+from app.core.security import verify_token
+from app.models.token import Token, TokenType
+from app.models.user import User, UserStatus
+from app.services.auth_service import AuthService
+from app.services.user_service import UserService
+
+
+@pytest.fixture
+def db():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+TEST_EMAIL = "token-lifecycle@example.invalid"
+
+
+def _drop_test_user(db):
+    """Remove the row if it is there. Tokens cascade with it.
+
+    Called before as well as after: the email is unique, so a run that dies
+    mid-test (a dropped connection is enough) would otherwise poison every
+    later run with a UniqueViolation in the fixture.
+    """
+    existing = db.query(User).filter(User.email == TEST_EMAIL).first()
+    if existing:
+        db.delete(existing)
+        db.commit()
+
+
+@pytest.fixture
+def user(db):
+    """A throwaway active user. Tokens cascade-delete with the row."""
+    _drop_test_user(db)
+
+    record = User(
+        email=TEST_EMAIL,
+        username="token-lifecycle",
+        full_name="Token Lifecycle",
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        status=UserStatus.ACTIVE,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+
+    yield record
+
+    _drop_test_user(db)
+
+
+def test_a_live_refresh_token_mints_a_new_pair(db, user):
+    """Baseline, so the revocation test below cannot pass vacuously."""
+    refresh = UserService(db).create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    pair = AuthService(db).refresh_token(refresh)
+
+    assert pair.access_token
+    assert pair.user_id == user.id
+
+
+def test_a_revoked_refresh_token_cannot_mint_new_tokens(db, user):
+    """This is the other half of the logout hole.
+
+    Revoking on logout only means something if refresh consults the row.
+    Verifying the signature alone let a stolen refresh token keep minting fresh
+    access tokens for its full 30-day life after the user had logged out.
+    """
+    service = UserService(db)
+    refresh = service.create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    AuthService(db).logout(access_token="unused", refresh_token=refresh)
+
+    with pytest.raises(UnauthorizedError):
+        AuthService(db).refresh_token(refresh)
+
+
+def test_refresh_rotates_the_token_it_consumed(db, user):
+    """The consumed token must not be replayable after rotation."""
+    refresh = UserService(db).create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    AuthService(db).refresh_token(refresh)
+
+    with pytest.raises(UnauthorizedError):
+        AuthService(db).refresh_token(refresh)
+
+
+def test_password_reset_kills_outstanding_sessions(db, user):
+    """revoke_all_user_tokens() is what makes "reset the password" a remedy."""
+    service = UserService(db)
+    refresh = service.create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    service.revoke_all_user_tokens(user.id)
+
+    with pytest.raises(UnauthorizedError):
+        AuthService(db).refresh_token(refresh)
+
+
+def test_every_token_carries_a_unique_id(db, user):
+    """`jti` is load-bearing, not decoration.
+
+    The rest of the payload — sub, type, exp, iat — is identical for two tokens
+    minted for the same user in the same second, and exp/iat only have
+    second resolution. Without `jti` the two JWTs came out byte-identical and
+    stored the same hash on two rows; revoke_token() updates .first() of those,
+    so logout flipped one row while get_valid_token() went on matching the
+    other and the "revoked" token kept working.
+
+    Asserted on the claim rather than by minting two tokens and comparing them:
+    whether two calls land in the same second depends on how slow the commit
+    between them happens to be, so that version of this test passes against the
+    bug about as often as it catches it.
+    """
+    service = UserService(db)
+    tokens = [
+        service.create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+        for _ in range(5)
+    ]
+
+    ids = [verify_token(t, expected_type="access")["jti"] for t in tokens]
+
+    assert len(set(ids)) == len(ids)
+    assert len(set(tokens)) == len(tokens)
+
+
+def test_revoking_one_token_leaves_the_others_alone(db, user):
+    """A user with two live sessions logs out of one; the other survives."""
+    service = UserService(db)
+    first = service.create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+    second = service.create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+
+    service.revoke_token(first)
+
+    assert service.get_valid_token(first, TokenType.ACCESS) is None
+    assert service.get_valid_token(second, TokenType.ACCESS) is not None
+
+
+def test_the_raw_token_is_never_written_to_the_database(db, user):
+    """The column is called token_hash; it used to hold the JWT itself, so read
+    access to the table handed over every live token ready to use."""
+    token = UserService(db).create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+
+    stored = db.query(Token).filter(Token.user_id == user.id).all()
+
+    assert stored
+    assert all(row.token_hash != token for row in stored)
+    assert all(len(row.token_hash) == 64 for row in stored)


### PR DESCRIPTION
Third of five stacked PRs. **Base is `phase-2-jwt-type` (#11)** — review #10 and #11 first; GitHub retargets this to `main` as they merge.

Three defects in one system: how issued tokens are recorded, and what the read path checks.

## 1. Logout was cosmetic

`logout()` set `is_revoked` on the token row — and nothing on the read path ever looked at that row. `get_current_user_dependency` trusted the JWT signature alone, and so did `refresh_token()`.

A token stolen after the user logged out kept working: 60 minutes for an access token, **30 days for a refresh token**, which could mint fresh access tokens for that entire window. Both paths now go through `get_valid_token()`, which filters on `is_revoked` and `expires_at`.

The refresh half is worth calling out separately. A previous pass closed this on the access-token path only; the refresh path was still signature-only, which left the more valuable half of the hole open.

## 2. Tokens were stored in the clear

The `token_hash` column held the raw JWT, with a `# In production, hash this` note beside it. Read access to the database handed over every live access, refresh, reset and verification token in directly usable form.

Now stores a SHA-256 digest. Lookups are exact-match, so nothing needed to be reversible. `revoke_token()` and `get_valid_token()` take the token itself and digest it internally.

## 3. Tokens were not unique — this one makes revocation silently unreliable

The payload was `sub`/`type`/`exp`/`iat`, and `exp`/`iat` have one-second resolution. Two tokens minted for one user **in the same second came out byte-identical** and stored the same digest on two rows. `revoke_token()` updates `.first()` of those, so logout flipped one row while `get_valid_token()` went on matching the other — and the "revoked" token kept working.

Every token now carries a random `jti`.

Also fixed: a forged token with a non-numeric `sub` reached `int()` and returned 500 rather than 401.

## Verification

New `tests/test_token_lifecycle.py` (7 tests) goes through the service layer against a real session, because an HTTP test cannot distinguish "rejected because revoked" from "rejected because the signature was bad". 32 tests pass, ruff clean, run locally — this repo has no CI.

I backed each fix out again to confirm the tests catch it. Worth flagging: my first version of the `jti` test minted two tokens and compared them, and it **passed against the bug** — whether two calls land in the same second depends on how slow the intervening commit is. It now asserts on the claim itself and fails deterministically. The three revocation tests do fail when the `get_valid_token` check is removed.

Note the new tests insert rows into whatever `DATABASE_URL` points at, so point it at a scratch database. The fixture clears its user before *and* after: a dropped connection mid-run leaves the row behind and would otherwise poison later runs with a `UniqueViolation`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
