### PR TITLE
feat(web): add a contact form, and make the API validate what it stores

### DIFF
--- a/apps/api/app/api/v1/endpoints/contacts.py
+++ b/apps/api/app/api/v1/endpoints/contacts.py
@@ -10,7 +10,7 @@ the contact form, to anyone who asked.
 
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
 
 from app.api.v1.dependencies import require_admin
@@ -45,7 +45,18 @@ def get_contact(contact_id: int, db: Session = Depends(get_db)):
 
 @router.post("/", response_model=Contact, status_code=201)
 @limiter.limit("5/hour")
-def create_contact(request: Request, contact: ContactCreate, db: Session = Depends(get_db)):
+def create_contact(
+    request: Request,
+    # Declared but unused by the body below, and load-bearing anyway: the
+    # limiter is built with headers_enabled=True, and when a decorated endpoint
+    # returns something that is not a Response — this one returns a model —
+    # slowapi reaches for a `response` keyword argument to write the
+    # X-RateLimit-* headers into. Without the parameter it raises on every
+    # successful submission, not just on the 429.
+    response: Response,
+    contact: ContactCreate,
+    db: Session = Depends(get_db),
+):
     """Submit a contact message. Public, rate limited per IP."""
     service = PortfolioService(db)
     return service.create_contact(contact)

--- a/apps/api/app/core/rate_limit.py
+++ b/apps/api/app/core/rate_limit.py
@@ -35,4 +35,9 @@ def client_ip(request: Request) -> str:
     return fallback
 
 
-limiter = Limiter(key_func=client_ip)
+# ``headers_enabled`` makes slowapi attach ``Retry-After`` (and the
+# ``X-RateLimit-*`` trio) to the 429. It defaults to False, and without it the
+# contact form can only tell someone they have been rate limited, not when they
+# may try again — leaving them to refresh and find out. The window is an hour,
+# so "try again later" is not usable guidance.
+limiter = Limiter(key_func=client_ip, headers_enabled=True)

--- a/apps/api/app/schemas/portfolio.py
+++ b/apps/api/app/schemas/portfolio.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import Annotated, List, Optional
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict
+from pydantic import BaseModel, BeforeValidator, ConfigDict, EmailStr, StringConstraints
 
 from app.models.portfolio import ProjectStatus, SkillLevel
 
@@ -165,7 +165,30 @@ class ContactBase(BaseModel):
     message: str
 
 class ContactCreate(ContactBase):
-    pass
+    """The public contact form's payload — the only unauthenticated write.
+
+    Constraints live here rather than on ``ContactBase`` on purpose. ``Contact``
+    is the *response* model and inherits the same base, so a stricter base would
+    validate on the way out too: any row already in the table with a malformed
+    address — every row is one, since nothing validated until now — would 500
+    the admin ``GET /contacts`` instead of being readable.
+
+    The max lengths are the column widths from ``models/portfolio.py``, not
+    invented numbers. Without them an over-long name reached Postgres and came
+    back as a DataError 500; ``message`` is a TEXT column with no width, so the
+    5000 is a judgement about what a contact form is for and is the one figure
+    here the database does not dictate.
+
+    ``str_strip_whitespace`` runs before the length checks, so a field of spaces
+    fails ``min_length`` rather than storing blank.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: Annotated[str, StringConstraints(min_length=1, max_length=100)]
+    email: Annotated[EmailStr, StringConstraints(max_length=255)]
+    subject: Annotated[str, StringConstraints(min_length=1, max_length=255)]
+    message: Annotated[str, StringConstraints(min_length=1, max_length=5000)]
 
 class Contact(ContactBase):
     model_config = ConfigDict(from_attributes=True)

--- a/apps/api/tests/test_contact_form.py
+++ b/apps/api/tests/test_contact_form.py
@@ -1,0 +1,91 @@
+"""Input validation on the public contact form.
+
+``ContactCreate`` was four bare ``str`` fields. Anything at all posted to
+``POST /api/v1/contacts/`` was stored: an empty name, a message of unlimited
+size, and "not an email" in the address field of the only route a stranger can
+write to. An over-long name reached Postgres and came back as a DataError 500.
+
+Every case here asserts a 422. That is not for want of a success case — it is
+because the route is rate limited to 5/hour on a module-level, in-memory bucket
+that is shared across the whole pytest session, and this file sorts before
+``test_security.py``, whose rate-limit test asserts that *its* first POST is a
+201. A successful submission here would spend part of that budget and fail a
+test in another file, which is a miserable thing to debug.
+
+Nothing is spent by these: FastAPI validates the request body before it calls
+the endpoint function, and the limiter decorator is on the endpoint function —
+so a 422 never reaches the bucket. The accepted-payload case is covered by the
+201 assertion in ``test_security.py``.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.portfolio import ContactCreate
+
+client = TestClient(app)
+
+VALID = {
+    "name": "Ada Lovelace",
+    "email": "ada@example.com",
+    "subject": "Analytical engine",
+    "message": "Interested in your notes.",
+}
+
+
+def _post(**overrides):
+    return client.post("/api/v1/contacts/", json={**VALID, **overrides})
+
+
+@pytest.mark.parametrize("field", ["name", "email", "subject", "message"])
+def test_blank_field_is_rejected(field):
+    assert _post(**{field: ""}).status_code == 422
+
+
+@pytest.mark.parametrize("field", ["name", "subject", "message"])
+def test_whitespace_only_field_is_rejected(field):
+    """`str_strip_whitespace` runs before min_length, so spaces are not content."""
+    assert _post(**{field: "   \n\t "}).status_code == 422
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "not-an-email",
+        "missing-domain@",
+        "@missing-local.com",
+        "spaces in@example.com",
+    ],
+)
+def test_malformed_email_is_rejected(address):
+    assert _post(email=address).status_code == 422
+
+
+@pytest.mark.parametrize(
+    "field,limit",
+    [("name", 100), ("subject", 255), ("message", 5000)],
+)
+def test_over_length_field_is_rejected(field, limit):
+    """The limits are the column widths; past them Postgres raised, not Pydantic."""
+    assert _post(**{field: "x" * (limit + 1)}).status_code == 422
+
+
+@pytest.mark.parametrize("field,limit", [("name", 100), ("subject", 255), ("message", 5000)])
+def test_field_at_its_limit_is_accepted(field, limit):
+    """Guards the off-by-one that would reject a legal maximum.
+
+    Exercises the schema directly rather than the route: a payload that passes
+    validation reaches the endpoint, and the endpoint spends a slot of the
+    shared rate-limit bucket described above. The boundary is a property of the
+    schema, so test it there and leave the bucket alone.
+    """
+    ContactCreate(**{**VALID, field: "x" * limit})
+
+
+def test_surrounding_whitespace_is_stripped_before_storing():
+    """What gets stored is what the length check measured."""
+    contact = ContactCreate(**{**VALID, "name": "  Ada Lovelace  ", "message": "\n hello \n"})
+
+    assert contact.name == "Ada Lovelace"
+    assert contact.message == "hello"

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -123,17 +123,31 @@ def test_public_signup_surface_is_gone(path):
 
 
 def test_contact_form_is_public_but_rate_limited():
