### PR TITLE
fix(api): land the token hardening from #11-#14 on main

### DIFF
--- a/apps/api/alembic/versions/4e8845a384cb_initial_schema.py
+++ b/apps/api/alembic/versions/4e8845a384cb_initial_schema.py
@@ -181,4 +181,9 @@ def downgrade() -> None:
     op.drop_table('contacts')
     op.drop_index(op.f('ix_certificates_id'), table_name='certificates')
     op.drop_table('certificates')
-    # ### end Alembic commands ### 
+    # ### end Alembic commands ###
+
+    # Autogenerate does not clean up named PostgreSQL enum types, so a
+    # downgrade-then-upgrade would fail with "type userstatus already exists".
+    op.execute("DROP TYPE IF EXISTS userstatus")
+    op.execute("DROP TYPE IF EXISTS tokentype")

--- a/apps/api/app/api/v1/dependencies.py
+++ b/apps/api/app/api/v1/dependencies.py
@@ -13,34 +13,51 @@ from app.services.user_service import UserService
 # Security scheme
 security = HTTPBearer()
 
+_UNAUTHORIZED = HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED,
+    detail=ErrorMessages.UNAUTHORIZED,
+    headers={"WWW-Authenticate": "Bearer"},
+)
+
+
 def get_current_user_dependency(
     credentials: HTTPAuthorizationCredentials = Depends(security),
     db: Session = Depends(get_db)
 ):
-    """Dependency to get current authenticated user"""
+    """Resolve the caller from a bearer access token."""
+    token = credentials.credentials
+
+    # Raises 401 on a bad signature, a wrong/missing type claim, or expiry.
+    user_id = get_current_user(token)
+
     try:
-        user_id = get_current_user(credentials.credentials)
-        user_service = UserService(db)
-        user = user_service.get_user_by_id(int(user_id))
-        if not user:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=ErrorMessages.UNAUTHORIZED
-            )
-        
-        # Check if user is active
-        if not user.is_active:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="User account is deactivated"
-            )
-        
-        return user
-    except HTTPException:
+        user_pk = int(user_id)
+    except (TypeError, ValueError):
+        # A forged token could carry a non-numeric `sub`; that is a rejected
+        # credential, not a 500.
+        raise _UNAUTHORIZED from None
+
+    user_service = UserService(db)
+
+    # Logout marks the row revoked. Checking only the JWT meant a stolen token
+    # kept working for its full lifetime after the user logged out, which made
+    # logout purely cosmetic.
+    if not user_service.get_valid_token(token, TokenType.ACCESS):
+        raise _UNAUTHORIZED
+
+    user = user_service.get_user_by_id(user_pk)
+    if not user:
+        raise _UNAUTHORIZED
+
+    if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ErrorMessages.UNAUTHORIZED
+            detail="User account is deactivated",
+            headers={"WWW-Authenticate": "Bearer"},
         )
+
+    return user
+
 
 def get_optional_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),

