### PR TITLE
feat(api): give content a slug, a publish state, and the fields the site needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,46 @@ python -m ruff check .
 ```
 
 Migrations are committed. Point `DATABASE_URL` at a scratch database when
-running the tests — the contact-form cases insert rows.
+running the tests — the contact-form and content cases insert rows.
+
+The `Procfile` runs uvicorn only. Migrations belong in a release/pre-deploy
+step, not the web process — a failed one there takes every instance down, and
+concurrent instances race for the lock on rollout.
+
+## Content
+
+The API owns the portfolio content: projects, skills, certificates and career
+history. Every content row carries a `slug` and a `published` flag. Public
+callers see published rows only; an admin bearer token also returns drafts. An
+unpublished row 404s rather than 403s, so whether a draft exists at that id
+stays private.
+
+```bash
+cd apps/api
+ADMIN_EMAIL=... ADMIN_PASSWORD=... python scripts/init_auth_tables.py  # roles + admin
+python scripts/seed_content.py --dry-run                               # preview
+python scripts/seed_content.py                                         # load content
+```
+
+`seed_content.py` carries the real portfolio content and is idempotent — rows
+are keyed on slug, so re-running updates in place rather than duplicating.
+
+`Skill.level` is a named enum (`beginner` … `expert`), not the old unlabelled
+1-5 integer. `Project.status` is `completed` / `in_progress` / `on_hold` /
+`dropped`. A career entry with a null `ended_on` is the current one.
 
 ## Known issues being worked through
 
-- `scripts/init_auth_tables.py` bootstraps an admin with the literal password
-  `admin123`. It must read from the environment before anything is deployed.
-  The seed script that replaces it is not written yet.
-- The content models are still the originals: no `slug`, no draft/published
-  state, no career-history table, and `Skill.level` is an integer while the
-  frontend uses strings.
-- `portfolio/frontend` is still what production serves; `apps/web` is an empty
-  Next.js scaffold.
-- The `Procfile` runs uvicorn only. Migrations belong in a release/pre-deploy
-  step, not the web process — a failed one there takes every instance down.
+- `portfolio/frontend` is still what production serves, and it does not call
+  this API at all — its projects, skills, certificates and career entries are
+  hardcoded arrays inside the components, and the contact form posts to EmailJS
+  with the service keys inline. `VITE_API_URL` is declared in `env.example` and
+  read by nothing.
+- `apps/web` is an empty Next.js scaffold. Pointing it at the content endpoints
+  above is the next piece of work.
+- There is no CI. `ruff check .` and `pytest` are run by hand.
+- Tests and the seed script both write to whatever `DATABASE_URL` names; there
+  is no separate test database.
 
 ## Environment
 

--- a/apps/api/Procfile
+++ b/apps/api/Procfile
@@ -1,7 +1,6 @@
 # Migrations are deliberately NOT run here. Chaining `alembic upgrade head &&`
 # into the web process means a failed migration takes every instance down with
 # no way back, and concurrent instances race for the migration lock on rollouts.
-# Run them as a release/pre-deploy step instead.
-# (Right now there is nothing to run anyway: alembic.ini was deleted in 32c7391
-# and alembic/versions/ is empty.)
+# Run them as a release/pre-deploy step instead:
+#   python -m alembic upgrade head
 web: uvicorn app.main:app --host 0.0.0.0 --port $PORT

--- a/apps/api/alembic/versions/b2f1c7d94a30_content_model_reshape.py
+++ b/apps/api/alembic/versions/b2f1c7d94a30_content_model_reshape.py
@@ -1,0 +1,222 @@
+"""content model reshape: slugs, publish state, richer projects, career entries
+
+Revision ID: b2f1c7d94a30
+Revises: 4e8845a384cb
+Create Date: 2026-08-09 13:20:11.402881
+
+Two things here are not autogenerate output and must not be replaced by it:
+
+* the slug backfills, which have to invent a value for every existing row and
+  keep it unique before the unique index goes on; and
+* ``skills.level``, which changes from a 1-5 integer to a named enum. Autogenerate
+  emits a bare ALTER TYPE for that, which Postgres refuses without a USING clause.
+
+Existing rows are backfilled to ``published = true``. They were publicly visible
+before this migration, and defaulting them to draft would silently unpublish a
+live portfolio.
+"""
+import re
+import unicodedata
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b2f1c7d94a30'
+down_revision = '4e8845a384cb'
+branch_labels = None
+depends_on = None
+
+
+# SQLAlchemy's Enum persists member *names*, not values — matching `userstatus`
+# and `tokentype` in the initial migration.
+project_status = sa.Enum(
+    'COMPLETED', 'IN_PROGRESS', 'ON_HOLD', 'DROPPED', name='projectstatus'
+)
+skill_level = sa.Enum(
+    'BEGINNER', 'INTERMEDIATE', 'ADVANCED', 'EXPERT', name='skilllevel'
+)
+
+
+def _slugify(value: str) -> str:
+    """Frozen copy of app/core/slugs.py:slugify.
+
+    Deliberately duplicated rather than imported. A migration has to keep
+    producing the same output forever, and importing application code would let
+    a later edit to slugify() silently change what this already-applied
+    migration would do on a fresh database.
+
+    Doing it in Python rather than SQL is not a style choice either: the obvious
+    ``regexp_replace(title, '[^a-zA-Z0-9]+', '-')`` treats an accented letter as
+    a separator, so "Phạm Đăng Khôi" comes out "ph-m-d-ng-kh-i" instead of
+    "pham-dang-khoi". NFKD folds; a character class cannot.
+    """
+    pre_folded = value.translate(str.maketrans({"Đ": "D", "đ": "d"}))
+    folded = unicodedata.normalize("NFKD", pre_folded)
+    ascii_only = folded.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_only.lower())
+    return re.sub(r"^-+|-+$", "", slug)[:255].strip("-")
+
+
+def _backfill_slugs(table: str) -> None:
+    """Give every existing row a unique slug derived from its title.
+
+    Duplicates are suffixed -2, -3 … and a title that reduces to nothing (all
+    punctuation) falls back to 'item', which then collides and gets suffixed
+    like any other duplicate. Row counts here are portfolio-sized, so the
+    per-row round trip costs nothing worth optimising away.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(f"SELECT id, title FROM {table} ORDER BY id")  # noqa: S608 - fixed table names
+    ).fetchall()
+
+    taken = set()
+    for row_id, title in rows:
+        base = _slugify(title or "") or "item"
+        candidate, suffix = base, 2
+        while candidate in taken:
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+        taken.add(candidate)
+
+        bind.execute(
+            sa.text(f"UPDATE {table} SET slug = :slug WHERE id = :id"),  # noqa: S608
+            {"slug": candidate, "id": row_id},
+        )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    project_status.create(bind, checkfirst=True)
+    skill_level.create(bind, checkfirst=True)
+
+    # --- projects -----------------------------------------------------------
+    op.add_column('projects', sa.Column('slug', sa.String(length=255), nullable=True))
+    op.add_column('projects', sa.Column('long_description', sa.Text(), nullable=True))
+    op.add_column('projects', sa.Column('features', sa.JSON(), nullable=True))
+    op.add_column('projects', sa.Column('challenges', sa.JSON(), nullable=True))
+    op.add_column('projects', sa.Column('started_on', sa.Date(), nullable=True))
+    op.add_column('projects', sa.Column('ended_on', sa.Date(), nullable=True))
+    op.add_column(
+        'projects',
+        sa.Column('status', project_status, nullable=False, server_default='COMPLETED'),
+    )
+    op.add_column(
+        'projects',
+        sa.Column('published', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.execute("UPDATE projects SET published = true")
+
+    _backfill_slugs('projects')
+    op.alter_column('projects', 'slug', nullable=False)
+    op.create_index(op.f('ix_projects_slug'), 'projects', ['slug'], unique=True)
+
+    # --- skills -------------------------------------------------------------
+    # 1-5 collapses onto four names; 2 and 3 both land on INTERMEDIATE because
+    # the old scale had no separate label for either.
+    op.execute(
+        """
+        ALTER TABLE skills
+        ALTER COLUMN level DROP DEFAULT,
+        ALTER COLUMN level TYPE skilllevel
+        USING (
+            CASE level
+                WHEN 5 THEN 'EXPERT'
+                WHEN 4 THEN 'ADVANCED'
+                WHEN 3 THEN 'INTERMEDIATE'
+                WHEN 2 THEN 'INTERMEDIATE'
+                ELSE 'BEGINNER'
+            END
+        )::skilllevel
+        """
+    )
+    op.execute("UPDATE skills SET level = 'BEGINNER' WHERE level IS NULL")
+    op.alter_column('skills', 'level', nullable=False, server_default='BEGINNER')
+
+    # --- certificates -------------------------------------------------------
+    op.add_column('certificates', sa.Column('slug', sa.String(length=255), nullable=True))
+    op.add_column('certificates', sa.Column('credential_id', sa.String(length=100), nullable=True))
+    op.add_column('certificates', sa.Column('category', sa.String(length=50), nullable=True))
+    op.add_column('certificates', sa.Column('skills', sa.JSON(), nullable=True))
+    op.add_column(
+        'certificates',
+        sa.Column('published', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.execute("UPDATE certificates SET published = true")
+
+    _backfill_slugs('certificates')
+    op.alter_column('certificates', 'slug', nullable=False)
+    op.create_index(op.f('ix_certificates_slug'), 'certificates', ['slug'], unique=True)
+
+    # --- career_entries -----------------------------------------------------
+    op.create_table(
+        'career_entries',
+        sa.Column('slug', sa.String(length=255), nullable=False),
+        sa.Column('title', sa.String(length=255), nullable=False),
+        sa.Column('company', sa.String(length=255), nullable=False),
+        sa.Column('location', sa.String(length=255), nullable=True),
+        sa.Column('started_on', sa.Date(), nullable=False),
+        sa.Column('ended_on', sa.Date(), nullable=True),
+        sa.Column('highlights', sa.JSON(), nullable=True),
+        sa.Column('published', sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=True,
+        ),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_career_entries_id'), 'career_entries', ['id'], unique=False)
+    op.create_index(op.f('ix_career_entries_slug'), 'career_entries', ['slug'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_career_entries_slug'), table_name='career_entries')
+    op.drop_index(op.f('ix_career_entries_id'), table_name='career_entries')
+    op.drop_table('career_entries')
+
+    op.drop_index(op.f('ix_certificates_slug'), table_name='certificates')
+    op.drop_column('certificates', 'published')
+    op.drop_column('certificates', 'skills')
+    op.drop_column('certificates', 'category')
+    op.drop_column('certificates', 'credential_id')
+    op.drop_column('certificates', 'slug')
+
+    # Back to the 1-5 scale. INTERMEDIATE has to pick one of the two integers it
+    # was merged from; 3 is the midpoint, so a round trip is lossy for old 2s.
+    op.execute(
+        """
+        ALTER TABLE skills
+        ALTER COLUMN level DROP DEFAULT,
+        ALTER COLUMN level TYPE INTEGER
+        USING (
+            CASE level
+                WHEN 'EXPERT' THEN 5
+                WHEN 'ADVANCED' THEN 4
+                WHEN 'INTERMEDIATE' THEN 3
+                ELSE 1
+            END
+        )
+        """
+    )
+    op.alter_column('skills', 'level', nullable=True, server_default='1')
+
+    op.drop_index(op.f('ix_projects_slug'), table_name='projects')
+    op.drop_column('projects', 'published')
+    op.drop_column('projects', 'status')
+    op.drop_column('projects', 'ended_on')
+    op.drop_column('projects', 'started_on')
+    op.drop_column('projects', 'challenges')
+    op.drop_column('projects', 'features')
+    op.drop_column('projects', 'long_description')
+    op.drop_column('projects', 'slug')
+
+    # Same reason as the initial migration: autogenerate never drops the named
+    # enum types, so a downgrade-then-upgrade fails with "type already exists".
+    bind = op.get_bind()
+    skill_level.drop(bind, checkfirst=True)
+    project_status.drop(bind, checkfirst=True)

--- a/apps/api/app/api/v1/api.py
+++ b/apps/api/app/api/v1/api.py
@@ -1,6 +1,14 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, certificates, contacts, projects, skills, users
+from app.api.v1.endpoints import (
+    auth,
+    career,
+    certificates,
+    contacts,
+    projects,
+    skills,
+    users,
+)
 
 api_router = APIRouter()
 
@@ -12,4 +20,5 @@ api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(projects.router, prefix="/projects", tags=["projects"])
 api_router.include_router(skills.router, prefix="/skills", tags=["skills"])
 api_router.include_router(certificates.router, prefix="/certificates", tags=["certificates"])
+api_router.include_router(career.router, prefix="/career", tags=["career"])
 api_router.include_router(contacts.router, prefix="/contacts", tags=["contacts"])

--- a/apps/api/app/api/v1/dependencies.py
+++ b/apps/api/app/api/v1/dependencies.py
@@ -58,11 +58,35 @@ def get_current_user_dependency(
     return user
 
 
-# get_optional_user() was removed. It took `Depends(security)` from the shared
+# The previous get_optional_user() took `Depends(security)` from the shared
 # HTTPBearer(), which defaults to auto_error=True and so raises 403 before the
-# body runs — its `if not credentials: return None` branch was unreachable.
-# Nothing used it, and left in place it would have silently rejected anonymous
-# callers on the first public route it was attached to.
+# body runs — its `if not credentials: return None` branch was unreachable, and
+# attaching it to a public route would have rejected every anonymous caller. It
+# was deleted. What follows is the working shape: its own HTTPBearer with
+# auto_error off, so a missing header reaches the body as None.
+optional_security = HTTPBearer(auto_error=False)
+
+
+def get_optional_admin(
+    credentials: HTTPAuthorizationCredentials = Depends(optional_security),
+    db: Session = Depends(get_db),
+):
+    """Resolve an admin caller if there is one, otherwise None.
+
+    Used by the public content routes to decide whether drafts are visible. A
+    missing *or bad* token means anonymous here, not 401 — these routes are
+    public, and an expired token should still render the published portfolio
+    rather than break the page.
+    """
+    if credentials is None:
+        return None
+
+    try:
+        user = get_current_user_dependency(credentials=credentials, db=db)
+    except HTTPException:
+        return None
+
+    return user if user.is_admin else None
 
 
 def require_admin(current_user = Depends(get_current_user_dependency)):

--- a/apps/api/app/api/v1/endpoints/career.py
+++ b/apps/api/app/api/v1/endpoints/career.py
@@ -1,0 +1,62 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.v1.dependencies import get_optional_admin, require_admin
+from app.core.constants import ErrorMessages, SuccessMessages
+from app.core.database import get_db
+from app.schemas.portfolio import CareerEntry, CareerEntryCreate, CareerEntryUpdate
+from app.services.portfolio_service import PortfolioService
+
+router = APIRouter()
+
+@router.get("/", response_model=List[CareerEntry])
+def get_career_entries(
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get published career entries, newest first; admins also see drafts"""
+    service = PortfolioService(db)
+    return service.get_career_entries(include_unpublished=viewer is not None)
+
+@router.get("/{entry_id}", response_model=CareerEntry)
+def get_career_entry(
+    entry_id: int,
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get a specific career entry by ID"""
+    service = PortfolioService(db)
+    entry = service.get_career_entry(entry_id, include_unpublished=viewer is not None)
+    if not entry:
+        raise HTTPException(status_code=404, detail=ErrorMessages.CAREER_ENTRY_NOT_FOUND)
+    return entry
+
+@router.post("/", response_model=CareerEntry, dependencies=[Depends(require_admin)])
+def create_career_entry(entry: CareerEntryCreate, db: Session = Depends(get_db)):
+    """Create a new career entry"""
+    service = PortfolioService(db)
+    return service.create_career_entry(entry)
+
+@router.put("/{entry_id}", response_model=CareerEntry, dependencies=[Depends(require_admin)])
+def update_career_entry(
+    entry_id: int,
+    entry: CareerEntryUpdate,
+    db: Session = Depends(get_db)
+):
+    """Update an existing career entry"""
+    service = PortfolioService(db)
+    updated_entry = service.update_career_entry(entry_id, entry)
+    if not updated_entry:
+        raise HTTPException(status_code=404, detail=ErrorMessages.CAREER_ENTRY_NOT_FOUND)
+    return updated_entry
+
+@router.delete("/{entry_id}", dependencies=[Depends(require_admin)])
+def delete_career_entry(entry_id: int, db: Session = Depends(get_db)):
+    """Delete a career entry"""
+    service = PortfolioService(db)
+    success = service.delete_career_entry(entry_id)
+    if not success:
+        raise HTTPException(status_code=404, detail=ErrorMessages.CAREER_ENTRY_NOT_FOUND)
+    return {"message": SuccessMessages.CAREER_ENTRY_DELETED}

--- a/apps/api/app/api/v1/endpoints/certificates.py
+++ b/apps/api/app/api/v1/endpoints/certificates.py
@@ -1,9 +1,9 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.api.v1.dependencies import require_admin
+from app.api.v1.dependencies import get_optional_admin, require_admin
 from app.core.constants import ErrorMessages, SuccessMessages
 from app.core.database import get_db
 from app.schemas.portfolio import Certificate, CertificateCreate, CertificateUpdate
@@ -12,16 +12,44 @@ from app.services.portfolio_service import PortfolioService
 router = APIRouter()
 
 @router.get("/", response_model=List[Certificate])
-def get_certificates(db: Session = Depends(get_db)):
-    """Get all certificates"""
+def get_certificates(
+    category: str = Query(None, description="Filter certificates by category"),
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get published certificates; admins also see drafts"""
     service = PortfolioService(db)
-    return service.get_certificates()
+    return service.get_certificates(
+        category=category,
+        include_unpublished=viewer is not None,
+    )
+
+@router.get("/slug/{slug}", response_model=Certificate)
+def get_certificate_by_slug(
+    slug: str,
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get a specific certificate by slug"""
+    service = PortfolioService(db)
+    certificate = service.get_certificate_by_slug(
+        slug, include_unpublished=viewer is not None
+    )
+    if not certificate:
+        raise HTTPException(status_code=404, detail=ErrorMessages.CERTIFICATE_NOT_FOUND)
+    return certificate
 
 @router.get("/{certificate_id}", response_model=Certificate)
-def get_certificate(certificate_id: int, db: Session = Depends(get_db)):
+def get_certificate(
+    certificate_id: int,
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
     """Get a specific certificate by ID"""
     service = PortfolioService(db)
-    certificate = service.get_certificate(certificate_id)
+    certificate = service.get_certificate(
+        certificate_id, include_unpublished=viewer is not None
+    )
     if not certificate:
         raise HTTPException(status_code=404, detail=ErrorMessages.CERTIFICATE_NOT_FOUND)
     return certificate

--- a/apps/api/app/api/v1/endpoints/projects.py
+++ b/apps/api/app/api/v1/endpoints/projects.py
@@ -3,7 +3,7 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.api.v1.dependencies import require_admin
+from app.api.v1.dependencies import get_optional_admin, require_admin
 from app.core.constants import ErrorMessages, SuccessMessages
 from app.core.database import get_db
 from app.schemas.portfolio import Project, ProjectCreate, ProjectUpdate
@@ -14,17 +14,40 @@ router = APIRouter()
 @router.get("/", response_model=List[Project])
 def get_projects(
     featured_only: bool = Query(False, description="Get only featured projects"),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
 ):
-    """Get all projects, optionally filtered by featured status"""
+    """Get published projects; admins also see drafts"""
     service = PortfolioService(db)
-    return service.get_projects(featured_only=featured_only)
+    return service.get_projects(
+        featured_only=featured_only,
+        include_unpublished=viewer is not None,
+    )
+
+@router.get("/slug/{slug}", response_model=Project)
+def get_project_by_slug(
+    slug: str,
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get a specific project by slug"""
+    service = PortfolioService(db)
+    project = service.get_project_by_slug(slug, include_unpublished=viewer is not None)
+    if not project:
+        raise HTTPException(status_code=404, detail=ErrorMessages.PROJECT_NOT_FOUND)
+    return project
 
 @router.get("/{project_id}", response_model=Project)
-def get_project(project_id: int, db: Session = Depends(get_db)):
+def get_project(
+    project_id: int,
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
     """Get a specific project by ID"""
     service = PortfolioService(db)
-    project = service.get_project(project_id)
+    # A draft 404s for anonymous callers rather than 403ing: whether an
+    # unpublished project exists at that id is itself not public.
+    project = service.get_project(project_id, include_unpublished=viewer is not None)
     if not project:
         raise HTTPException(status_code=404, detail=ErrorMessages.PROJECT_NOT_FOUND)
     return project

--- a/apps/api/app/core/constants.py
+++ b/apps/api/app/core/constants.py
@@ -19,6 +19,9 @@ class ErrorMessages:
     # Certificate related
     CERTIFICATE_NOT_FOUND = "Certificate not found"
 
+    # Career related
+    CAREER_ENTRY_NOT_FOUND = "Career entry not found"
+
     # Role & Permission related
     ROLE_NOT_FOUND = "Role not found"
     PERMISSION_NOT_FOUND = "Permission not found"
@@ -44,3 +47,4 @@ class SuccessMessages:
     PROJECT_DELETED = "Project deleted successfully"
     SKILL_DELETED = "Skill deleted successfully"
     CERTIFICATE_DELETED = "Certificate deleted successfully"
+    CAREER_ENTRY_DELETED = "Career entry deleted successfully"

--- a/apps/api/app/core/slugs.py
+++ b/apps/api/app/core/slugs.py
@@ -1,0 +1,56 @@
+"""URL slugs for content rows.
+
+Every public content row is addressable by slug so the frontend can link to
+``/projects/food-forum`` instead of ``/projects/5``. Slugs are generated from
+the title once, on create, and then left alone — regenerating one on every
+title edit would silently break any link already published to it.
+"""
+
+import re
+import unicodedata
+
+_NON_WORD = re.compile(r"[^a-z0-9]+")
+_TRIM = re.compile(r"^-+|-+$")
+
+# NFKD splits a base letter from its accents, so "ễ" reduces to "e". It does not
+# touch letters whose stroke is part of the glyph rather than a combining mark,
+# and Vietnamese "Đ" is one: left alone it is dropped entirely, turning "Đăng"
+# into "ang". That is the author's own name, so it gets mapped by hand.
+_PRE_FOLD = str.maketrans({"Đ": "D", "đ": "d"})
+
+
+def slugify(value: str, *, max_length: int = 255) -> str:
+    """Reduce a title to a lowercase ASCII slug.
+
+    Accents are folded rather than dropped, so "Phạm Đăng Khôi" becomes
+    "pham-dang-khoi" and not "pham-ang-khoi" — the titles here are mostly
+    English but the author's name is not, and a slug with letters missing is
+    worse than a transliterated one.
+    """
+    folded = unicodedata.normalize("NFKD", value.translate(_PRE_FOLD))
+    ascii_only = folded.encode("ascii", "ignore").decode("ascii")
+    slug = _NON_WORD.sub("-", ascii_only.lower())
+    slug = _TRIM.sub("", slug)[:max_length]
+    return _TRIM.sub("", slug)
+
+
+def unique_slug(db, model, value: str, *, exclude_id: int | None = None) -> str:
+    """Return a slug for ``value`` that no other row of ``model`` holds.
+
+    Collisions get a ``-2``, ``-3`` … suffix. This narrows the race window but
+    does not close it; the unique index on the column is what actually
+    guarantees correctness, and a concurrent insert will still raise there.
+    Content is written by one admin, so that is an acceptable trade.
+    """
+    base = slugify(value) or "item"
+    candidate = base
+    suffix = 2
+
+    while True:
+        query = db.query(model).filter(model.slug == candidate)
+        if exclude_id is not None:
+            query = query.filter(model.id != exclude_id)
+        if query.first() is None:
+            return candidate
+        candidate = f"{base}-{suffix}"
+        suffix += 1

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -1,6 +1,14 @@
 # Import all models
 from .base import Base
-from .portfolio import Certificate, Contact, Project, Skill
+from .portfolio import (
+    CareerEntry,
+    Certificate,
+    Contact,
+    Project,
+    ProjectStatus,
+    Skill,
+    SkillLevel,
+)
 from .role import Permission, Role, RolePermission, UserRole
 from .token import Token, TokenType
 from .user import User, UserStatus
@@ -9,7 +17,8 @@ from .user import User, UserStatus
 __all__ = [
     "Base",
     "User", "UserStatus",
-    "Token", "TokenType", 
+    "Token", "TokenType",
     "Role", "Permission", "UserRole", "RolePermission",
-    "Contact", "Project", "Skill", "Certificate"
+    "Contact", "Project", "ProjectStatus", "Skill", "SkillLevel",
+    "Certificate", "CareerEntry"
 ] 

--- a/apps/api/app/models/portfolio.py
+++ b/apps/api/app/models/portfolio.py
@@ -1,44 +1,94 @@
-from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String, Text
+import enum
+
+from sqlalchemy import JSON, Boolean, Column, Date, DateTime, Enum, Integer, String, Text
 
 from .base import BaseModel
 
 
+class ProjectStatus(enum.Enum):
+    COMPLETED = "completed"
+    IN_PROGRESS = "in_progress"
+    ON_HOLD = "on_hold"
+    DROPPED = "dropped"
+
+
+class SkillLevel(enum.Enum):
+    BEGINNER = "beginner"
+    INTERMEDIATE = "intermediate"
+    ADVANCED = "advanced"
+    EXPERT = "expert"
+
+
 class Project(BaseModel):
     __tablename__ = "projects"
-    
+
+    slug = Column(String(255), unique=True, index=True, nullable=False)
     title = Column(String(255), nullable=False)
+    # The card blurb. `long_description` is the modal body — the frontend has
+    # always had both, but only this one had a column, so the detail view could
+    # never have been served from the API.
     description = Column(Text, nullable=False)
+    long_description = Column(Text)
     image_url = Column(String(500))
     github_url = Column(String(500))
     live_url = Column(String(500))
-    technologies = Column(JSON)  # Store as JSON array
+    technologies = Column(JSON)  # list[str]
+    features = Column(JSON)      # list[str]
+    challenges = Column(JSON)    # list[str]
+    started_on = Column(Date)
+    ended_on = Column(Date)      # Null while the work is still running.
+    status = Column(Enum(ProjectStatus), nullable=False, default=ProjectStatus.COMPLETED)
     featured = Column(Boolean, default=False)
+    published = Column(Boolean, nullable=False, default=False)
     order = Column(Integer, default=0)
+
 
 class Skill(BaseModel):
     __tablename__ = "skills"
-    
+
     name = Column(String(100), nullable=False)
-    category = Column(String(50), nullable=False)  # frontend, backend, tools, etc.
-    level = Column(Integer, default=1)  # 1-5 scale
+    category = Column(String(50), nullable=False)  # Frontend, Backend, Database, ...
+    # Was an unlabelled 1-5 integer. The frontend renders "Advanced"/"Expert"
+    # and had to invent its own mapping, so the names live here instead.
+    level = Column(Enum(SkillLevel), nullable=False, default=SkillLevel.BEGINNER)
     icon = Column(String(100))
     order = Column(Integer, default=0)
 
+
 class Certificate(BaseModel):
     __tablename__ = "certificates"
-    
+
+    slug = Column(String(255), unique=True, index=True, nullable=False)
     title = Column(String(255), nullable=False)
     issuer = Column(String(255), nullable=False)
     issue_date = Column(DateTime, nullable=False)
+    credential_id = Column(String(100))
     credential_url = Column(String(500))
     image_url = Column(String(500))
     description = Column(Text)
+    category = Column(String(50))
+    skills = Column(JSON)  # list[str]
+    published = Column(Boolean, nullable=False, default=False)
+
+
+class CareerEntry(BaseModel):
+    __tablename__ = "career_entries"
+
+    slug = Column(String(255), unique=True, index=True, nullable=False)
+    title = Column(String(255), nullable=False)
+    company = Column(String(255), nullable=False)
+    location = Column(String(255))
+    started_on = Column(Date, nullable=False)
+    ended_on = Column(Date)  # Null means "Present"; the frontend renders that.
+    highlights = Column(JSON)  # list[str]
+    published = Column(Boolean, nullable=False, default=False)
+
 
 class Contact(BaseModel):
     __tablename__ = "contacts"
-    
+
     name = Column(String(100), nullable=False)
     email = Column(String(255), nullable=False)
     subject = Column(String(255), nullable=False)
     message = Column(Text, nullable=False)
-    read = Column(Boolean, default=False) 
+    read = Column(Boolean, default=False)

--- a/apps/api/app/schemas/portfolio.py
+++ b/apps/api/app/schemas/portfolio.py
@@ -1,46 +1,76 @@
-from datetime import datetime
-from typing import List, Optional
+from datetime import date, datetime
+from typing import Annotated, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, BeforeValidator, ConfigDict
+
+from app.models.portfolio import ProjectStatus, SkillLevel
+
+
+def _no_null_list(value):
+    """Read a nullable JSON column as an empty list rather than ``None``.
+
+    The columns are nullable and rows written before this change have NULL in
+    them, which fails ``List[str]`` validation — as a 500 on a public GET,
+    because the error surfaces during response serialisation.
+    """
+    return [] if value is None else value
+
+
+StringList = Annotated[List[str], BeforeValidator(_no_null_list)]
 
 
 # Project Schemas
 class ProjectBase(BaseModel):
     title: str
     description: str
+    long_description: Optional[str] = None
     image_url: Optional[str] = None
     github_url: Optional[str] = None
     live_url: Optional[str] = None
-    technologies: List[str] = []
+    technologies: StringList = []
+    features: StringList = []
+    challenges: StringList = []
+    started_on: Optional[date] = None
+    ended_on: Optional[date] = None
+    status: ProjectStatus = ProjectStatus.COMPLETED
     featured: bool = False
+    published: bool = False
     order: int = 0
 
 class ProjectCreate(ProjectBase):
-    pass
+    # Optional on create: left out, it is derived from the title.
+    slug: Optional[str] = None
 
 class ProjectUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
+    long_description: Optional[str] = None
     image_url: Optional[str] = None
     github_url: Optional[str] = None
     live_url: Optional[str] = None
     technologies: Optional[List[str]] = None
+    features: Optional[List[str]] = None
+    challenges: Optional[List[str]] = None
+    started_on: Optional[date] = None
+    ended_on: Optional[date] = None
+    status: Optional[ProjectStatus] = None
     featured: Optional[bool] = None
+    published: Optional[bool] = None
     order: Optional[int] = None
 
 class Project(ProjectBase):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
+    slug: str
     created_at: datetime
     updated_at: Optional[datetime] = None
-
-    class Config:
-        from_attributes = True
 
 # Skill Schemas
 class SkillBase(BaseModel):
     name: str
     category: str
-    level: int = 1
+    level: SkillLevel = SkillLevel.BEGINNER
     icon: Optional[str] = None
     order: int = 0
 
@@ -50,45 +80,82 @@ class SkillCreate(SkillBase):
 class SkillUpdate(BaseModel):
     name: Optional[str] = None
     category: Optional[str] = None
-    level: Optional[int] = None
+    level: Optional[SkillLevel] = None
     icon: Optional[str] = None
     order: Optional[int] = None
 
 class Skill(SkillBase):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     created_at: datetime
     updated_at: Optional[datetime] = None
-
-    class Config:
-        from_attributes = True
 
 # Certificate Schemas
 class CertificateBase(BaseModel):
     title: str
     issuer: str
     issue_date: datetime
+    credential_id: Optional[str] = None
     credential_url: Optional[str] = None
     image_url: Optional[str] = None
     description: Optional[str] = None
+    category: Optional[str] = None
+    skills: StringList = []
+    published: bool = False
 
 class CertificateCreate(CertificateBase):
-    pass
+    slug: Optional[str] = None
 
 class CertificateUpdate(BaseModel):
     title: Optional[str] = None
     issuer: Optional[str] = None
     issue_date: Optional[datetime] = None
+    credential_id: Optional[str] = None
     credential_url: Optional[str] = None
     image_url: Optional[str] = None
     description: Optional[str] = None
+    category: Optional[str] = None
+    skills: Optional[List[str]] = None
+    published: Optional[bool] = None
 
 class Certificate(CertificateBase):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
+    slug: str
     created_at: datetime
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+# Career Schemas
+class CareerEntryBase(BaseModel):
+    title: str
+    company: str
+    location: Optional[str] = None
+    started_on: date
+    ended_on: Optional[date] = None
+    highlights: StringList = []
+    published: bool = False
+
+class CareerEntryCreate(CareerEntryBase):
+    slug: Optional[str] = None
+
+class CareerEntryUpdate(BaseModel):
+    title: Optional[str] = None
+    company: Optional[str] = None
+    location: Optional[str] = None
+    started_on: Optional[date] = None
+    ended_on: Optional[date] = None
+    highlights: Optional[List[str]] = None
+    published: Optional[bool] = None
+
+class CareerEntry(CareerEntryBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    slug: str
+    created_at: datetime
+    updated_at: Optional[datetime] = None
 
 # Contact Schemas
 class ContactBase(BaseModel):
@@ -101,10 +168,9 @@ class ContactCreate(ContactBase):
     pass
 
 class Contact(ContactBase):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     read: bool
     created_at: datetime
     updated_at: Optional[datetime] = None
-
-    class Config:
-        from_attributes = True 

--- a/apps/api/app/services/portfolio_service.py
+++ b/apps/api/app/services/portfolio_service.py
@@ -2,8 +2,11 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.portfolio import Certificate, Contact, Project, Skill
+from app.core.slugs import unique_slug
+from app.models.portfolio import CareerEntry, Certificate, Contact, Project, Skill
 from app.schemas.portfolio import (
+    CareerEntryCreate,
+    CareerEntryUpdate,
     CertificateCreate,
     CertificateUpdate,
     ContactCreate,
@@ -15,44 +18,83 @@ from app.schemas.portfolio import (
 
 
 class PortfolioService:
+    """Reads and writes portfolio content.
+
+    Every read takes ``include_unpublished``, which defaults to False. Callers
+    that want drafts have to ask for them, so a route that forgets to think
+    about visibility leaks nothing — it just shows the published set.
+    """
+
     def __init__(self, db: Session):
         self.db = db
 
+    def _create_with_slug(self, model, payload, title_field: str = "title"):
+        """Insert a slugged row, deriving the slug from its title if absent."""
+        data = payload.model_dump()
+        requested = data.pop("slug", None) or getattr(payload, title_field)
+        data["slug"] = unique_slug(self.db, model, requested)
+
+        record = model(**data)
+        self.db.add(record)
+        self.db.commit()
+        self.db.refresh(record)
+        return record
+
+    @staticmethod
+    def _apply_update(record, payload) -> None:
+        # exclude_unset, not exclude_none: a PATCH-style body that explicitly
+        # sends `"ended_on": null` means "clear this", and dropping nulls would
+        # make an ongoing project impossible to mark ongoing again.
+        for field, value in payload.model_dump(exclude_unset=True).items():
+            setattr(record, field, value)
+
     # Project methods
-    def get_projects(self, featured_only: bool = False) -> List[Project]:
+    def get_projects(
+        self,
+        featured_only: bool = False,
+        include_unpublished: bool = False,
+    ) -> List[Project]:
         query = self.db.query(Project)
+        if not include_unpublished:
+            query = query.filter(Project.published.is_(True))
         if featured_only:
             query = query.filter(Project.featured.is_(True))
-        return query.order_by(Project.order).all()
+        return query.order_by(Project.order, Project.id).all()
 
-    def get_project(self, project_id: int) -> Optional[Project]:
-        return self.db.query(Project).filter(Project.id == project_id).first()
+    def get_project(
+        self, project_id: int, include_unpublished: bool = False
+    ) -> Optional[Project]:
+        query = self.db.query(Project).filter(Project.id == project_id)
+        if not include_unpublished:
+            query = query.filter(Project.published.is_(True))
+        return query.first()
+
+    def get_project_by_slug(
+        self, slug: str, include_unpublished: bool = False
+    ) -> Optional[Project]:
+        query = self.db.query(Project).filter(Project.slug == slug)
+        if not include_unpublished:
+            query = query.filter(Project.published.is_(True))
+        return query.first()
 
     def create_project(self, project: ProjectCreate) -> Project:
-        db_project = Project(**project.model_dump())
-        self.db.add(db_project)
-        self.db.commit()
-        self.db.refresh(db_project)
-        return db_project
+        return self._create_with_slug(Project, project)
 
     def update_project(self, project_id: int, project: ProjectUpdate) -> Optional[Project]:
-        db_project = self.get_project(project_id)
+        db_project = self.get_project(project_id, include_unpublished=True)
         if not db_project:
             return None
-        
-        update_data = project.model_dump(exclude_unset=True)
-        for field, value in update_data.items():
-            setattr(db_project, field, value)
-        
+
+        self._apply_update(db_project, project)
         self.db.commit()
         self.db.refresh(db_project)
         return db_project
 
     def delete_project(self, project_id: int) -> bool:
-        db_project = self.get_project(project_id)
+        db_project = self.get_project(project_id, include_unpublished=True)
         if not db_project:
             return False
-        
+
         self.db.delete(db_project)
         self.db.commit()
         return True
@@ -62,7 +104,7 @@ class PortfolioService:
         query = self.db.query(Skill)
         if category:
             query = query.filter(Skill.category == category)
-        return query.order_by(Skill.order).all()
+        return query.order_by(Skill.order, Skill.id).all()
 
     def get_skill(self, skill_id: int) -> Optional[Skill]:
         return self.db.query(Skill).filter(Skill.id == skill_id).first()
@@ -78,11 +120,8 @@ class PortfolioService:
         db_skill = self.get_skill(skill_id)
         if not db_skill:
             return None
-        
-        update_data = skill.model_dump(exclude_unset=True)
-        for field, value in update_data.items():
-            setattr(db_skill, field, value)
-        
+
+        self._apply_update(db_skill, skill)
         self.db.commit()
         self.db.refresh(db_skill)
         return db_skill
@@ -91,44 +130,101 @@ class PortfolioService:
         db_skill = self.get_skill(skill_id)
         if not db_skill:
             return False
-        
+
         self.db.delete(db_skill)
         self.db.commit()
         return True
 
     # Certificate methods
-    def get_certificates(self) -> List[Certificate]:
-        return self.db.query(Certificate).order_by(Certificate.issue_date.desc()).all()
+    def get_certificates(
+        self,
+        category: Optional[str] = None,
+        include_unpublished: bool = False,
+    ) -> List[Certificate]:
+        query = self.db.query(Certificate)
+        if not include_unpublished:
+            query = query.filter(Certificate.published.is_(True))
+        if category:
+            query = query.filter(Certificate.category == category)
+        return query.order_by(Certificate.issue_date.desc()).all()
 
-    def get_certificate(self, certificate_id: int) -> Optional[Certificate]:
-        return self.db.query(Certificate).filter(Certificate.id == certificate_id).first()
+    def get_certificate(
+        self, certificate_id: int, include_unpublished: bool = False
+    ) -> Optional[Certificate]:
+        query = self.db.query(Certificate).filter(Certificate.id == certificate_id)
+        if not include_unpublished:
+            query = query.filter(Certificate.published.is_(True))
+        return query.first()
+
+    def get_certificate_by_slug(
+        self, slug: str, include_unpublished: bool = False
+    ) -> Optional[Certificate]:
+        query = self.db.query(Certificate).filter(Certificate.slug == slug)
+        if not include_unpublished:
+            query = query.filter(Certificate.published.is_(True))
+        return query.first()
 
     def create_certificate(self, certificate: CertificateCreate) -> Certificate:
-        db_certificate = Certificate(**certificate.model_dump())
-        self.db.add(db_certificate)
-        self.db.commit()
-        self.db.refresh(db_certificate)
-        return db_certificate
+        return self._create_with_slug(Certificate, certificate)
 
-    def update_certificate(self, certificate_id: int, certificate: CertificateUpdate) -> Optional[Certificate]:
-        db_certificate = self.get_certificate(certificate_id)
+    def update_certificate(
+        self, certificate_id: int, certificate: CertificateUpdate
+    ) -> Optional[Certificate]:
+        db_certificate = self.get_certificate(certificate_id, include_unpublished=True)
         if not db_certificate:
             return None
-        
-        update_data = certificate.model_dump(exclude_unset=True)
-        for field, value in update_data.items():
-            setattr(db_certificate, field, value)
-        
+
+        self._apply_update(db_certificate, certificate)
         self.db.commit()
         self.db.refresh(db_certificate)
         return db_certificate
 
     def delete_certificate(self, certificate_id: int) -> bool:
-        db_certificate = self.get_certificate(certificate_id)
+        db_certificate = self.get_certificate(certificate_id, include_unpublished=True)
         if not db_certificate:
             return False
-        
+
         self.db.delete(db_certificate)
+        self.db.commit()
+        return True
+
+    # Career methods
+    def get_career_entries(self, include_unpublished: bool = False) -> List[CareerEntry]:
+        query = self.db.query(CareerEntry)
+        if not include_unpublished:
+            query = query.filter(CareerEntry.published.is_(True))
+        # Newest first, which is how a CV reads.
+        return query.order_by(CareerEntry.started_on.desc()).all()
+
+    def get_career_entry(
+        self, entry_id: int, include_unpublished: bool = False
+    ) -> Optional[CareerEntry]:
+        query = self.db.query(CareerEntry).filter(CareerEntry.id == entry_id)
+        if not include_unpublished:
+            query = query.filter(CareerEntry.published.is_(True))
+        return query.first()
+
+    def create_career_entry(self, entry: CareerEntryCreate) -> CareerEntry:
+        return self._create_with_slug(CareerEntry, entry)
+
+    def update_career_entry(
+        self, entry_id: int, entry: CareerEntryUpdate
+    ) -> Optional[CareerEntry]:
+        db_entry = self.get_career_entry(entry_id, include_unpublished=True)
+        if not db_entry:
+            return None
+
+        self._apply_update(db_entry, entry)
+        self.db.commit()
+        self.db.refresh(db_entry)
+        return db_entry
+
+    def delete_career_entry(self, entry_id: int) -> bool:
+        db_entry = self.get_career_entry(entry_id, include_unpublished=True)
+        if not db_entry:
+            return False
+
+        self.db.delete(db_entry)
         self.db.commit()
         return True
 
@@ -153,7 +249,7 @@ class PortfolioService:
         db_contact = self.get_contact(contact_id)
         if not db_contact:
             return None
-        
+
         db_contact.read = True
         self.db.commit()
         self.db.refresh(db_contact)
@@ -163,7 +259,7 @@ class PortfolioService:
         db_contact = self.get_contact(contact_id)
         if not db_contact:
             return False
-        
+
         self.db.delete(db_contact)
         self.db.commit()
-        return True 
+        return True

--- a/apps/api/scripts/seed_content.py
+++ b/apps/api/scripts/seed_content.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Load the real portfolio content into the database.
+
+Until now every project, skill, certificate and career entry lived as a
+hardcoded array inside the Vite components — the API served content tables that
+nothing wrote to, and the site rendered content the API had never seen. This
+script is the one-time bridge: it lifts that data out of the components so the
+API becomes the source of truth and the frontend can be pointed at it.
+
+Idempotent. Rows are keyed on slug, so a second run updates rather than
+duplicates, and re-running after editing an entry here pushes the edit through.
+
+    python scripts/seed_content.py
+    python scripts/seed_content.py --dry-run    # print what would change
+"""
+import argparse
+import os
+import sys
+from datetime import date, datetime
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.core.database import SessionLocal
+from app.core.slugs import slugify
+from app.models.portfolio import (
+    CareerEntry,
+    Certificate,
+    Project,
+    ProjectStatus,
+    Skill,
+    SkillLevel,
+)
+
+PROJECTS = [
+    {
+        "title": "Cenematic",
+        "description": (
+            "Cinematic is an online cinema ticket booking system built with Java "
+            "Servlet and JSP, enabling users to browse movies, choose seats, and "
+            "make secure bookings."
+        ),
+        "long_description": (
+            "Cinematic is a web-based cinema ticket booking system developed as part "
+            "of a Java Servlet & JSP course at FPT University. The platform allows "
+            "users to explore movies, select showtimes and seats, and complete "
+            "bookings through a secure interface. Administrators can efficiently "
+            "manage show schedules, ticket slots, and user accounts."
+        ),
+        "image_url": "/assets/images/cenematic.png",
+        "github_url": "https://github.com/dangkhoipham80/Cenematic",
+        "live_url": None,
+        "technologies": [
+            "Java Servlet", "JSP", "HTML", "CSS", "JavaScript",
+            "Bootstrap", "SQL Server", "Bcrypt", "jQuery",
+        ],
+        "features": [
+            "Online cinema ticket booking",
+            "Responsive and intuitive UI",
+            "Admin panel for schedule management",
+            "Secure login system with Bcrypt encryption",
+            "Movie search functionality",
+        ],
+        "challenges": [
+            "Implementing full CRUD operations for admin panel",
+            "Integrating SMTP email service securely",
+            "Creating responsive UI with Bootstrap",
+            "Managing compatibility with Java libraries and Tomcat",
+        ],
+        "started_on": date(2024, 8, 11),
+        "ended_on": date(2024, 9, 22),
+        "status": ProjectStatus.COMPLETED,
+        "featured": True,
+        "order": 1,
+    },
+    {
+        "title": "Feng Shui Koi",
+        "description": (
+            "The FengShui Koi Consulting System is a project that provides "
+            "consultation on Feng Shui and compatibility for Koi fish and ponds."
+        ),
+        "long_description": (
+            "The FengShui Koi Consulting System is a comprehensive web application "
+            "designed to provide expert consultation on Feng Shui principles and "
+            "compatibility for Koi fish and ponds. This project combines traditional "
+            "Feng Shui wisdom with modern technology to help users create harmonious "
+            "aquatic environments."
+        ),
+        "image_url": "/assets/images/feng-shui-koi.png",
+        "github_url": (
+            "https://github.com/dangkhoipham80/"
+            "FA24_SE1854_SWP391_G8_FengShuiKoiConsultingSystem.git"
+        ),
+        "live_url": None,
+        "technologies": [
+            "FireBase", "Java Spring Boot", "MySQL", "React", "TypeScript",
+            "HTML", "CSS",
+        ],
+        "features": [
+            "Feng Shui pond analysis and recommendations",
+            "Koi fish compatibility assessment",
+            "Interactive consultation dashboard",
+            "User account management",
+            "Expert consultation booking",
+            "Mobile-responsive design",
+        ],
+        "challenges": [
+            "Implementing complex Feng Shui algorithms",
+            "Managing real-time data synchronization",
+            "Creating intuitive user experience",
+            "Integrating multiple databases",
+        ],
+        "started_on": date(2024, 1, 15),
+        "ended_on": date(2024, 3, 20),
+        "status": ProjectStatus.COMPLETED,
+        "featured": True,
+        "order": 2,
+    },
+    {
+        "title": "Portfolio",
+        "description": (
+            "This is my portfolio website. A project that focuses to show my "
+            "Frontend skills and introduce myself."
+        ),
+        "long_description": (
+            "A modern, responsive portfolio website built to showcase my technical "
+            "skills and professional journey. This project demonstrates my "
+            "proficiency in frontend development using cutting-edge technologies "
+            "and design principles."
+        ),
+        "image_url": "/assets/images/portfolio.png",
+        "github_url": "https://github.com/dangkhoipham80/portfolio",
+        "live_url": "https://portfolio-fthuepi8a-pham-dang-khois-projects.vercel.app/",
+        "technologies": ["React", "TypeScript", "Tailwind CSS", "Vite", "Vercel"],
+        "features": [
+            "Interactive animated backgrounds",
+            "Dynamic theme switching",
+            "Responsive design across all devices",
+            "Smooth page transitions",
+            "Contact form with email integration",
+            "Project showcase with filtering",
+        ],
+        "challenges": [
+            "Creating smooth, performant animations",
+            "Implementing complex CSS animations",
+            "Optimizing for mobile performance",
+            "Managing state across components",
+        ],
+        "started_on": date(2024, 3, 1),
+        "ended_on": None,
+        "status": ProjectStatus.IN_PROGRESS,
+        "featured": False,
+        "order": 3,
+    },
+    {
+        "title": "EduPath",
+        "description": (
+            "EduPath is a smart platform that helps high school students explore "
+            "universities, compare majors, and receive 24/7 career guidance."
+        ),
+        "long_description": (
+            "EduPath is an educational platform designed to support Vietnamese high "
+            "school students in researching university information, comparing "
+            "admission scores, viewing score distributions, and receiving real-time "
+            "career guidance. The platform is being built using scalable "
+            "architecture and modern technologies to ensure high availability and "
+            "performance."
+        ),
+        "image_url": "/assets/images/edupath.png",
+        "github_url": "https://gitlab.com/fpt2843445/period_7/sba301/edupath",
+        "live_url": None,
+        "technologies": [
+            "Java Spring Boot", "ReactTS", "FastAPI", "PostgreSQL", "MongoDB",
+            "Minio", "Docker", "Kibana", "Elasticsearch", "Redis", "Kafka",
+        ],
+        "features": [
+            "University admission score search by year and major",
+            "Score distribution visualization (THPT exam)",
+            "University and major comparison tool",
+            "AI-powered career counseling chatbot",
+            "Live advisor support available 24/7",
+        ],
+        "challenges": [
+            "Data collection and integration from multiple sources",
+            "Real-time score distribution updates",
+            "AI model training and optimization",
+            "User privacy and data security",
+            "Scalable architecture for high traffic",
+        ],
+        "started_on": date(2024, 6, 8),
+        "ended_on": date(2024, 7, 27),
+        "status": ProjectStatus.COMPLETED,
+        "featured": True,
+        "order": 4,
+    },
+    {
+        "title": "Food Forum",
+        "description": (
+            "Food Forum is a vibrant community platform for food lovers to share "
+            "recipes, experiences, and engage in real-time conversations."
+        ),
+        "long_description": (
+            "Food Forum is a social platform built for all cooking enthusiasts — "
+            "regardless of skill level — to connect, share recipes, post food "
+            "experiences, and join real-time conversations. The frontend is built "
+            "with React, TypeScript and TailwindCSS on Vercel; the backend is "
+            "FastAPI with WebSocket on AWS EC2 behind Nginx, backed by PostgreSQL "
+            "hosted on Neon.tech."
+        ),
+        "image_url": "/assets/images/foodforum.png",
+        "github_url": "https://gitlab.com/fpt2843445/period_7/swd392/food-forum",
+        "live_url": None,
+        "technologies": [
+            "React", "TypeScript", "TailwindCSS", "FastAPI", "PostgreSQL",
+            "WebSocket", "Firebase Auth", "AWS", "Vercel", "Neon.tech", "Nginx",
+        ],
+        "features": [
+            "Post recipes and food experiences",
+            "Comment, like, and interact with others",
+            "Topic-based group chats and 1-on-1 messaging",
+            "Real-time communication via WebSocket (FastAPI)",
+            "User authentication via Firebase",
+            "Content reporting and user feedback",
+            "Admin dashboard for moderation",
+            "Responsive UI with TailwindCSS",
+        ],
+        "challenges": [
+            "Building real-time messaging using FastAPI WebSocket",
+            "Securing backend with Firebase token verification",
+            "Managing deployment via AWS & Nginx",
+            "Database performance with large user-generated content",
+            "Responsive design & real-time UX consistency",
+        ],
+        "started_on": date(2024, 5, 25),
+        "ended_on": date(2024, 7, 27),
+        "status": ProjectStatus.COMPLETED,
+        "featured": True,
+        "order": 5,
+    },
+]
+
+# (name, category, level) in the order the Skills section renders them.
+SKILLS = [
+    ("HTML/CSS", "Frontend", SkillLevel.ADVANCED),
+    ("JavaScript", "Frontend", SkillLevel.INTERMEDIATE),
+    ("React", "Frontend", SkillLevel.INTERMEDIATE),
+    ("Tailwind CSS", "Frontend", SkillLevel.BEGINNER),
+    ("TypeScript", "Frontend", SkillLevel.BEGINNER),
+    ("Bootstrap", "Frontend", SkillLevel.INTERMEDIATE),
+    ("Java Spring Boot", "Backend", SkillLevel.INTERMEDIATE),
+    ("FastAPI", "Backend", SkillLevel.INTERMEDIATE),
+    ("MongoDB", "Database", SkillLevel.BEGINNER),
+    ("PostgreSQL", "Database", SkillLevel.INTERMEDIATE),
+    ("MySQL", "Database", SkillLevel.INTERMEDIATE),
+    ("SQLite", "Database", SkillLevel.BEGINNER),
+    ("Redis", "Database", SkillLevel.BEGINNER),
+    ("AWS", "Cloud", SkillLevel.INTERMEDIATE),
+    ("Azure", "Cloud", SkillLevel.INTERMEDIATE),
+    ("Google Cloud", "Cloud", SkillLevel.BEGINNER),
+    ("Firebase", "Cloud", SkillLevel.INTERMEDIATE),
+    ("Docker", "DevOps", SkillLevel.INTERMEDIATE),
+    ("Kubernetes", "DevOps", SkillLevel.BEGINNER),
+    ("GitLab", "Tools", SkillLevel.INTERMEDIATE),
+    ("GitHub", "Tools", SkillLevel.INTERMEDIATE),
+    ("Vscode", "Tools", SkillLevel.INTERMEDIATE),
+    ("Slack", "Tools", SkillLevel.BEGINNER),
+]
+
+CERTIFICATES = [
+    {
+        "title": "AWS Certified Cloud Practitioner",
+        "issuer": "Amazon Web Services",
+        "issue_date": datetime(2024, 3, 1),
+        "credential_id": "AWS-123456",
+        "credential_url": "https://www.credly.com/aws-certified-cloud-practitioner",
+        "description": (
+            "Foundational level certification demonstrating cloud fluency and AWS "
+            "Cloud concepts."
+        ),
+        "category": "Cloud",
+        "skills": ["Cloud Computing", "AWS", "Cloud Architecture"],
+    },
+    {
+        "title": "Python for Data Science",
+        "issuer": "IBM",
+        "issue_date": datetime(2024, 2, 1),
+        "credential_id": "IBM-789012",
+        "credential_url": (
+            "https://www.coursera.org/account/accomplishments/certificate/IBM-789012"
+        ),
+        "description": (
+            "Comprehensive course covering Python programming for data analysis and "
+            "visualization."
+        ),
+        "category": "Data Science",
+        "skills": ["Python", "Data Science", "Data Analysis"],
+    },
+    {
+        "title": "Spring Boot Developer",
+        "issuer": "Udemy",
+        "issue_date": datetime(2024, 1, 1),
+        "credential_id": "UDEMY-345678",
+        "credential_url": "https://www.udemy.com/certificate/UDEMY-345678",
+        "description": (
+            "Advanced Spring Boot development certification covering microservices "
+            "and REST APIs."
+        ),
+        "category": "Backend",
+        "skills": ["Java", "Spring Boot", "REST APIs"],
+    },
+    {
+        "title": "React Developer Certification",
+        "issuer": "Meta",
+        "issue_date": datetime(2023, 12, 1),
+        "credential_id": "META-456789",
+        "credential_url": (
+            "https://www.coursera.org/account/accomplishments/certificate/META-456789"
+        ),
+        "description": (
+            "Professional certification in React development and frontend "
+            "engineering."
+        ),
+        "category": "Frontend",
+        "skills": ["React", "JavaScript", "Frontend Development"],
+    },
+    {
+        "title": "Machine Learning Specialization",
+        "issuer": "Stanford Online",
+        "issue_date": datetime(2023, 11, 1),
+        "credential_id": "STAN-234567",
+        "credential_url": (
+            "https://www.coursera.org/account/accomplishments/certificate/STAN-234567"
+        ),
+        "description": (
+            "Comprehensive machine learning certification covering algorithms and "
+            "practical applications."
+        ),
+        "category": "AI/ML",
+        "skills": ["Machine Learning", "AI", "Data Analysis"],
+    },
+]
+
+CAREER_ENTRIES = [
+    {
+        "title": "Python Developer Intern",
+        "company": "FPT Software",
+        "location": "Ho Chi Minh City, Vietnam",
+        "started_on": date(2024, 12, 1),
+        "ended_on": date(2025, 3, 31),
+        "highlights": [
+            "Developed and maintained RESTful APIs using Python and FastAPI",
+            "Collaborated with cross-functional teams to implement new features",
+            "Optimized database queries and improved application performance",
+            "Participated in code reviews and implemented best practices",
+        ],
+    },
+    {
+        "title": "Software Engineering Student",
+        "company": "FPT University",
+        "location": "Ho Chi Minh City, Vietnam",
+        "started_on": date(2022, 9, 1),
+        "ended_on": None,  # Still ongoing; the frontend renders this as "Present".
+        "highlights": [
+            "Studying Software Engineering with focus on Backend Development",
+            "Participated in various hackathons and coding competitions",
+            "Developed personal projects to enhance technical skills",
+            "Learning Data Science and AI concepts",
+        ],
+    },
+]
+
+
+def _upsert(db, model, key_field, key_value, values, dry_run):
+    """Insert or update one row, reporting which it did."""
+    existing = db.query(model).filter(getattr(model, key_field) == key_value).first()
+
+    if existing is None:
+        if not dry_run:
+            db.add(model(**{key_field: key_value}, **values))
+        return "create"
+
+    changed = [f for f, v in values.items() if getattr(existing, f) != v]
+    if not changed:
+        return "unchanged"
+
+    if not dry_run:
+        for field, value in values.items():
+            setattr(existing, field, value)
+    return "update"
+
+
+def seed(dry_run: bool = False) -> None:
+    db = SessionLocal()
+    tally = {"create": 0, "update": 0, "unchanged": 0}
+
+    def record(outcome, label):
+        tally[outcome] += 1
+        if outcome != "unchanged":
+            print(f"  {outcome:9} {label}")
+
+    try:
+        print("Projects")
+        for entry in PROJECTS:
+            values = dict(entry, published=True)
+            record(
+                _upsert(db, Project, "slug", slugify(entry["title"]), values, dry_run),
+                entry["title"],
+            )
+
+        print("Skills")
+        for order, (name, category, level) in enumerate(SKILLS, start=1):
+            # Skills have no slug — name is the natural key.
+            values = {"category": category, "level": level, "order": order}
+            record(_upsert(db, Skill, "name", name, values, dry_run), name)
+
+        print("Certificates")
+        for entry in CERTIFICATES:
+            values = dict(entry, published=True)
+            record(
+                _upsert(db, Certificate, "slug", slugify(entry["title"]), values, dry_run),
+                entry["title"],
+            )
+
+        print("Career entries")
+        for entry in CAREER_ENTRIES:
+            values = dict(entry, published=True)
+            label = f"{entry['title']} @ {entry['company']}"
+            record(
+                _upsert(db, CareerEntry, "slug", slugify(label), values, dry_run),
+                label,
+            )
+
+        if dry_run:
+            db.rollback()
+            print(f"\nDry run — nothing written. {tally}")
+        else:
+            db.commit()
+            print(f"\nDone. {tally}")
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change without writing",
+    )
+    seed(dry_run=parser.parse_args().dry_run)

--- a/apps/api/tests/test_content_api.py
+++ b/apps/api/tests/test_content_api.py
@@ -1,0 +1,310 @@
+"""Content endpoints: publish state, slugs, and the reshaped fields.
+
+The point of this file is the draft/published split. Everything under
+``/projects``, ``/certificates`` and ``/career`` is world-readable, so the only
+thing standing between an unfinished draft and the public internet is the
+``published`` filter in PortfolioService — and a filter that is only ever
+exercised by the code that sets it is not tested at all. Each case here asks
+the question from outside: can an anonymous caller see this row?
+
+Runs against whatever ``DATABASE_URL`` points at and inserts rows; each test
+cleans up what it made.
+"""
+
+from datetime import date, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.slugs import slugify, unique_slug
+from app.main import app
+from app.models.portfolio import CareerEntry, Certificate, Project, ProjectStatus, Skill, SkillLevel
+from app.models.role import Role, UserRole
+from app.models.token import TokenType
+from app.services.user_service import UserService
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def make_project(db):
+    """Insert projects and remove them afterwards, published or not."""
+    made = []
+
+    def _make(title, *, published: bool, featured: bool = False):
+        record = Project(
+            slug=unique_slug(db, Project, title),
+            title=title,
+            description="Seeded by the test suite.",
+            status=ProjectStatus.COMPLETED,
+            published=published,
+            featured=featured,
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        made.append(record.id)
+        return record
+
+    yield _make
+
+    for project_id in made:
+        db.query(Project).filter(Project.id == project_id).delete()
+    db.commit()
+
+
+@pytest.fixture
+def admin_token(db, make_user):
+    """A bearer token for a real admin user.
+
+    Goes through UserService.create_token rather than signing a JWT by hand,
+    because get_current_user_dependency also checks the token has a live row —
+    a hand-signed token is rejected before the admin check is ever reached.
+    """
+    admin_role = db.query(Role).filter(Role.name == "admin").first()
+    if admin_role is None:
+        pytest.skip("no admin role in this database; run scripts/init_auth_tables.py")
+
+    user = make_user("content-admin@example.invalid")
+    db.add(UserRole(user_id=user.id, role_id=admin_role.id))
+    db.commit()
+
+    return UserService(db).create_token(user.id, TokenType.ACCESS, expires_in_minutes=10)
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# --- draft visibility ------------------------------------------------------
+
+def test_a_draft_project_is_not_in_the_public_list(make_project):
+    draft = make_project("Half Written Thing", published=False)
+
+    slugs = [p["slug"] for p in client.get("/api/v1/projects/").json()]
+
+    assert draft.slug not in slugs
+
+
+def test_a_published_project_is_in_the_public_list(make_project):
+    """Baseline: without this the test above could pass on an empty list."""
+    live = make_project("Perfectly Finished Thing", published=True)
+
+    slugs = [p["slug"] for p in client.get("/api/v1/projects/").json()]
+
+    assert live.slug in slugs
+
+
+def test_fetching_a_draft_by_id_is_a_404_not_a_403(make_project):
+    """403 would confirm the row exists. Whether a draft exists is not public."""
+    draft = make_project("Secret Draft", published=False)
+
+    assert client.get(f"/api/v1/projects/{draft.id}").status_code == 404
+
+
+def test_fetching_a_draft_by_slug_is_a_404(make_project):
+    draft = make_project("Secret Draft By Slug", published=False)
+
+    assert client.get(f"/api/v1/projects/slug/{draft.slug}").status_code == 404
+
+
+def test_an_admin_sees_drafts(make_project, admin_token):
+    draft = make_project("Visible To Admin", published=False)
+
+    response = client.get("/api/v1/projects/", headers=_auth(admin_token))
+
+    assert draft.slug in [p["slug"] for p in response.json()]
+
+
+def test_an_expired_or_bogus_token_still_gets_the_public_list(make_project):
+    """The content routes are public: a bad token means anonymous, not 401.
+
+    get_optional_admin swallows the auth failure. If it ever stops doing so,
+    one stale token in a visitor's browser breaks the whole portfolio page.
+    """
+    live = make_project("Readable Without Credentials", published=True)
+
+    response = client.get("/api/v1/projects/", headers=_auth("not-a-real-token"))
+
+    assert response.status_code == 200
+    assert live.slug in [p["slug"] for p in response.json()]
+
+
+def test_featured_filter_still_excludes_drafts(make_project):
+    """Two filters compose here, and `featured` is the one that came first."""
+    draft = make_project("Featured But Unpublished", published=False, featured=True)
+
+    slugs = [p["slug"] for p in client.get("/api/v1/projects/?featured_only=true").json()]
+
+    assert draft.slug not in slugs
+
+
+# --- slugs -----------------------------------------------------------------
+
+def test_a_project_is_reachable_by_slug(make_project):
+    live = make_project("Reachable By Slug", published=True)
+
+    body = client.get(f"/api/v1/projects/slug/{live.slug}").json()
+
+    assert body["id"] == live.id
+    assert body["slug"] == "reachable-by-slug"
+
+
+def test_slug_route_does_not_shadow_the_id_route(make_project):
+    """`/projects/slug/x` and `/projects/{id}` are both live; check both resolve."""
+    live = make_project("Both Routes Work", published=True)
+
+    assert client.get(f"/api/v1/projects/{live.id}").json()["slug"] == live.slug
+    assert client.get(f"/api/v1/projects/slug/{live.slug}").json()["id"] == live.id
+
+
+def test_slugify_folds_accents_rather_than_dropping_them():
+    """"Đ" has no combining form, so NFKD alone silently deletes it."""
+    assert slugify("Phạm Đăng Khôi") == "pham-dang-khoi"
+
+
+def test_slugify_collapses_punctuation_and_trims_the_ends():
+    assert slugify("  Hello, World!! ") == "hello-world"
+
+
+def test_unique_slug_suffixes_a_collision(db, make_project):
+    make_project("Duplicate Title", published=True)
+
+    assert unique_slug(db, Project, "Duplicate Title") == "duplicate-title-2"
+
+
+def test_two_projects_with_the_same_title_get_different_slugs(make_project):
+    first = make_project("Same Name", published=True)
+    second = make_project("Same Name", published=True)
+
+    assert first.slug != second.slug
+
+
+# --- reshaped fields -------------------------------------------------------
+
+def test_a_project_with_no_lists_serialises_them_as_empty_not_null(make_project):
+    """The JSON columns are nullable; rows predating this change hold NULL.
+
+    Without the BeforeValidator that becomes a 500 during response
+    serialisation, on a public GET.
+    """
+    live = make_project("No Lists At All", published=True)
+
+    body = client.get(f"/api/v1/projects/{live.id}").json()
+
+    assert body["technologies"] == []
+    assert body["features"] == []
+    assert body["challenges"] == []
+
+
+def test_project_status_serialises_as_its_name(make_project):
+    live = make_project("Status Shape", published=True)
+
+    assert client.get(f"/api/v1/projects/{live.id}").json()["status"] == "completed"
+
+
+def test_skill_level_is_a_name_not_a_number(db):
+    """The old column was an unlabelled 1-5 int the frontend had to map itself."""
+    skill = Skill(name="Test Skill For Levels", category="Testing", level=SkillLevel.ADVANCED)
+    db.add(skill)
+    db.commit()
+
+    try:
+        body = client.get("/api/v1/skills/").json()
+        entry = next(s for s in body if s["name"] == "Test Skill For Levels")
+        assert entry["level"] == "advanced"
+    finally:
+        db.query(Skill).filter(Skill.id == skill.id).delete()
+        db.commit()
+
+
+def test_creating_a_skill_rejects_the_old_integer_level(admin_token):
+    """A client still sending `"level": 4` should be told, not silently accepted."""
+    response = client.post(
+        "/api/v1/skills/",
+        json={"name": "Rejected Skill", "category": "Testing", "level": 4},
+        headers=_auth(admin_token),
+    )
+
+    assert response.status_code == 422
+
+
+# --- career ----------------------------------------------------------------
+
+@pytest.fixture
+def make_career_entry(db):
+    made = []
+
+    def _make(title, company, *, published: bool, ended_on=None):
+        record = CareerEntry(
+            slug=unique_slug(db, CareerEntry, f"{title} {company}"),
+            title=title,
+            company=company,
+            started_on=date(2024, 1, 1),
+            ended_on=ended_on,
+            published=published,
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        made.append(record.id)
+        return record
+
+    yield _make
+
+    for entry_id in made:
+        db.query(CareerEntry).filter(CareerEntry.id == entry_id).delete()
+    db.commit()
+
+
+def test_career_entries_are_publicly_readable(make_career_entry):
+    entry = make_career_entry("Test Role", "Test Company", published=True)
+
+    response = client.get("/api/v1/career/")
+
+    assert response.status_code == 200
+    assert entry.slug in [e["slug"] for e in response.json()]
+
+
+def test_a_draft_career_entry_is_hidden(make_career_entry):
+    entry = make_career_entry("Unannounced Role", "Stealth Co", published=False)
+
+    slugs = [e["slug"] for e in client.get("/api/v1/career/").json()]
+
+    assert entry.slug not in slugs
+
+
+def test_an_ongoing_role_has_a_null_end_date(make_career_entry):
+    """Null end date is how "Present" is represented; it must survive the API."""
+    entry = make_career_entry("Current Role", "Current Co", published=True, ended_on=None)
+
+    body = client.get(f"/api/v1/career/{entry.id}").json()
+
+    assert body["ended_on"] is None
+
+
+def test_writing_career_entries_needs_admin():
+    payload = {"title": "x", "company": "y", "started_on": "2024-01-01"}
+
+    assert client.post("/api/v1/career/", json=payload).status_code in (401, 403)
+
+
+# --- certificates ----------------------------------------------------------
+
+def test_a_draft_certificate_is_hidden(db):
+    cert = Certificate(
+        slug=unique_slug(db, Certificate, "Unlisted Certificate"),
+        title="Unlisted Certificate",
+        issuer="Nobody",
+        issue_date=datetime(2024, 1, 1),
+        published=False,
+    )
+    db.add(cert)
+    db.commit()
+
+    try:
+        slugs = [c["slug"] for c in client.get("/api/v1/certificates/").json()]
+        assert cert.slug not in slugs
+    finally:
+        db.query(Certificate).filter(Certificate.id == cert.id).delete()
+        db.commit()


### PR DESCRIPTION
## Why

The content tables were still the originals. A project had a title, a blurb and
a tag list — while `ProjectSection.tsx` has been rendering a long description, a
feature list, a challenge list, start/end dates and a status all along. None of
those had a column, so the detail modal **could never have been served from the
API**. That is part of why the frontend fetches nothing and hardcodes all five
projects, and why the API served content tables that nothing ever wrote to.

There was also no way to work on an unfinished entry: every row was live the
moment it existed.

## What changed

**Schema**
- `slug` + `published` on projects, certificates, and the new `career_entries`
  table (career history had no table at all).
- `long_description`, `features`, `challenges`, `started_on`, `ended_on`,
  `status` on projects — the fields the modal already renders.
- `Skill.level` becomes a named enum (`beginner` … `expert`). It was an
  unlabelled 1-5 integer that the frontend mapped to names itself, and `2` and
  `3` both meant "Intermediate" to it.

**Visibility**
- Public callers see published rows only; an admin bearer token also returns
  drafts.
- A draft **404s rather than 403s**. Whether an unfinished project exists at
  that id is not public information either.
- `PortfolioService` reads all default to `include_unpublished=False`, so a
  route that forgets to think about visibility leaks nothing.

**`get_optional_admin`**
The dependency the public routes needed. The previous attempt at this shape was
deleted for taking `Depends()` from the shared `HTTPBearer`, whose
`auto_error=True` fires before the body runs — its `if not credentials` branch
was unreachable. This one owns an `auto_error=False` bearer and swallows auth
failures, so a visitor with a stale token still gets the published portfolio
instead of a 401 on the whole page.

**`scripts/seed_content.py`**
Lifts the real content (5 projects, 23 skills, 5 certificates, 2 career
entries) out of the Vite components so the API becomes the source of truth.
Idempotent — keyed on slug, so re-running updates in place. Has `--dry-run`.

## The migration is not autogenerate output

Two parts were written by hand and should not be replaced by a regenerate:

1. **Slug backfill runs in Python, not SQL.** The obvious
   `regexp_replace(title, '[^a-zA-Z0-9]+', '-')` treats an accented letter as a
   separator. Comparing the two implementations directly:

   ```
   py=pham-dang-khoi | pg=ph-m-d-ng-kh-i
   py=do-an-tot-nghiep | pg=d-n-t-t-nghi-p
   ```

   NFKD folds; a character class cannot. The `slugify` used in the migration is
   a **frozen copy**, not an import — a later edit to `app/core/slugs.py` must
   not change what an already-applied migration would do on a fresh database.

2. **`skills.level`** needs an explicit `USING` clause; autogenerate emits a
   bare `ALTER TYPE` that Postgres refuses.

Existing rows are backfilled to `published = true`. They were publicly visible
before this migration, and defaulting them to draft would silently unpublish a
live portfolio.

`downgrade()` drops the two new enum types, for the same reason the initial
migration does.

## Verification

- `upgrade → downgrade → upgrade` against Neon **with real rows present**,
  including a Vietnamese title and two duplicate titles: accents fold, and the
  duplicate gets `-2`.
- `alembic check` → "No new upgrade operations detected" (no model/schema drift).
- **69/69 tests pass**, `ruff check .` clean.
- **Mutation-tested**: disabling the `published` filter fails exactly 4 of the
  new tests, so they are not passing vacuously.
- Endpoints driven over HTTP against a running uvicorn — not just TestClient.

## Docs

README's known-issues list was stale on two counts: `init_auth_tables.py`
already reads `ADMIN_EMAIL`/`ADMIN_PASSWORD` from the environment, and the
`Procfile` already declines to run migrations. Corrected, and the `Procfile`
comment no longer claims `alembic.ini` was deleted and `versions/` is empty.

## Not in this PR

`apps/web` is still an empty scaffold and `portfolio/frontend` still hardcodes
everything. Pointing a frontend at these endpoints is the next piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)