### PR TITLE
chore(api): delete two unreachable helpers, fix the migration downgrade

### DIFF
--- a/apps/api/alembic/versions/4e8845a384cb_initial_schema.py
+++ b/apps/api/alembic/versions/4e8845a384cb_initial_schema.py
@@ -181,4 +181,9 @@ def downgrade() -> None:
     op.drop_table('contacts')
     op.drop_index(op.f('ix_certificates_id'), table_name='certificates')
     op.drop_table('certificates')
-    # ### end Alembic commands ### 
+    # ### end Alembic commands ###
+
+    # Autogenerate does not clean up named PostgreSQL enum types, so a
+    # downgrade-then-upgrade would fail with "type userstatus already exists".
+    op.execute("DROP TYPE IF EXISTS userstatus")
+    op.execute("DROP TYPE IF EXISTS tokentype")

--- a/apps/api/app/api/v1/dependencies.py
+++ b/apps/api/app/api/v1/dependencies.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -59,21 +58,12 @@ def get_current_user_dependency(
     return user
 
 
-def get_optional_user(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-    db: Session = Depends(get_db)
-):
-    """Dependency to get optional authenticated user (for public endpoints)"""
-    if not credentials:
-        return None
-    
-    try:
-        user_id = get_current_user(credentials.credentials)
-        user_service = UserService(db)
-        user = user_service.get_user_by_id(int(user_id))
-        return user if user and user.is_active else None
-    except Exception:
-        return None
+# get_optional_user() was removed. It took `Depends(security)` from the shared
+# HTTPBearer(), which defaults to auto_error=True and so raises 403 before the
+# body runs — its `if not credentials: return None` branch was unreachable.
+# Nothing used it, and left in place it would have silently rejected anonymous
+# callers on the first public route it was attached to.
+
 
 def require_admin(current_user = Depends(get_current_user_dependency)):
     """Dependency to require admin role"""

--- a/apps/api/app/api/v1/middleware.py
+++ b/apps/api/app/api/v1/middleware.py
@@ -2,10 +2,6 @@ import logging
 import time
 
 from fastapi import Request
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.trustedhost import TrustedHostMiddleware
-
-from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -43,24 +39,8 @@ class ErrorHandlingMiddleware:
             logger.error(f"Unhandled error: {str(e)}")
             raise
 
-def setup_middleware(app):
-    """Setup all middleware for the application"""
-    
-    # CORS middleware
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=settings.BACKEND_CORS_ORIGINS,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-    
-    # Trusted host middleware
-    app.add_middleware(
-        TrustedHostMiddleware,
-        allowed_hosts=["*"]  # Configure based on your needs
-    )
-    
-    # Custom middleware
-    app.middleware("http")(LoggingMiddleware())
-    app.middleware("http")(ErrorHandlingMiddleware()) 
+
+# setup_middleware() lived here and was never called — app/main.py wires CORS
+# itself. It has been removed rather than left lying around: it allowed
+# methods=["*"], headers=["*"] and TrustedHostMiddleware(allowed_hosts=["*"]),
+# so wiring it in "to add logging" would have quietly widened CORS.

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -107,7 +107,7 @@ class AuthService:
         user = self.user_service.get_user_by_id(user_id)
         if not user:
             raise ValidationError("User not found")
-
+        
         # Update password
         user.hashed_password = get_password_hash(request.new_password)
         user.updated_at = datetime.now(timezone.utc)
@@ -269,8 +269,3 @@ class AuthService:
         except Exception as e:
             # Log error but don't fail the request
             print(f"Failed to send email to {to_email}: {str(e)}")
-
-    def get_password_hash(self, password: str) -> str:
-        """Get password hash"""
-        from app.core.security import get_password_hash
-        return get_password_hash(password)


### PR DESCRIPTION
Last of five stacked PRs. **Base is `phase-4-misc` (#13).** Non-security housekeeping, deliberately kept out of the fix PRs so those stay easy to read.

## Two helpers that could not work

**`get_optional_user()`** was meant to let public routes see a caller if one was present. It took `Depends(security)` from the shared `HTTPBearer()`, which defaults to `auto_error=True` — so an anonymous request raised 403 *before the function body ran*, and its `if not credentials: return None` branch was unreachable. Nothing referenced it.

This one is worth deleting rather than leaving alone: the first public route to adopt it would have started rejecting exactly the anonymous callers it was written to accommodate, and the cause is invisible at the call site.

**`setup_middleware()`** was never called — `app/main.py` wires CORS itself. It set `allow_methods=["*"]`, `allow_headers=["*"]` and `TrustedHostMiddleware(allowed_hosts=["*"])`. Wiring it in later "to get the logging" would have quietly widened CORS and disabled host checking. The `LoggingMiddleware`/`ErrorHandlingMiddleware` classes it referenced are kept.

**`AuthService.get_password_hash()`** — wrapper with no remaining callers after #11.

## Migration downgrade was broken

`downgrade()` dropped its tables but not the named PostgreSQL enum types the upgrade created, so downgrade-then-upgrade failed with `type userstatus already exists`. Alembic autogenerate does not clean these up. Adds `DROP TYPE IF EXISTS` for `userstatus` and `tokentype`.

## Verification

32 tests pass, ruff clean, locally.

Ruff is doing real work in this PR specifically — removing `get_optional_user` orphans the `Optional` import, and that is the kind of thing a phase split gets wrong silently.

One end-to-end check on the whole series: this branch is **byte-identical** to the verified pre-split state (`git diff` against the backup tag is empty). The five PRs reorganise that work into reviewable units without changing a line of the result.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