--- a/apps/api/app/api/v1/dependencies.py
+++ b/apps/api/app/api/v1/dependencies.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -59,21 +58,12 @@ def get_current_user_dependency(
     return user
 
 
-def get_optional_user(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-    db: Session = Depends(get_db)
-):
-    """Dependency to get optional authenticated user (for public endpoints)"""
-    if not credentials:
-        return None
-    
-    try:
-        user_id = get_current_user(credentials.credentials)
-        user_service = UserService(db)
-        user = user_service.get_user_by_id(int(user_id))
-        return user if user and user.is_active else None
-    except Exception:
-        return None
+# get_optional_user() was removed. It took `Depends(security)` from the shared
+# HTTPBearer(), which defaults to auto_error=True and so raises 403 before the
+# body runs — its `if not credentials: return None` branch was unreachable.
+# Nothing used it, and left in place it would have silently rejected anonymous
+# callers on the first public route it was attached to.
+
 
 def require_admin(current_user = Depends(get_current_user_dependency)):
     """Dependency to require admin role"""

--- a/apps/api/app/api/v1/middleware.py
+++ b/apps/api/app/api/v1/middleware.py
@@ -2,10 +2,6 @@ import logging
 import time
 
 from fastapi import Request
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.trustedhost import TrustedHostMiddleware
-
-from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -43,24 +39,8 @@ class ErrorHandlingMiddleware:
             logger.error(f"Unhandled error: {str(e)}")
             raise
 
-def setup_middleware(app):
-    """Setup all middleware for the application"""
-    
-    # CORS middleware
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=settings.BACKEND_CORS_ORIGINS,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-    
-    # Trusted host middleware
-    app.add_middleware(
-        TrustedHostMiddleware,
-        allowed_hosts=["*"]  # Configure based on your needs
-    )
-    
-    # Custom middleware
-    app.middleware("http")(LoggingMiddleware())
-    app.middleware("http")(ErrorHandlingMiddleware()) 
+
+# setup_middleware() lived here and was never called — app/main.py wires CORS
+# itself. It has been removed rather than left lying around: it allowed
+# methods=["*"], headers=["*"] and TrustedHostMiddleware(allowed_hosts=["*"]),
+# so wiring it in "to add logging" would have quietly widened CORS.

--- a/apps/api/app/core/rate_limit.py
+++ b/apps/api/app/core/rate_limit.py
@@ -4,7 +4,35 @@ Lives here rather than in app.main so endpoint modules can import it without a
 circular import (main -> api_router -> endpoints -> main).
 """
 
+from fastapi import Request
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address)
+from app.core.config import settings
+
+
+def client_ip(request: Request) -> str:
+    """Best-effort real client IP.
+
+    slowapi's ``get_remote_address`` reads ``request.client.host``, which behind
+    Vercel or Railway is the proxy — so every visitor shares a single bucket and
+    five contact-form submissions in total lock the form for everyone.
+
+    ``X-Forwarded-For`` is only trusted in production, where a proxy is actually
+    terminating the connection and appending the real address. Trusting it
+    locally (or on a directly-exposed port) would let a caller pick their own
+    rate-limit key by sending the header themselves.
+    """
+    fallback = request.client.host if request.client else "unknown"
+
+    if not settings.is_production:
+        return fallback
+
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        # Left-most entry is the original client; the rest are proxy hops.
+        return forwarded.split(",")[0].strip() or fallback
+
+    return fallback
+
+
+limiter = Limiter(key_func=client_ip)

--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -61,14 +61,19 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
 
 
-def verify_token(token: str) -> Optional[dict]:
+def verify_token(token: str, expected_type: Optional[str] = None) -> Optional[dict]:
     """Decode and verify a JWT, returning its claims or None.
 
     ``algorithms`` is an allow-list, so a token whose header advertises
     ``none`` — or any algorithm other than HS256 — is rejected outright.
+
+    ``expected_type`` checks the ``type`` claim that user_service.create_token
+    stamps on every token. Without it a 30-day refresh token authenticated
+    every bearer-protected route, which defeats the point of issuing a
+    60-minute access token alongside it.
     """
     try:
-        return jwt.decode(
+        payload = jwt.decode(
             token,
             settings.SECRET_KEY,
             algorithms=[ALGORITHM],
@@ -77,16 +82,21 @@ def verify_token(token: str) -> Optional[dict]:
     except jwt.PyJWTError:
         return None
 
+    if expected_type is not None and payload.get("type") != expected_type:
+        return None
+
+    return payload
+
 
 def get_current_user(token: str) -> str:
-    """Return the subject claim of a valid token, or raise 401."""
+    """Return the subject of a valid *access* token, or raise 401."""
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    payload = verify_token(token)
+    payload = verify_token(token, expected_type="access")
     if payload is None:
         raise credentials_exception
 

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -43,6 +43,13 @@ class AuthService:
         if not token_data:
             raise UnauthorizedError("Invalid refresh token")
 
+        # The signature alone is not enough: logout() and reset_password() revoke
+        # the row, not the JWT. Checking only the signature here left the other
+        # half of the logout hole open — a stolen refresh token kept minting
+        # fresh access tokens for its full 30 days after the user logged out.
+        if not self.user_service.get_valid_token(refresh_token, TokenType.REFRESH):
+            raise UnauthorizedError("Invalid refresh token")
+
         user_id = int(token_data["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user or not user.is_active:

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -146,16 +146,15 @@ class AuthService:
         return True
 
     def resend_verification_email(self, email: str) -> bool:
-        """Resend email verification"""
+        """Resend email verification.
+
+        Returns quietly for unknown or already-verified addresses. It used to
+        raise "User not found", which let anyone enumerate registered emails —
+        request_password_reset() one method up already got this right.
+        """
         user = self.user_service.get_user_by_email(email)
-        if not user:
-            raise ValidationError("User not found")
-
-        if user.is_verified:
-            raise ValidationError("Email is already verified")
-
-        if user.google_id:
-            raise ValidationError("OAuth users don't need email verification")
+        if not user or user.is_verified:
+            return True
 
         # Create new verification token
         verification_token = self.user_service.create_token(

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -107,7 +107,7 @@ class AuthService:
         user = self.user_service.get_user_by_id(user_id)
         if not user:
             raise ValidationError("User not found")
-
+        
         # Update password
         user.hashed_password = get_password_hash(request.new_password)
         user.updated_at = datetime.now(timezone.utc)
@@ -269,8 +269,3 @@ class AuthService:
         except Exception as e:
             # Log error but don't fail the request
             print(f"Failed to send email to {to_email}: {str(e)}")
-
-    def get_password_hash(self, password: str) -> str:
-        """Get password hash"""
-        from app.core.security import get_password_hash
-        return get_password_hash(password)

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.exceptions import UnauthorizedError, ValidationError
-from app.core.security import verify_token
+from app.core.security import get_password_hash, verify_token
 from app.models.token import TokenType
 from app.models.user import UserStatus
 from app.schemas.user import PasswordResetConfirm, PasswordResetRequest, TokenResponse, UserLogin
@@ -38,13 +38,12 @@ class AuthService:
     # the seed script, so nothing needs a public signup path.
 
     def refresh_token(self, refresh_token: str) -> TokenResponse:
-        """Refresh access token using refresh token"""
-        # Verify refresh token
-        token_data = verify_token(refresh_token)
-        if not token_data or token_data.get("type") != TokenType.REFRESH.value:
+        """Exchange a refresh token for a new token pair."""
+        token_data = verify_token(refresh_token, expected_type=TokenType.REFRESH.value)
+        if not token_data:
             raise UnauthorizedError("Invalid refresh token")
 
-        user_id = int(token_data.get("sub"))
+        user_id = int(token_data["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user or not user.is_active:
             raise UnauthorizedError("User not found or inactive")
@@ -92,14 +91,18 @@ class AuthService:
         token = self.user_service.get_valid_token(request.token, TokenType.RESET_PASSWORD)
         if not token:
             raise ValidationError("Invalid or expired reset token")
-        
-        user_id = int(verify_token(request.token).get("sub"))
+
+        payload = verify_token(request.token, expected_type=TokenType.RESET_PASSWORD.value)
+        if not payload:
+            raise ValidationError("Invalid or expired reset token")
+
+        user_id = int(payload["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user:
             raise ValidationError("User not found")
-        
+
         # Update password
-        user.hashed_password = self.user_service.get_password_hash(request.new_password)
+        user.hashed_password = get_password_hash(request.new_password)
         user.updated_at = datetime.now(timezone.utc)
         self.db.commit()
         
@@ -114,8 +117,12 @@ class AuthService:
         token_obj = self.user_service.get_valid_token(token, TokenType.EMAIL_VERIFICATION)
         if not token_obj:
             raise ValidationError("Invalid or expired verification token")
-        
-        user_id = int(verify_token(token).get("sub"))
+
+        payload = verify_token(token, expected_type=TokenType.EMAIL_VERIFICATION.value)
+        if not payload:
+            raise ValidationError("Invalid or expired verification token")
+
+        user_id = int(payload["sub"])
         user = self.user_service.get_user_by_id(user_id)
         if not user:
             raise ValidationError("User not found")

--- a/apps/api/app/services/user_service.py
+++ b/apps/api/app/services/user_service.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
@@ -185,22 +187,43 @@ class UserService:
         return user
 
     # Token management
+    @staticmethod
+    def hash_token(token_string: str) -> str:
+        """Digest a token for storage.
+
+        The column is named token_hash but used to hold the raw JWT, with a
+        "# In production, hash this" note next to it. That meant read access to
+        the database handed over every live access, refresh and reset token in
+        directly usable form. A digest is enough: lookups are exact-match, so
+        there is nothing to compare fuzzily and no need to be reversible.
+        """
+        return hashlib.sha256(token_string.encode("utf-8")).hexdigest()
+
     def create_token(self, user_id: int, token_type: TokenType, expires_in_minutes: int = 30, metadata: Dict[str, Any] = None) -> str:
         """Create a new token"""
 
         expires_at = datetime.now(timezone.utc) + timedelta(minutes=expires_in_minutes)
-        token_data = {"sub": str(user_id), "type": token_type.value}
+
+        # `jti` makes the JWT unique. Without it the payload is just sub/type/exp/iat,
+        # and exp/iat have one-second resolution — so two logins inside the same
+        # second produced byte-identical tokens and therefore two rows with the same
+        # hash. revoke_token() updates .first() of those, so logout would flip one row
+        # while get_valid_token() went on matching the other: the token stayed live.
+        token_data = {
+            "sub": str(user_id),
+            "type": token_type.value,
+            "jti": secrets.token_urlsafe(16),
+        }
 
         if metadata:
             token_data.update(metadata)
 
         token_string = create_access_token(token_data, timedelta(minutes=expires_in_minutes))
 
-        # Store token in database
         token = Token(
             user_id=user_id,
             token_type=token_type,
-            token_hash=token_string,  # In production, hash this
+            token_hash=self.hash_token(token_string),
             expires_at=expires_at,
             token_metadata=json.dumps(metadata) if metadata else None
         )
@@ -210,12 +233,14 @@ class UserService:
 
         return token_string
 
-    def revoke_token(self, token_hash: str) -> bool:
-        """Revoke a token"""
-        token = self.db.query(Token).filter(Token.token_hash == token_hash).first()
+    def revoke_token(self, token_string: str) -> bool:
+        """Revoke a token, given the token itself."""
+        token = self.db.query(Token).filter(
+            Token.token_hash == self.hash_token(token_string)
+        ).first()
         if not token:
             return False
-        
+
         token.is_revoked = True
         self.db.commit()
         return True
@@ -233,11 +258,11 @@ class UserService:
         self.db.commit()
         return True
 
-    def get_valid_token(self, token_hash: str, token_type: TokenType) -> Optional[Token]:
-        """Get a valid token"""
+    def get_valid_token(self, token_string: str, token_type: TokenType) -> Optional[Token]:
+        """Look up a token by its value; None if unknown, revoked or expired."""
         token = self.db.query(Token).filter(
             and_(
-                Token.token_hash == token_hash,
+                Token.token_hash == self.hash_token(token_string),
                 Token.token_type == token_type,
                 Token.is_revoked.is_(False),
                 Token.expires_at > datetime.now(timezone.utc)

--- a/apps/api/scripts/init_auth_tables.py
+++ b/apps/api/scripts/init_auth_tables.py
@@ -122,17 +122,31 @@ def create_default_admin():
     user_service = UserService(db)
 
     # Check if admin already exists
-    admin_user = user_service.get_user_by_email("admin@example.com")
+    # Credentials come from the environment. This used to hardcode
+    # admin@example.com / admin123, so anyone who ran the script — or simply
+    # read the repository — knew how to log in as the administrator.
+    email = os.environ.get("ADMIN_EMAIL")
+    password = os.environ.get("ADMIN_PASSWORD")
+
+    if not email or not password:
+        raise SystemExit(
+            "Set ADMIN_EMAIL and ADMIN_PASSWORD before running this script. Generate one with:\n"
+            '  python -c "import secrets; print(secrets.token_urlsafe(24))"'
+        )
+
+    if len(password) < 12:
+        raise SystemExit("ADMIN_PASSWORD must be at least 12 characters.")
+
+    admin_user = user_service.get_user_by_email(email)
     if admin_user:
         print("⚠️  Admin user already exists")
         return admin_user
 
-    # Create admin user
     admin_data = UserCreate(
-        email="admin@example.com",
+        email=email,
         username="admin",
         full_name="System Administrator",
-        password="admin123"  # Change this in production!
+        password=password,
     )
 
     try:

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -98,6 +98,24 @@ def test_refresh_token_cannot_be_used_as_an_access_token():
     assert r.status_code in (401, 403)
 
 
+def test_token_not_present_in_the_database_is_rejected():
+    """Logout revokes the row, so authentication has to consult it.
+
+    A correctly signed token that was never issued — or was issued and then
+    revoked — must not authenticate.
+    """
+    orphan = create_access_token({"sub": "1", "type": "access"})
+    r = _call("post", "/api/v1/projects/", headers={"Authorization": f"Bearer {orphan}"})
+    assert r.status_code in (401, 403)
+
+
+def test_non_numeric_subject_is_rejected_not_a_crash():
+    """`int(sub)` used to raise ValueError straight out of the dependency."""
+    weird = create_access_token({"sub": "not-a-number", "type": "access"})
+    r = _call("post", "/api/v1/projects/", headers={"Authorization": f"Bearer {weird}"})
+    assert r.status_code in (401, 403), r.status_code
+
+
 @pytest.mark.parametrize("path", ["/api/v1/auth/register", "/api/v1/auth/google"])
 def test_public_signup_surface_is_gone(path):
     """Single-owner API: the admin comes from the seed script, not signup."""

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -17,6 +17,7 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core.security import create_access_token
 from app.main import app
 
 client = TestClient(app)
@@ -83,6 +84,17 @@ def test_alg_none_token_is_rejected():
 
 def test_malformed_token_is_rejected():
     r = _call("post", "/api/v1/projects/", headers={"Authorization": "Bearer garbage.token.here"})
+    assert r.status_code in (401, 403)
+
+
+def test_refresh_token_cannot_be_used_as_an_access_token():
+    """A refresh token lives for 30 days; an access token for 60 minutes.
+
+    Without a check on the `type` claim the long-lived one authenticated every
+    protected route, which made the short access-token lifetime meaningless.
+    """
+    refresh = create_access_token({"sub": "1", "type": "refresh"})
+    r = _call("post", "/api/v1/projects/", headers={"Authorization": f"Bearer {refresh}"})
     assert r.status_code in (401, 403)
 
 

--- a/apps/api/tests/test_token_lifecycle.py
+++ b/apps/api/tests/test_token_lifecycle.py
@@ -1,0 +1,166 @@
+"""Token issue/revoke behaviour, exercised against the database.
+
+test_security.py drives HTTP and can only assert "rejected". These cases go
+through the service layer with a real session, because the interesting part of
+revocation is what happens to a token that *is* correctly signed — a request
+test cannot tell "rejected because revoked" apart from "rejected because the
+signature was bad".
+
+Needs whatever ``DATABASE_URL`` points at; each test cleans up the row it made.
+"""
+
+import pytest
+
+from app.core.database import SessionLocal
+from app.core.exceptions import UnauthorizedError
+from app.core.security import verify_token
+from app.models.token import Token, TokenType
+from app.models.user import User, UserStatus
+from app.services.auth_service import AuthService
+from app.services.user_service import UserService
+
+
+@pytest.fixture
+def db():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+TEST_EMAIL = "token-lifecycle@example.invalid"
+
+
+def _drop_test_user(db):
+    """Remove the row if it is there. Tokens cascade with it.
+
+    Called before as well as after: the email is unique, so a run that dies
+    mid-test (a dropped connection is enough) would otherwise poison every
+    later run with a UniqueViolation in the fixture.
+    """
+    existing = db.query(User).filter(User.email == TEST_EMAIL).first()
+    if existing:
+        db.delete(existing)
+        db.commit()
+
+
+@pytest.fixture
+def user(db):
+    """A throwaway active user. Tokens cascade-delete with the row."""
+    _drop_test_user(db)
+
+    record = User(
+        email=TEST_EMAIL,
+        username="token-lifecycle",
+        full_name="Token Lifecycle",
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        status=UserStatus.ACTIVE,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+
+    yield record
+
+    _drop_test_user(db)
+
+
+def test_a_live_refresh_token_mints_a_new_pair(db, user):
+    """Baseline, so the revocation test below cannot pass vacuously."""
+    refresh = UserService(db).create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    pair = AuthService(db).refresh_token(refresh)
+
+    assert pair.access_token
+    assert pair.user_id == user.id
+
+
+def test_a_revoked_refresh_token_cannot_mint_new_tokens(db, user):
+    """This is the other half of the logout hole.
+
+    Revoking on logout only means something if refresh consults the row.
+    Verifying the signature alone let a stolen refresh token keep minting fresh
+    access tokens for its full 30-day life after the user had logged out.
+    """
+    service = UserService(db)
+    refresh = service.create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    AuthService(db).logout(access_token="unused", refresh_token=refresh)
+
+    with pytest.raises(UnauthorizedError):
+        AuthService(db).refresh_token(refresh)
+
+
+def test_refresh_rotates_the_token_it_consumed(db, user):
+    """The consumed token must not be replayable after rotation."""
+    refresh = UserService(db).create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    AuthService(db).refresh_token(refresh)
+
+    with pytest.raises(UnauthorizedError):
+        AuthService(db).refresh_token(refresh)
+
+
+def test_password_reset_kills_outstanding_sessions(db, user):
+    """revoke_all_user_tokens() is what makes "reset the password" a remedy."""
+    service = UserService(db)
+    refresh = service.create_token(user.id, TokenType.REFRESH, expires_in_minutes=60)
+
+    service.revoke_all_user_tokens(user.id)
+
+    with pytest.raises(UnauthorizedError):
+        AuthService(db).refresh_token(refresh)
+
+
+def test_every_token_carries_a_unique_id(db, user):
+    """`jti` is load-bearing, not decoration.
+
+    The rest of the payload — sub, type, exp, iat — is identical for two tokens
+    minted for the same user in the same second, and exp/iat only have
+    second resolution. Without `jti` the two JWTs came out byte-identical and
+    stored the same hash on two rows; revoke_token() updates .first() of those,
+    so logout flipped one row while get_valid_token() went on matching the
+    other and the "revoked" token kept working.
+
+    Asserted on the claim rather than by minting two tokens and comparing them:
+    whether two calls land in the same second depends on how slow the commit
+    between them happens to be, so that version of this test passes against the
+    bug about as often as it catches it.
+    """
+    service = UserService(db)
+    tokens = [
+        service.create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+        for _ in range(5)
+    ]
+
+    ids = [verify_token(t, expected_type="access")["jti"] for t in tokens]
+
+    assert len(set(ids)) == len(ids)
+    assert len(set(tokens)) == len(tokens)
+
+
+def test_revoking_one_token_leaves_the_others_alone(db, user):
+    """A user with two live sessions logs out of one; the other survives."""
+    service = UserService(db)
+    first = service.create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+    second = service.create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+
+    service.revoke_token(first)
+
+    assert service.get_valid_token(first, TokenType.ACCESS) is None
+    assert service.get_valid_token(second, TokenType.ACCESS) is not None
+
+
+def test_the_raw_token_is_never_written_to_the_database(db, user):
+    """The column is called token_hash; it used to hold the JWT itself, so read
+    access to the table handed over every live token ready to use."""
+    token = UserService(db).create_token(user.id, TokenType.ACCESS, expires_in_minutes=60)
+
+    stored = db.query(Token).filter(Token.user_id == user.id).all()
+
+    assert stored
+    assert all(row.token_hash != token for row in stored)
+    assert all(len(row.token_hash) == 64 for row in stored)


### PR DESCRIPTION
Follow-up to #10–#14. **This carries no new code** — it lands work that has already been reviewed and approved.

## What happened

#10–#14 were a stack: each PR's base was the previous phase's branch, not `main`. GitHub retargets a stacked PR to `main` only when its base branch is **deleted** after merging. The phase branches were merged but not deleted, so four of the five merged into their literal bases instead:

| PR | merged into | reached `main`? |
|----|-------------|-----------------|
| #10 | `main` | yes |
| #11 | `phase-1-access-control` | no |
| #12 | `phase-2-jwt-type` | no |
| #13 | `phase-3-revocation` | no |
| #14 | `phase-4-misc` | no |

All five show as MERGED, which is what makes this easy to miss. The effect is that `main` currently has **only the access-control and CVE work from #10** — none of the token fixes. The logout hole, the cleartext token storage and the JWT type confusion are all still live on `main`.

The content is not lost; it accumulated on `phase-5-cleanup`, which is where the stack was supposed to end up.

## What this PR does

Merges `phase-5-cleanup` into `main`, bringing the four reviewed commits:

- `9310b21` reject tokens presented as the wrong type (#11)
- `d5774fa` make logout actually revoke, and stop storing tokens in the clear (#12)
- `17e160a` stop leaking which emails are registered, key rate limits on the real IP (#13)
- `ccf19fd` delete two unreachable helpers, fix the migration downgrade (#14)

Each stays a separate commit, so the per-phase history survives.

## Verification

The merge is clean, and the resulting tree is **byte-identical** to the state verified before the split — `git diff` against the pre-split backup is empty. 32 tests pass, ruff clean, run locally on the merged result.

## To avoid the repeat

Delete each branch when merging a stack, or merge bottom-up retargeting as you go. Once this lands, all five phase branches can be deleted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