-    codes = [
+    responses = [
         client.post(
             "/api/v1/contacts/",
             json={
                 "name": "Rate Test",
-                "email": f"ratelimit{i}@example.invalid",
+                # Was example.invalid. Once ContactCreate grew an EmailStr,
+                # email-validator rejected it: .invalid is a reserved
+                # special-use TLD, so every request here 422'd before it ever
+                # reached the limiter and the test passed vacuously on 422s.
+                "email": f"ratelimit{i}@example.com",
                 "subject": "Hi",
                 "message": "hello",
             },
-        ).status_code
+        )
         for i in range(7)
     ]
+    codes = [r.status_code for r in responses]
+
     assert codes[0] == 201, codes
     assert 429 in codes, codes
+
+    # The form tells the visitor when they may try again, which it can only do
+    # if the 429 carries Retry-After. slowapi omits those headers unless the
+    # Limiter is built with headers_enabled=True, so this is load-bearing rather
+    # than a restatement of the library's defaults.
+    limited = next(r for r in responses if r.status_code == 429)
+    assert "retry-after" in limited.headers, dict(limited.headers)
+    assert int(limited.headers["retry-after"]) > 0

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/web/app/actions/contact.ts
+++ b/apps/web/app/actions/contact.ts
@@ -1,0 +1,183 @@
+"use server";
+
+import { headers } from "next/headers";
+
+import {
+  type ContactErrors,
+  type ContactState,
+  readContactForm,
+  validateContact,
+} from "@/lib/contact";
+
+/**
+ * The contact form's write path.
+ *
+ * ## Why a Server Action and not a route handler
+ *
+ * Both keep `API_URL` on the server, which is the property lib/api.ts exists to
+ * protect — the browser never learns where the API lives, and CORS never enters
+ * the picture. The Server Action wins on two others:
+ *
+ * 1. `<form action={submitContact}>` posts without JavaScript. A route handler
+ *    means a client `fetch`, which means the form is inert until hydration and
+ *    dead if the bundle fails. This one degrades to a normal form POST.
+ * 2. No hand-rolled contract. A route handler needs a request shape, a response
+ *    shape, a JSON parse and error handling on both sides for what is one
+ *    function call — roughly twice the code to arrive at the same place.
+ *
+ * ## Why it is not in lib/api.ts
+ *
+ * That module is `server-only` reads: GET, cached with `revalidate`, and every
+ * failure swallowed into a fallback so a sleeping backend cannot 500 the page.
+ * All three are wrong for a mutation. A POST must not be cached, must not be
+ * retried by a framework that thinks it is idempotent, and above all must not
+ * silently swallow failure — "your message went nowhere" is exactly the thing
+ * the visitor has to be told. Same degradation *principle* as lib/api.ts, which
+ * is that the site keeps working when the API does not; opposite mechanism,
+ * because here that means reporting the failure instead of hiding it.
+ */
+
+const API_URL = process.env.API_URL ?? "http://127.0.0.1:8000";
+
+/** A hung backend must not hang the submit button along with it. */
+const TIMEOUT_MS = 8000;
+
+/*
+ * ContactState and INITIAL_CONTACT_STATE are defined in lib/contact.ts, not
+ * here where they belong. A "use server" module may only export async
+ * functions; exporting the initial-state object from this file builds and
+ * type-checks cleanly, then throws on the first submission.
+ */
+
+/**
+ * Forward the visitor's address so the API rate-limits the right person.
+ *
+ * The API's limit is 5/hour keyed on client IP. Because this POST is proxied by
+ * the Next server, the address the API sees is the Next server's — so without
+ * this every visitor in the world would share one five-message bucket and the
+ * form would lock for everybody after five submissions total.
+ *
+ * `client_ip` in apps/api only trusts this header when the API is in
+ * production, so locally the bucket stays shared. That is the safe direction:
+ * an unproxied API that trusted the header would let a caller choose their own
+ * rate-limit key by sending it.
+ */
+async function forwardedFor(): Promise<Record<string, string>> {
+  const incoming = await headers();
+  const forwarded = incoming.get("x-forwarded-for");
+
+  return forwarded ? { "X-Forwarded-For": forwarded } : {};
+}
+
+/**
+ * Map the API's 422 back onto a field.
+ *
+ * Should be rare — the same `validateContact` ran before the request went out —
+ * but the API's `EmailStr` is stricter than the regex a form can reasonably
+ * use, so a domain like `foo@bar..com` passes here and fails there. Better to
+ * land that on the email field than to report it as an outage.
+ */
+function fieldErrorsFrom422(body: unknown): ContactErrors {
+  const detail = (body as { detail?: unknown })?.detail;
+  if (!Array.isArray(detail)) return {};
+
+  const errors: ContactErrors = {};
+
+  for (const item of detail) {
+    const loc = (item as { loc?: unknown })?.loc;
+    const field = Array.isArray(loc) ? loc[loc.length - 1] : null;
+
+    if (field === "email") {
+      errors.email = "That email address has a domain we cannot deliver to. Check it for a typo.";
+    } else if (typeof field === "string" && field in errors === false) {
+      // Wording stays ours rather than pydantic's: the raw message is written
+      // for an API consumer ("String should have at most 100 characters") and
+      // names the schema, not the thing on screen.
+      errors[field as keyof ContactErrors] = "The server rejected this value. Shorten it and try again.";
+    }
+  }
+
+  return errors;
+}
+
+/** Seconds from a `Retry-After` header, or null when it is missing or odd. */
+function retryAfterSeconds(response: Response): number | null {
+  const header = response.headers.get("retry-after");
+  if (!header) return null;
+
+  // slowapi sends a delta in seconds by default. An HTTP-date is also legal, so
+  // parse defensively rather than rendering "NaN minutes" at someone.
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds);
+
+  const date = Date.parse(header);
+  if (Number.isNaN(date)) return null;
+
+  return Math.max(0, Math.round((date - Date.now()) / 1000));
+}
+
+export async function submitContact(
+  _previous: ContactState,
+  formData: FormData,
+): Promise<ContactState> {
+  const values = readContactForm(formData);
+
+  // The browser ran this too. It runs again because the browser's copy is a
+  // convenience, not a control — this form posts fine with JavaScript off.
+  const errors = validateContact(values);
+  if (Object.keys(errors).length > 0) {
+    return { status: "invalid", errors, values };
+  }
+
+  const url = `${API_URL}/api/v1/contacts/`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(await forwardedFor()),
+      },
+      // Trimmed here as well as on the API, so what is stored matches what the
+      // length check measured.
+      body: JSON.stringify({
+        name: values.name.trim(),
+        email: values.email.trim(),
+        subject: values.subject.trim(),
+        message: values.message.trim(),
+      }),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      // A mutation must never be served from, or written to, the data cache.
+      cache: "no-store",
+    });
+  } catch (error) {
+    // DNS failure, connection refused, or the timeout above.
+    console.error(`[contact] POST to ${url} failed:`, error);
+    return { status: "unavailable", values };
+  }
+
+  if (response.status === 201) {
+    return { status: "sent" };
+  }
+
+  if (response.status === 429) {
+    return { status: "rate_limited", retryAfterSeconds: retryAfterSeconds(response), values };
+  }
+
+  if (response.status === 422) {
+    const body = await response.json().catch(() => null);
+    const apiErrors = fieldErrorsFrom422(body);
+
+    return Object.keys(apiErrors).length > 0
+      ? { status: "invalid", errors: apiErrors, values }
+      : { status: "unavailable", values };
+  }
+
+  // 5xx, or anything else unexpected. The visitor's problem is the same in
+  // every case — the message did not arrive — so they get one clear answer and
+  // the detail goes to the server log.
+  console.error(`[contact] ${response.status} ${response.statusText} from ${url}`);
+  return { status: "unavailable", values };
+}

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -5,6 +5,7 @@
 
 import { useEffect } from "react";
 
