### PR TITLE
fix(api): stop leaking which emails are registered, key rate limits on the real IP

### DIFF
--- a/apps/api/app/core/rate_limit.py
+++ b/apps/api/app/core/rate_limit.py
@@ -4,7 +4,35 @@ Lives here rather than in app.main so endpoint modules can import it without a
 circular import (main -> api_router -> endpoints -> main).
 """
 
+from fastapi import Request
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address)
+from app.core.config import settings
+
+
+def client_ip(request: Request) -> str:
+    """Best-effort real client IP.
+
+    slowapi's ``get_remote_address`` reads ``request.client.host``, which behind
+    Vercel or Railway is the proxy — so every visitor shares a single bucket and
+    five contact-form submissions in total lock the form for everyone.
+
+    ``X-Forwarded-For`` is only trusted in production, where a proxy is actually
+    terminating the connection and appending the real address. Trusting it
+    locally (or on a directly-exposed port) would let a caller pick their own
+    rate-limit key by sending the header themselves.
+    """
+    fallback = request.client.host if request.client else "unknown"
+
+    if not settings.is_production:
+        return fallback
+
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        # Left-most entry is the original client; the rest are proxy hops.
+        return forwarded.split(",")[0].strip() or fallback
+
+    return fallback
+
+
+limiter = Limiter(key_func=client_ip)

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -146,16 +146,15 @@ class AuthService:
         return True
 
     def resend_verification_email(self, email: str) -> bool:
-        """Resend email verification"""
+        """Resend email verification.
+
+        Returns quietly for unknown or already-verified addresses. It used to
+        raise "User not found", which let anyone enumerate registered emails —
+        request_password_reset() one method up already got this right.
+        """
         user = self.user_service.get_user_by_email(email)
-        if not user:
-            raise ValidationError("User not found")
-
-        if user.is_verified:
-            raise ValidationError("Email is already verified")
-
-        if user.google_id:
-            raise ValidationError("OAuth users don't need email verification")
+        if not user or user.is_verified:
+            return True
 
         # Create new verification token
         verification_token = self.user_service.create_token(

--- a/apps/api/scripts/init_auth_tables.py
+++ b/apps/api/scripts/init_auth_tables.py
@@ -122,17 +122,31 @@ def create_default_admin():
     user_service = UserService(db)
 
     # Check if admin already exists
-    admin_user = user_service.get_user_by_email("admin@example.com")
+    # Credentials come from the environment. This used to hardcode
+    # admin@example.com / admin123, so anyone who ran the script — or simply
+    # read the repository — knew how to log in as the administrator.
+    email = os.environ.get("ADMIN_EMAIL")
+    password = os.environ.get("ADMIN_PASSWORD")
+
+    if not email or not password:
+        raise SystemExit(
+            "Set ADMIN_EMAIL and ADMIN_PASSWORD before running this script. Generate one with:\n"
+            '  python -c "import secrets; print(secrets.token_urlsafe(24))"'
+        )
+
+    if len(password) < 12:
+        raise SystemExit("ADMIN_PASSWORD must be at least 12 characters.")
+
+    admin_user = user_service.get_user_by_email(email)
     if admin_user:
         print("⚠️  Admin user already exists")
         return admin_user
 
-    # Create admin user
     admin_data = UserCreate(
-        email="admin@example.com",
+        email=email,
         username="admin",
         full_name="System Administrator",
-        password="admin123"  # Change this in production!
+        password=password,
     )
 
     try:


### PR DESCRIPTION
Fourth of five stacked PRs. **Base is `phase-3-revocation` (#12).** Three unrelated hardening fixes, grouped because each is a few lines.

## Email enumeration

`resend_verification_email()` raised `"User not found"` for an unknown address and `"Email is already verified"` for a known one. An unauthenticated caller could walk a list of addresses and learn which were registered.

Returns quietly either way now. `request_password_reset()` one method up already did exactly this, with a comment explaining why — this just brings the sibling method in line.

## Rate limiting was keyed on the proxy, not the visitor

`get_remote_address` reads `request.client.host`, which behind Vercel or Railway is the proxy. **Every visitor shared a single bucket**, so five contact-form submissions in total locked the form for everyone — a self-inflicted DoS on the one public write endpoint.

`client_ip()` now reads the left-most `X-Forwarded-For` entry, **but only in production**, where a proxy is actually terminating the connection and appending the real address. Trusting that header on a directly-exposed port would be worse than the bug: a caller could pick their own rate-limit key just by sending it.

## Seed script shipped working admin credentials

It created `admin@example.com` with password `admin123`, both literal in the file. Anyone who read the repo knew the administrator credentials of any deployment where the script had been run. Now requires `ADMIN_EMAIL` and `ADMIN_PASSWORD` from the environment and refuses passwords under 12 characters.

## Verification

32 tests pass, ruff clean, locally. `test_contact_form_is_public_but_rate_limited` covers the limiter still firing; the proxy-header branch is production-gated so the test exercises the fallback path.

The enumeration and seed-script changes have no test — the first needs a live mail path, the second is a script. Both asserted by reading.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