+import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
 import { Eyebrow } from "@/components/ui/eyebrow";
 
@@ -34,13 +35,9 @@ export default function Error({
       <p className="mt-4 text-muted-foreground">
         Something went wrong while rendering. Trying again usually works.
       </p>
-      <button
-        type="button"
-        onClick={reset}
-        className="mt-8 rounded-[--radius-control] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
-      >
+      <Button onClick={reset} className="mt-8">
         Try again
-      </button>
+      </Button>
     </Container>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -23,6 +23,7 @@
   --color-accent: hsl(var(--accent));
   --color-accent-foreground: hsl(var(--accent-foreground));
   --color-destructive: hsl(var(--destructive));
+  --color-destructive-text: hsl(var(--destructive-text));
   --color-ring: hsl(var(--ring));
 
   /*
@@ -83,6 +84,16 @@
     --accent: 210 40% 96.1%;
     --accent-foreground: 222 47% 11%;
     --destructive: 0 84.2% 60.2%;
+    /*
+     * A second red, for error *text*.
+     *
+     * --destructive is tuned to be seen as a fill or a border, and at 60%
+     * lightness it measures 3.76:1 as text on a card — under the 4.5:1 body
+     * text needs. Its dark counterpart is worse: 1.88:1, effectively invisible.
+     * Field validation messages are the first real text this palette has had to
+     * set in red, which is why nothing caught it before. 7.46:1 here.
+     */
+    --destructive-text: 0 72% 38%;
     --ring: 120 60% 28%;
   }
 
@@ -104,6 +115,8 @@
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
     --destructive: 0 62.8% 30.6%;
+    /* Light rather than dark, for the same reason the light mode's is dark. 7.93:1. */
+    --destructive-text: 0 85% 75%;
     --ring: 250 65% 65%;
   }
 

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { buttonClasses } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
 import { Eyebrow } from "@/components/ui/eyebrow";
 
@@ -17,10 +18,7 @@ export default function NotFound() {
       <p className="mt-4 text-muted-foreground">
         The link may be out of date, or the project behind it is not published.
       </p>
-      <Link
-        href="/"
-        className="mt-8 inline-block rounded-[--radius-control] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
-      >
+      <Link href="/" className={buttonClasses("primary", "mt-8")}>
         Back to the portfolio
       </Link>
     </Container>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { ContactSection } from "@/components/contact-section";
 import { HeroTopology } from "@/components/hero-topology";
 import { ProjectCard } from "@/components/project-card";
 import { EmptyState, Section } from "@/components/section";
@@ -98,6 +99,8 @@ export default async function HomePage() {
           </div>
         )}
       </Section>
+
+      <ContactSection />
     </>
   );
 }

--- a/apps/web/components/contact-form.tsx
+++ b/apps/web/components/contact-form.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+/*
+ * A client component for three reasons that have no server equivalent:
+ * `useActionState` to hold the result of the submission, `useState` for the
+ * validation errors raised as you leave a field, and `useRef` to move focus to
+ * the first field that needs fixing. None of that can be done in CSS or on the
+ * server.
+ *
+ * The form still posts without JavaScript: `action` is the Server Action
+ * itself, not a wrapper, so the browser's native form POST reaches it and the
+ * page re-renders with whatever it returned.
+ */
+
+import { useActionState, useRef, useState } from "react";
+
+import { submitContact } from "@/app/actions/contact";
+import { Button } from "@/components/ui/button";
+import { TextAreaField, TextField } from "@/components/ui/field";
+import {
+  CONTACT_FIELDS,
+  CONTACT_LIMITS,
+  type ContactErrors,
+  type ContactField,
+  type ContactState,
+  EMPTY_CONTACT,
+  INITIAL_CONTACT_STATE,
+  OWNER_EMAIL,
+  readContactForm,
+  validateContact,
+} from "@/lib/contact";
+
+/** "about 43 minutes" — vague on purpose, since the exact second is not useful. */
+function formatWait(seconds: number | null): string {
+  if (seconds === null) return "in a little while";
+  if (seconds < 60) return "in under a minute";
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `in about ${minutes} minute${minutes === 1 ? "" : "s"}`;
+
+  const hours = Math.round(minutes / 60);
+  return `in about ${hours} hour${hours === 1 ? "" : "s"}`;
+}
+
+/**
+ * The section's one animated element.
+ *
+ * It is the rule that separates the fields from the submit button, and while a
+ * request is in flight it becomes the hero's wire: the same dashed stroke and
+ * the same `wire-flow` keyframes from globals.css, which already reads as
+ * packets moving along an edge. Reusing it costs one <svg> and no JavaScript,
+ * and it stops under `prefers-reduced-motion` because the global rule in
+ * globals.css covers every animation on the site.
+ */
+function Wire({ active }: { active: boolean }) {
+  return (
+    <svg
+      // aria-hidden alone. It already removes the element from the
+      // accessibility tree, so role="presentation" alongside it does nothing.
+      aria-hidden="true"
+      className={`h-px w-full ${active ? "text-primary" : "text-border"}`}
+    >
+      <line
+        x1="0"
+        y1="0.5"
+        x2="100%"
+        y2="0.5"
+        stroke="currentColor"
+        className={active ? "wire-flow" : undefined}
+      />
+    </svg>
+  );
+}
+
+/**
+ * Everything the form has to say lands here, in one place under the fields.
+ *
+ * Short states get a mono line; the two that need to hand over an alternative
+ * route get a bordered notice with the address in it. A toast was the other
+ * option and is worse: it disappears, and the two states most worth reading are
+ * the two you cannot act on immediately.
+ */
+function StatusLine({
+  state,
+  isPending,
+  errorCount,
+}: {
+  state: ContactState;
+  isPending: boolean;
+  errorCount: number;
+}) {
+  // Not the uppercase, wide-tracked treatment the eyebrows use. This line
+  // carries a route and a verb, and "POST /CONTACTS" reads as shouting rather
+  // than as a path. Lower case mono is what a log line looks like, which is
+  // what this is.
+  const mono = "font-mono text-xs";
+
+  if (isPending) {
+    return <p className={`${mono} text-primary`}>sending…</p>;
+  }
+
+  if (state.status === "rate_limited") {
+    return (
+      <Notice>
+        Rate limit: five messages an hour from one address. Try again{" "}
+        {formatWait(state.retryAfterSeconds)}, or email{" "}
+        <MailLink /> — that reaches me directly.
+      </Notice>
+    );
+  }
+
+  if (state.status === "unavailable") {
+    return (
+      <Notice>
+        The server is not reachable, so this message has not been sent. Your text
+        is still in the form — try again, or email <MailLink />.
+      </Notice>
+    );
+  }
+
+  if (errorCount > 0) {
+    return (
+      <p className={`${mono} text-destructive-text`}>
+        {errorCount} field{errorCount === 1 ? "" : "s"} {errorCount === 1 ? "needs" : "need"} fixing
+      </p>
+    );
+  }
+
+  // The endpoint this posts to, and the budget, stated up front. It is the one
+  // line on the page that says the owner wrote the backend as well as the form.
+  return <p className={`${mono} text-muted-foreground`}>POST /contacts · 5 per hour</p>;
+}
+
+function Notice({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-[--radius-control] border border-border bg-card px-4 py-3 text-sm text-foreground">
+      {children}
+    </p>
+  );
+}
+
+function MailLink() {
+  return (
+    <a href={`mailto:${OWNER_EMAIL}`} className="text-primary underline underline-offset-4">
+      {OWNER_EMAIL}
+    </a>
+  );
+}
+
+export function ContactForm() {
+  const [state, formAction, isPending] = useActionState(submitContact, INITIAL_CONTACT_STATE);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Errors raised in the browser. The Server Action's own errors arrive in
+  // `state`; both are produced by the same validateContact, so they read alike.
+  const [clientErrors, setClientErrors] = useState<ContactErrors>({});
+
+  // The only value tracked in React, because the counter has to show it. The
+  // inputs stay uncontrolled so a no-JS post and a JS post behave the same.
+  const [messageLength, setMessageLength] = useState(0);
+
+  /*
+   * Field errors live in exactly one map, and the Server Action's verdict is
+   * folded into it when it arrives rather than being held alongside.
+   *
+   * Keeping the two separate and merging them at render time does not work in
+   * either direction: `{...server, ...client}` means clearing a client error on
+   * blur uncovers a stale server one underneath, so a corrected address keeps
+   * being told it is wrong; letting the client map win outright means a server
+   * error on a field the visitor already blurred — an address that passes the
+   * regex here and is refused by email-validator there — is never shown at all,
+   * and the submit appears to do nothing.
+   */
+  const [seenState, setSeenState] = useState(state);
+  if (seenState !== state) {
+    // React's "adjusting state when a prop changes" pattern, done during render
+    // rather than in an effect: React re-runs this component immediately and
+    // before anything paints, so the errors never flash out of date. An effect
+    // here would be a second render pass after paint, and eslint's
+    // react-hooks/set-state-in-effect rejects it for that reason.
+    setSeenState(state);
+    setClientErrors(state.status === "invalid" ? state.errors : {});
+  }
+
+  const errors = clientErrors;
+  const errorCount = CONTACT_FIELDS.filter((field) => errors[field]).length;
+
+  const previousValues = "values" in state ? state.values : EMPTY_CONTACT;
+
+  /** Re-check one field when it loses focus, but only to clear or set its own error. */
+  function handleBlur(field: ContactField, value: string) {
+    // Nothing is flagged until the field has been touched and left — validating
+    // on every keystroke tells someone their email is invalid while they are
+    // still on the first character of it.
+    const fieldErrors = validateContact({ ...EMPTY_CONTACT, [field]: value });
+
+    setClientErrors((current) => {
+      const next = { ...current };
+      // An empty optional-looking field that was never filled should not shout
+      // on blur; only flag what was actually typed and is wrong.
+      if (value.trim() && fieldErrors[field]) {
+        next[field] = fieldErrors[field];
+      } else {
+        delete next[field];
+      }
+      return next;
+    });
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    const values = readContactForm(new FormData(event.currentTarget));
+    const found = validateContact(values);
+
+    if (Object.keys(found).length === 0) {
+      setClientErrors({});
+      return; // Falls through to the Server Action.
+    }
+
+    // Cancelling here stops React from running the form's action, which saves a
+    // round trip to be told what the browser already knows.
+    event.preventDefault();
+    setClientErrors(found);
+
+    // Focus lands on the first thing to fix. Without this the errors appear
+    // above the fold for a sighted user and nowhere at all for a keyboard one,
+    // whose focus is still sitting on the submit button.
+    const firstBad = CONTACT_FIELDS.find((field) => found[field]);
+    if (firstBad) {
+      formRef.current?.querySelector<HTMLElement>(`[name="${firstBad}"]`)?.focus();
+    }
+  }
+
+  if (state.status === "sent") {
+    return (
+      <div className="rounded-[--radius-card] border border-border bg-card p-6">
+        <h3 className="font-display text-lg font-semibold tracking-tight text-foreground">
+          Message sent
+        </h3>
+        <p className="mt-2 text-muted-foreground">
+          It is in the inbox. I usually reply within a couple of days — if it is
+          urgent, <MailLink /> is faster.
+        </p>
+        {/*
+          The confirmation replaces the form rather than appearing beside it, so
+          there is no ambiguity about whether the thing was sent. Getting back
+          to a blank form is an explicit choice.
+        */}
+        <Button
+          variant="quiet"
+          className="mt-5"
+          onClick={() => {
+            formRef.current?.reset();
+            setClientErrors({});
+            setMessageLength(0);
+            // A full reload is the honest way to clear a useActionState result;
+            // there is no reset API, and faking one by remounting leaves the
+            // stale state reachable on the next submit.
+            window.location.hash = "contact";
+            window.location.reload();
+          }}
+        >
+          Send another
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      onSubmit={handleSubmit}
+      // Our own copy names the field and the fix; the browser's bubbles say
+      // "Please fill out this field" in the browser's voice, not the site's.
+      // The attributes below stay on the inputs regardless — they are what
+      // tells assistive tech the field is required.
+      noValidate
+      className="space-y-5"
+    >
+      <div className="grid gap-5 sm:grid-cols-2">
+        <TextField
+          name="name"
+          label="Name"
+          required
+          maxLength={CONTACT_LIMITS.name}
+          autoComplete="name"
+          placeholder="Your name"
+          defaultValue={previousValues.name}
+          error={errors.name}
+          onBlur={(event) => handleBlur("name", event.target.value)}
+        />
+        <TextField
+          name="email"
+          label="Email"
+          type="email"
+          required
+          maxLength={CONTACT_LIMITS.email}
+          autoComplete="email"
+          placeholder="you@company.com"
+          defaultValue={previousValues.email}
+          error={errors.email}
+          onBlur={(event) => handleBlur("email", event.target.value)}
+        />
+      </div>
+
+      <TextField
+        name="subject"
+        label="Subject"
+        required
+        maxLength={CONTACT_LIMITS.subject}
+        placeholder="What this is about"
+        defaultValue={previousValues.subject}
+        error={errors.subject}
+        onBlur={(event) => handleBlur("subject", event.target.value)}
+      />
+
+      <TextAreaField
+        name="message"
+        label="Message"
+        required
+        rows={6}
+        maxLength={CONTACT_LIMITS.message}
+        placeholder="Hello — I am getting in touch about…"
+        defaultValue={previousValues.message}
+        error={errors.message}
+        // The count is on this field alone. It is the only one where the length
+        // is a decision the writer is making rather than a limit they will
+        // never come close to.
+        meta={
+          <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+            {messageLength} / {CONTACT_LIMITS.message}
+          </span>
+        }
+        onChange={(event) => setMessageLength(event.target.value.length)}
+        onBlur={(event) => handleBlur("message", event.target.value)}
+      />
+
+      <div className="pt-3">
+        <Wire active={isPending} />
+        <div className="mt-5 flex flex-wrap items-center gap-x-5 gap-y-3">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Sending…" : "Send message"}
+          </Button>
+          {/*
+            aria-live so the outcome is announced. `polite` rather than
+            `assertive`: it should be read after whatever the user is doing,
+            not cut across it.
+          */}
+          <div aria-live="polite" className="min-w-0 flex-1">
+            <StatusLine state={state} isPending={isPending} errorCount={errorCount} />
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/components/contact-section.tsx
+++ b/apps/web/components/contact-section.tsx
@@ -1,0 +1,77 @@
+import { ContactForm } from "@/components/contact-form";
+import { Section } from "@/components/section";
+import { ExternalLink } from "@/components/ui/external-link";
+import { OWNER_EMAIL } from "@/lib/contact";
+
+/**
+ * The channels are listed above the form, not tucked into an error state.
+ *
+ * The form depends on the API being up. These do not — a mailto works when the
+ * backend is asleep, when the Server Action times out, and when someone has
+ * already spent their five messages for the hour. Showing them only after a
+ * failure would mean the section's fallback is invisible until the moment it is
+ * needed, which is the wrong moment to introduce it.
+ */
+const CHANNELS = [
+  { label: "Email", value: OWNER_EMAIL, href: `mailto:${OWNER_EMAIL}` },
+  { label: "GitHub", value: "dangkhoipham80", href: "https://github.com/dangkhoipham80" },
+  { label: "LinkedIn", value: "khoipham4022", href: "https://www.linkedin.com/in/khoipham4022/" },
+] as const;
+
+export function ContactSection() {
+  return (
+    <Section
+      id="contact"
+      width="reading"
+      // This read "Contact · POST /contacts" — the route the form submits to,
+      // which is true and is the one thing that distinguishes this form from
+      // the EmailJS one it replaces. It does not survive the eyebrow's
+      // `uppercase`: "POST /CONTACTS" reads as shouting, not as a path. The
+      // systems-voice detail moved to the status line above the submit button,
+      // where the text is under this component's control.
+      eyebrow="Contact"
+      title="Send me a message"
+      description="Open to internships and graduate roles in backend, data and AI engineering. Anything that lands here reaches my inbox."
+    >
+      {/*
+        A description list, because that is what this is: a stable key and its
+        value. The same mono-key / value shape the meta rows elsewhere use.
+      */}
+      {/*
+        Flex rather than a three-column grid. In equal columns the email address
+        is 6px wider than its cell and breaks to "dangkhoipham80@gmail.co" /
+        "m" — an address split across two lines is not one you can read back to
+        someone. Letting each channel take its natural width fixes it and wraps
+        gracefully at 375px.
+      */}
+      <dl className="mb-10 flex flex-wrap gap-x-10 gap-y-4">
+        {CHANNELS.map((channel) => (
+          <div key={channel.label}>
+            <dt className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+              {channel.label}
+            </dt>
+            <dd>
+              {channel.href.startsWith("mailto:") ? (
+                // Not an ExternalLink: a mailto does not leave for another site
+                // and the ↗ affordance would be a lie about where it goes.
+                <a
+                  href={channel.href}
+                  // py-3 to match ExternalLink's tap target; these sit in the
+                  // same row and one being shorter than its neighbours is both
+                  // a miss on touch and visibly uneven.
+                  className="inline-flex py-3 text-sm text-muted-foreground transition-colors hover:text-primary"
+                >
+                  {channel.value}
+                </a>
+              ) : (
+                <ExternalLink href={channel.href}>{channel.value}</ExternalLink>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <ContactForm />
+    </Section>
+  );
+}

--- a/apps/web/components/section.tsx
+++ b/apps/web/components/section.tsx
@@ -15,6 +15,12 @@ export function Section({
    * outline starting at level 2.
    */
   level = "h2",
+  /**
+   * Passed through to Container. Sections of cards want the wide measure; a
+   * section that is mostly text or a single column of form fields does not,
+   * and stretching one to 5xl leaves a very long line and a lot of dead space.
+   */
+  width = "wide",
   children,
 }: {
   id?: string;
@@ -23,13 +29,14 @@ export function Section({
   title: string;
   description?: string;
   level?: "h1" | "h2";
+  width?: "wide" | "reading";
   children: ReactNode;
 }) {
   const Heading = level;
 
   return (
     <section id={id} className="border-t border-border/60 py-16 sm:py-20">
-      <Container>
+      <Container width={width}>
         {eyebrow ? <Eyebrow className="mb-3">{eyebrow}</Eyebrow> : null}
         <Heading className="font-display text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
           {title}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import type { ButtonHTMLAttributes } from "react";
+
+import { cn } from "@/lib/cn";
+
+/**
+ * The filled action, in one place.
+ *
+ * `rounded-[--radius-control] bg-primary px-5 py-2.5 …` was written out
+ * identically in app/not-found.tsx and app/error.tsx, and the contact form
+ * would have been the third copy. Three sites is how the padding on one of them
+ * quietly drifts.
+ *
+ * Exported as classes as well as a component because two of the call sites are
+ * a `next/link` and would otherwise need a polymorphic `as` prop — a lot of
+ * type machinery to avoid one `className={buttonClasses()}`.
+ */
+
+const VARIANTS = {
+  /** The one action a screen is asking for. */
+  primary: "bg-primary text-primary-foreground hover:opacity-90",
+  /** Secondary actions that should not compete: "send another", "cancel". */
+  quiet: "border border-border text-foreground hover:border-primary/40 hover:text-primary",
+} as const;
+
+export function buttonClasses(
+  variant: keyof typeof VARIANTS = "primary",
+  className?: string,
+) {
+  return cn(
+    // inline-flex + gap so a button can carry a status dot or an arrow without
+    // each call site re-inventing the alignment.
+    // py-3 rather than the py-2.5 the inlined versions used: that came to 40px,
+    // just under a comfortable touch target.
+    "inline-flex items-center justify-center gap-2 rounded-[--radius-control] px-5 py-3 text-sm font-medium transition-opacity",
+    // A disabled submit still has to read as the same control, just inert —
+    // and it must not keep the pointer affordance of something clickable.
+    "disabled:cursor-not-allowed disabled:opacity-70",
+    VARIANTS[variant],
+    className,
+  );
+}
+
+export function Button({
+  variant = "primary",
+  className,
+  type = "button",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: keyof typeof VARIANTS }) {
+  // `type` defaults to "button": an untyped <button> inside a <form> is a
+  // submit button, which is a footgun for anything that is not the submit.
+  return <button type={type} className={buttonClasses(variant, className)} {...props} />;
+}

--- a/apps/web/components/ui/external-link.tsx
+++ b/apps/web/components/ui/external-link.tsx
@@ -24,8 +24,11 @@ export function ExternalLink({
       target="_blank"
       rel="noreferrer noopener"
       className={cn(
-        // py-1.5 so the row is a usable tap target, not a 20px-tall hairline.
-        "inline-flex items-center gap-1 py-1.5 text-sm text-muted-foreground transition-colors hover:text-primary",
+        // py-3, not the py-1.5 this started with: that measured 32px tall, under
+        // the ~44px a fingertip needs. Used for the contact channels as well as
+        // the repo and demo links on a project card, so it is among the most
+        // tapped things on the site.
+        "inline-flex items-center gap-1 py-3 text-sm text-muted-foreground transition-colors hover:text-primary",
         className,
       )}
     >

--- a/apps/web/components/ui/eyebrow.tsx
+++ b/apps/web/components/ui/eyebrow.tsx
@@ -10,6 +10,15 @@ import { cn } from "@/lib/cn";
  * this site. Setting them in the same face as the body would throw away that
  * signal; setting body copy in mono would be costume.
  */
+/**
+ * The treatment on its own, for the places that need this look on an element
+ * that is not a <p> — a form's <label> above all. A field's label *is* a field
+ * name, so it is the most literal use this style has on the site; copying the
+ * four utilities into field.tsx is where the two would have drifted apart.
+ */
+export const eyebrowClasses =
+  "font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground";
+
 export function Eyebrow({
   className,
   children,
@@ -17,14 +26,5 @@ export function Eyebrow({
   className?: string;
   children: ReactNode;
 }) {
-  return (
-    <p
-      className={cn(
-        "font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground",
-        className,
-      )}
-    >
-      {children}
-    </p>
-  );
+  return <p className={cn(eyebrowClasses, className)}>{children}</p>;
 }

--- a/apps/web/components/ui/field.tsx
+++ b/apps/web/components/ui/field.tsx
@@ -1,0 +1,121 @@
+import type { InputHTMLAttributes, ReactNode, TextareaHTMLAttributes } from "react";
+
+import { eyebrowClasses } from "@/components/ui/eyebrow";
+import { cn } from "@/lib/cn";
+
+/**
+ * A labelled form control.
+ *
+ * The point of this wrapper is that the accessibility wiring cannot be
+ * forgotten at a call site: the label is bound to the control by id, the error
+ * gets its own id and is pointed at by `aria-describedby`, and `aria-invalid`
+ * is set from the same prop that decides whether an error prints. Written out
+ * by hand per field, one of those four is eventually missed, and the failure is
+ * invisible unless you are the person using a screen reader.
+ *
+ * The invalid styling keys off the `aria-invalid` attribute rather than a
+ * parallel `isError` class, so the visual state and the announced state cannot
+ * disagree.
+ */
+
+const controlClasses = cn(
+  "w-full rounded-[--radius-control] border border-border bg-card px-3.5 py-2.5 text-sm text-foreground",
+  "transition-colors placeholder:text-muted-foreground/60 hover:border-primary/40",
+  "aria-[invalid=true]:border-destructive",
+  // No `focus:outline-none` here. It was written to "avoid fighting" the
+  // :focus-visible rule in globals.css and did the opposite: that rule lives in
+  // @layer base and this would be a utility, so the utility wins and every
+  // input in the form loses its focus ring. The global rule is the whole focus
+  // treatment; a control adds nothing.
+);
+
+function FieldShell({
+  htmlFor,
+  label,
+  /** Right-aligned mono note on the label row — a counter, a constraint. */
+  meta,
+  error,
+  children,
+}: {
+  htmlFor: string;
+  label: string;
+  meta?: ReactNode;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      {/*
+        Label and meta share a baseline row, the same shape the skill list on
+        the home page uses for name-plus-level. Consistency here is not
+        cosmetic: it teaches that a right-aligned mono value belongs to the
+        thing on its left.
+      */}
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <label htmlFor={htmlFor} className={eyebrowClasses}>
+          {label}
+        </label>
+        {meta}
+      </div>
+
+      {children}
+
+      {error ? (
+        <p id={`${htmlFor}-error`} className="mt-2 text-sm text-destructive-text">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+type SharedProps = {
+  name: string;
+  label: string;
+  meta?: ReactNode;
+  error?: string;
+};
+
+export function TextField({
+  name,
+  label,
+  meta,
+  error,
+  ...props
+}: SharedProps & Omit<InputHTMLAttributes<HTMLInputElement>, "name" | "id">) {
+  return (
+    <FieldShell htmlFor={name} label={label} meta={meta} error={error}>
+      <input
+        id={name}
+        name={name}
+        className={controlClasses}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${name}-error` : undefined}
+        {...props}
+      />
+    </FieldShell>
+  );
+}
+
+export function TextAreaField({
+  name,
+  label,
+  meta,
+  error,
+  ...props
+}: SharedProps & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "name" | "id">) {
+  return (
+    <FieldShell htmlFor={name} label={label} meta={meta} error={error}>
+      <textarea
+        id={name}
+        name={name}
+        // Vertical resize only: a horizontally resizable textarea can be
+        // dragged out past its container and break the column.
+        className={cn(controlClasses, "resize-y")}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${name}-error` : undefined}
+        {...props}
+      />
+    </FieldShell>
+  );
+}

--- a/apps/web/lib/contact.ts
+++ b/apps/web/lib/contact.ts
@@ -1,0 +1,145 @@
+/**
+ * Contact form field rules, shared by the browser and the server.
+ *
+ * Deliberately not `server-only` and deliberately dependency-free: this module
+ * is imported by both the client component and the Server Action, so the two
+ * cannot disagree about what a valid message is or word the same problem two
+ * different ways. Client-side checks are for turnaround — the Server Action
+ * runs the identical function, because anything the browser enforces can be
+ * skipped by posting the form directly.
+ *
+ * The maximums mirror ContactCreate in apps/api/app/schemas/portfolio.py, which
+ * in turn mirrors the column widths. Being stricter here than the API would
+ * reject messages the API accepts; being looser hands the visitor a server
+ * error we could have explained in the field.
+ */
+
+/**
+ * The address the form falls back to.
+ *
+ * One definition, because it appears in the channel list, the success card and
+ * both failure notices — and an address that is right in three places and stale
+ * in the fourth is worse than one that is wrong everywhere, because nobody
+ * notices.
+ */
+export const OWNER_EMAIL = "dangkhoipham80@gmail.com";
+
+export const CONTACT_LIMITS = {
+  name: 100,
+  email: 255,
+  subject: 255,
+  message: 5000,
+} as const;
+
+export type ContactField = keyof typeof CONTACT_LIMITS;
+
+export const CONTACT_FIELDS: ContactField[] = ["name", "email", "subject", "message"];
+
+export type ContactValues = Record<ContactField, string>;
+
+export type ContactErrors = Partial<Record<ContactField, string>>;
+
+/**
+ * The result of a submission.
+ *
+ * Lives here rather than beside the Server Action that produces it, because a
+ * `"use server"` module may only export async functions — Next throws
+ * "A 'use server' file can only export async functions, found object" at
+ * runtime for anything else. The type would have been erased and been fine;
+ * INITIAL_CONTACT_STATE below is a real object and would not. Neither
+ * `tsc --noEmit` nor `next build` catches it: the module evaluates, and fails,
+ * only when the action is first invoked.
+ */
+export type ContactState =
+  | { status: "idle" }
+  | { status: "sent" }
+  /** Field-level problems, plus what was typed so the form can be refilled. */
+  | { status: "invalid"; errors: ContactErrors; values: ContactValues }
+  /** 429 from the API. `retryAfterSeconds` is null if the header was absent. */
+  | { status: "rate_limited"; retryAfterSeconds: number | null; values: ContactValues }
+  /** API unreachable, timed out, or 5xx. The message was not delivered. */
+  | { status: "unavailable"; values: ContactValues };
+
+export const INITIAL_CONTACT_STATE: ContactState = { status: "idle" };
+
+export const EMPTY_CONTACT: ContactValues = {
+  name: "",
+  email: "",
+  subject: "",
+  message: "",
+};
+
+/**
+ * Good enough to catch a typo, not an attempt at RFC 5322.
+ *
+ * The authoritative check is `EmailStr` on the API, which uses email-validator.
+ * A regex that tries to be complete is famously wrong at the edges and would
+ * reject valid addresses here that the server would have accepted — the worse
+ * of the two failure modes, because the visitor cannot argue with it.
+ */
+const LOOKS_LIKE_EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const LABELS: Record<ContactField, string> = {
+  name: "Name",
+  email: "Email",
+  subject: "Subject",
+  message: "Message",
+};
+
+const MISSING: Record<ContactField, string> = {
+  name: "Enter your name.",
+  email: "Enter your email address.",
+  subject: "Enter a subject.",
+  message: "Write a message before sending.",
+};
+
+/**
+ * Errors name the field and the fix. No apologies, and no "invalid input" —
+ * that tells someone their input was rejected without telling them what to
+ * change, which is the one thing they need.
+ */
+export function validateContact(values: ContactValues): ContactErrors {
+  const errors: ContactErrors = {};
+
+  for (const field of CONTACT_FIELDS) {
+    const value = values[field].trim();
+    const limit = CONTACT_LIMITS[field];
+
+    if (!value) {
+      // "Enter your subject" is not English — the subject is not something the
+      // sender possesses, unlike their name and address.
+      errors[field] = MISSING[field];
+      continue;
+    }
+
+    if (value.length > limit) {
+      errors[field] = `${LABELS[field]} is ${value.length} characters. Trim it to ${limit}.`;
+      continue;
+    }
+
+    if (field === "email" && !LOOKS_LIKE_EMAIL.test(value)) {
+      // Naming the specific defect beats "enter a valid email": the usual cause
+      // is a missing @ or a truncated domain, and saying so removes the guessing.
+      errors.email = value.includes("@")
+        ? "That email address needs a domain, like name@example.com."
+        : "That email address is missing an @.";
+    }
+  }
+
+  return errors;
+}
+
+/** Reads the four fields out of a FormData, so a no-JS post parses the same way. */
+export function readContactForm(formData: FormData): ContactValues {
+  const read = (field: ContactField) => {
+    const value = formData.get(field);
+    return typeof value === "string" ? value : "";
+  };
+
+  return {
+    name: read("name"),
+    email: read("email"),
+    subject: read("subject"),
+    message: read("message"),
+  };
+}


### PR DESCRIPTION
Replaces the EmailJS form from the Vite app — which posted to a third party with the service id, template id and public key hardcoded inline — with one that posts to `POST /api/v1/contacts/`. That endpoint has existed since #17 with nothing calling it.

## Server Action, not a route handler

Both keep `API_URL` on the server, which is the property `lib/api.ts` exists to protect: the browser never learns where the API lives and CORS never enters the picture. The Server Action wins on two others — `<form action={submitContact}>` posts **without JavaScript**, and there is no hand-rolled request/response contract for what is one function call.

It deliberately does **not** live in `lib/api.ts`. Every read there is cached with `revalidate` and swallows failure into a fallback; all three are wrong for a mutation. A POST must not be cached, must not be retried as if idempotent, and above all must not silently swallow failure — "your message went nowhere" is the one thing the visitor has to be told. Same degradation *principle* as `lib/api.ts` (the site keeps working when the API does not), opposite mechanism.

## Failure states

| State | What the visitor sees |
|---|---|
| 429 | "Rate limit: five messages an hour from one address. Try again in about 43 minutes, or email … — that reaches me directly." Time comes from `Retry-After`. |
| API down / 5xx / timeout | "The server is not reachable, so this message has not been sent. Your text is still in the form — try again, or email …" |
| Field invalid | "That email address is missing an @." Focus moves to the first field to fix. |

The direct channels (email, GitHub, LinkedIn) sit **above** the form rather than appearing on failure — a fallback introduced at the moment it is needed is one the visitor has never seen before.

## Two bugs found by running it

**`Retry-After` was never sent.** slowapi omits the rate-limit headers unless the `Limiter` is built with `headers_enabled=True`. Enabling it then required a `response: Response` parameter on the endpoint: when a decorated endpoint returns a model rather than a `Response`, slowapi reaches for that kwarg to write headers into, and raises on every *successful* submission without it. `test_security.py` now asserts the header is present, so this cannot regress silently.

**Every visitor shared one rate-limit bucket.** The limit is per IP, but proxying the POST through the Next server meant the API saw the Next server's address — five submissions in total would have locked the form for everyone. The action forwards `X-Forwarded-For`, which `client_ip` only trusts in production.

## API input validation

`ContactCreate` was four bare `str` fields on the only unauthenticated write in the API. An empty name, a message of unlimited size and `"not an email"` were all stored as-is, and an over-long name reached Postgres and came back as a `DataError` 500.

Constraints go on `ContactCreate` and **not** the shared `ContactBase`: `Contact` is the response model and inherits the same base, so a stricter base would 500 the admin `GET /contacts` on any row written before validation existed — which is all of them.

18 new tests. They assert 422s only, because the route's 5/hour bucket is module-level and shared across the pytest session, and this file sorts before `test_security.py`, whose test asserts its first POST is a 201. Boundary cases exercise the schema directly for the same reason. One existing fixture had to change: `example.invalid` is a reserved special-use TLD that email-validator rejects, so those requests would have 422'd before reaching the limiter and passed vacuously.

## Design

The palette, type scale and radii are fixed by `globals.css`, so the decision was what a contact form looks like on a site whose visual language is already logs, schemas and wire topology — not the two-column "Get In Touch" with info cards and a paper-plane icon, which is both the generic answer and what the old Vite app did.

- Single column at `Container width="reading"`; every other section is a wide grid, so narrowing reads as the end of the document.
- Labels use the existing eyebrow treatment. The site sets eyebrows in mono because "these lines are field names" — on a form they literally are.
- The rule above the submit button **is** the wire: it reuses the hero's `.wire-flow` dashed-stroke keyframes and animates only while a request is in flight.
- A mono status line is the single place feedback lands: `POST /contacts · 5 per hour` at rest.

## Shared primitives

`Button`/`buttonClasses` (the filled-button class string was already duplicated between `not-found.tsx` and `error.tsx`, both now adopt it), and `TextField`/`TextAreaField`, which own the label/`aria-invalid`/`aria-describedby` wiring so no call site can forget a quarter of it.

New `--destructive-text` token: `--destructive` is tuned as a fill and measures **3.76:1** as text in light mode and **1.88:1** in dark. Field validation messages are the first red *text* this palette has had to set, which is why nothing caught it before. The new token measures 7.46:1 and 7.93:1.

## Verification

Driven on a production build (`next build` + `next start`) against the live API, not just type-checked:

- All four states exercised in the browser — idle, per-field validation, success, 429, and API-down (killed the API mid-session).
- Reviewed with the `frontend-reviewer` subagent on the running page: **no Blocking**. Its two should-fixes are applied — tap targets were 32px/40px and are now 44px, and a server-side field error persisted after the visitor corrected it.
- 87 API tests pass, ruff clean, `pnpm type-check` and `pnpm lint` clean.
- 375px with no horizontal overflow, both themes, visible keyboard focus on every control.

A `focus:outline-none` I had written into the control classes silently killed the global focus ring — a Tailwind utility beats the `:focus-visible` rule in `@layer base`. Caught by measuring the computed outline, not by reading the code.

## Notes

- `apps/web/AGENTS.md` and `apps/web/CLAUDE.md` are generated by `next dev`; Next's own note says committing them keeps the tree clean. Unrelated to this change and easy to drop if unwanted.
- Not included: no nav link. The nav collapses to single initials below `sm`, where Career and Certificates are already both "C"; a third would make it worse.
- Not included: contact messages still only land in the `contacts` table. SMTP is wired to `auth_service` only, so filling `SMTP_USER`/`SMTP_PASSWORD` does not make submissions arrive by email — that wants `BackgroundTasks` so a slow SMTP handshake cannot block the POST, and belongs in its own PR.
- Follow-up: dark-mode `--primary` on card measures 4.60:1, which passes AA with no margin. Raising its lightness a few points is a one-line change but repaints the accent site-wide, so it did not belong here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)