### PR TITLE
test(web): a test suite for apps/web, and the bug it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - run: pytest
 
   web:
-    name: web — lint + type-check + build
+    name: web — lint + type-check + build + tests
     runs-on: ubuntu-latest
 
     defaults:
@@ -114,4 +114,53 @@ jobs:
       # backend that is not there — if it ever stops doing so, the site can be
       # taken down by a sleeping free-tier server, which is the exact thing the
       # fetch layer exists to prevent.
+      #
+      # This is also the command Vercel runs, so it stays here as its own step
+      # even though the e2e suite below builds again. What it does not do is
+      # look at the result: a build that succeeds has proved that nothing threw,
+      # not that the pages say anything to a visitor.
       - run: pnpm build
+
+      # Under a second, no browser. Pure functions only — the fallback logic in
+      # lib/api.ts against every way a request can fail, and the contact form's
+      # field rules, including whether they still match the API's schema.
+      - run: pnpm test
+
+      # Cache the browser binaries, not the OS packages.
+      #
+      # `playwright install` downloads ~130MB of Chromium, which is most of the
+      # cost of running these tests in CI and is pure waste on a run where no
+      # dependency moved. Keyed on the lockfile: too broad, since it re-downloads
+      # when any unrelated package changes, but it can never serve a Chromium
+      # that does not match the installed @playwright/test — and the failure
+      # mode of a too-narrow key is a confusing version mismatch rather than a
+      # slow run.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      # Chromium alone — see the note in playwright.config.ts about why the
+      # other two engines would triple this step for no extra signal.
+      #
+      # `--with-deps` still runs apt on a cache hit, which costs ~20s and cannot
+      # be cached. That is the price of the whole browser layer, and it buys the
+      # states nothing else here can reach: a 429 rendered as "about 45 minutes",
+      # a dropped connection reported as "not sent", and the form working with
+      # JavaScript switched off.
+      - run: pnpm exec playwright install --with-deps chromium
+        working-directory: apps/web
+
+      # Builds again, deliberately, against a port it has checked is closed.
+      # Every page in this app is prerendered, so the fallback is chosen at build
+      # time — a suite that reused a build made while an API was reachable would
+      # be reading content, not fallbacks, and would pass no matter what.
+      - run: pnpm test:e2e
+
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ venv/
 # Browser-automation scratch output (screenshots, page snapshots)
 .playwright-mcp/
 
+# Playwright's own output: traces and screenshots kept from a failing run, and
+# the HTML report built from them. Useful locally, meaningless in a diff.
+test-results/
+playwright-report/
+blob-report/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -38,9 +38,45 @@ uvicorn app.main:app --reload --port 8000
 If port 8000 is taken, run the API elsewhere and set `API_URL` to match — the
 web app has no other way to find it.
 
-Root scripts: `pnpm dev` / `build` / `lint` / `type-check` for the web app, and
-`pnpm api:dev` / `api:lint` / `api:test` for the API — the API ones invoke
-`python -m ...`, so **activate the virtualenv first** or they will not resolve.
+Root scripts: `pnpm dev` / `build` / `lint` / `type-check` / `test` / `test:e2e`
+for the web app, and `pnpm api:dev` / `api:lint` / `api:test` for the API — the
+API ones invoke `python -m ...`, so **activate the virtualenv first** or they
+will not resolve.
+
+## Tests
+
+87 on the API, 72 on the web app, split across three runners that each answer a
+question the others cannot.
+
+```bash
+pnpm test          # vitest — 46 unit tests, under a second, no browser
+pnpm test:e2e      # playwright — 26 tests in Chromium against a production build
+pnpm api:test      # pytest — 87 tests, needs the virtualenv and a scratch database
+```
+
+**Vitest covers the modules that are plain functions**: every way a request in
+`lib/api.ts` can fail, and the contact form's field rules in `lib/contact.ts`.
+One of those tests reads `apps/api/app/schemas/portfolio.py` and compares the
+field limits directly, because the comment saying they mirror the API is not
+something a comment can enforce.
+
+**Playwright covers what only exists once a page is rendered**: the empty
+states, and the contact form's 429 and outage notices. It builds the app against
+a port it has checked is closed, then serves that build with `API_URL` pointing
+at a stub. That split is the whole design — every page here is prerendered, so
+the fallback is chosen at *build* time, while the Server Action behind the
+contact form runs per request and reaches the stub. One build, both states, and
+no real API is ever contacted.
+
+**There are no component tests, and that is a decision.** The jsdom layer
+between these two would need a faked DOM, a faked `useActionState` and a stubbed
+Server Action to ask a question Playwright already answers against the real
+thing.
+
+The e2e servers default to ports 3142 and 8142, and fail immediately rather than
+reuse anything already listening — a port quietly answered by another project is
+how a suite ends up testing software that is not this one. Override with
+`E2E_WEB_PORT` and `E2E_STUB_PORT`.
 
 ## Database
 
@@ -126,15 +162,17 @@ pointer check so phones do not pay for it.
   with the service keys inline. `VITE_API_URL` is declared in `env.example` and
   read by nothing. `apps/web` is the replacement, but Vercel's root directory
   has not been switched over yet.
-- `apps/web` has no contact form. The API's `POST /contacts/` endpoint is rate
-  limited and ready; nothing posts to it.
 - The legacy decorative layer — meteors, drifting stars, the fifteen keyframe
   animations in `portfolio/frontend/src/index.css` — is not ported. Only the
   colour tokens are.
-- `apps/web` has no tests. The API has 69; the web app has none.
-- There is no CI. `ruff check .` and `pytest` are run by hand.
-- Tests and the seed script both write to whatever `DATABASE_URL` names; there
-  is no separate test database.
+- Project images are unused: `image_url` is null on every row, so
+  `ProjectMedia` renders its generated placeholder everywhere.
+- The contact form stores a message and nothing else happens. There is no email
+  notification, so a message is only seen by someone opening the admin endpoint.
+- Locally, the API tests and the seed script still write to whatever
+  `DATABASE_URL` names. CI runs them against a throwaway Postgres service
+  container; on a development machine, pointing `DATABASE_URL` at a scratch
+  database is still a matter of remembering to.
 
 ## Environment
 

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getCareerEntries,
+  getCertificates,
+  getProject,
+  getProjects,
+  getSkills,
+} from "./api";
+
+/**
+ * The promise this file exists to keep.
+ *
+ * `apps/web` replaced a static site that could not break, so every read has to
+ * degrade to a fallback rather than take the page down with it. The CI web job
+ * builds with no API running for the same reason — but a build that succeeds
+ * only proves nothing threw, not that a dead backend, a 500, a timeout and a
+ * body that is not JSON all land on the same safe answer. Those four are the
+ * ones tested here; what a visitor then sees is tested in tests/e2e.
+ */
+
+const OK = { status: 200, headers: { "content-type": "application/json" } };
+
+function json(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), { ...OK, ...init });
+}
+
+/** Every list reader, so a new one added without a fallback is caught here. */
+const LIST_READERS = [
+  ["getProjects", getProjects],
+  ["getSkills", getSkills],
+  ["getCertificates", getCertificates],
+  ["getCareerEntries", getCareerEntries],
+] as const;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let errorLog: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  // Failures are meant to be logged, not swallowed. Spying keeps the test
+  // output readable and lets the logging itself be asserted.
+  errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("when the API is unreachable", () => {
+  it.each(LIST_READERS)("%s returns an empty list", async (_name, read) => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new TypeError("fetch failed"), { cause: new Error("ECONNREFUSED") }),
+    );
+
+    await expect(read()).resolves.toEqual([]);
+  });
+
+  it("getProject returns null", async () => {
+    fetchMock.mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(getProject("portfolio")).resolves.toBeNull();
+  });
+
+  it("says so on the server log", async () => {
+    fetchMock.mockRejectedValue(new TypeError("fetch failed"));
+
+    await getProjects();
+
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/projects/"),
+      expect.anything(),
+    );
+  });
+});
+
+describe("when the API hangs", () => {
+  it("gives up rather than holding the render open", async () => {
+    // What AbortSignal.timeout(5000) produces once it fires. The page must
+    // render without the data; a request with no ceiling would mean a hung
+    // backend hanging every visitor's first paint.
+    fetchMock.mockRejectedValue(new DOMException("The operation timed out", "TimeoutError"));
+
+    await expect(getSkills()).resolves.toEqual([]);
+  });
+
+  it("asks for a timeout at all", async () => {
+    fetchMock.mockResolvedValue(json([]));
+
+    await getSkills();
+
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ signal: expect.any(AbortSignal) });
+  });
+});
+
+describe("when the API answers with an error", () => {
+  it.each([500, 502, 503, 401, 400])("%i falls back", async (status) => {
+    fetchMock.mockResolvedValue(json({ detail: "boom" }, { status }));
+
+    await expect(getCertificates()).resolves.toEqual([]);
+    expect(errorLog).toHaveBeenCalled();
+  });
+
+  it("treats a 404 on a detail route as no project", async () => {
+    fetchMock.mockResolvedValue(json({ detail: "Not found" }, { status: 404 }));
+
+    await expect(getProject("nope")).resolves.toBeNull();
+  });
+});
+
+describe("when the body is not what it claims", () => {
+  it("falls back on a body that is not JSON at all", async () => {
+    // The realistic shape of this is a proxy or a suspended free-tier host
+    // returning an HTML error page with a 200 on it.
+    fetchMock.mockResolvedValue(new Response("<html>Service suspended</html>", OK));
+
+    await expect(getProjects()).resolves.toEqual([]);
+  });
+
+  it("falls back on an empty body", async () => {
+    fetchMock.mockResolvedValue(new Response("", OK));
+
+    await expect(getProjects()).resolves.toEqual([]);
+  });
+
+  it.each(LIST_READERS)(
+    "%s falls back when the route answers 200 with something that is not a list",
+    async (_name, read) => {
+      // Every caller does `.length` and `.map`. An object satisfies the type
+      // only because the cast in getJson says so, and the page then throws at
+      // render — a 500 produced by a *successful* request, which is the one
+      // outcome this module exists to prevent.
+      fetchMock.mockResolvedValue(json({ detail: "Unauthorized" }));
+
+      await expect(read()).resolves.toEqual([]);
+      expect(errorLog).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected shape"),
+        expect.anything(),
+      );
+    },
+  );
+
+  it("getProject falls back when a detail route answers with a list", async () => {
+    fetchMock.mockResolvedValue(json([{ id: 1 }]));
+
+    await expect(getProject("portfolio")).resolves.toBeNull();
+  });
+
+  it("getProject falls back when a detail route answers with a bare string", async () => {
+    fetchMock.mockResolvedValue(json("Service Unavailable"));
+
+    await expect(getProject("portfolio")).resolves.toBeNull();
+  });
+});
+
+describe("when the API works", () => {
+  it("returns the payload", async () => {
+    const projects = [{ id: 1, slug: "portfolio", title: "Portfolio" }];
+    fetchMock.mockResolvedValue(json(projects));
+
+    await expect(getProjects()).resolves.toEqual(projects);
+    expect(errorLog).not.toHaveBeenCalled();
+  });
+
+  it("returns the project a detail route sends", async () => {
+    fetchMock.mockResolvedValue(json({ id: 1, slug: "portfolio" }));
+
+    await expect(getProject("portfolio")).resolves.toMatchObject({ slug: "portfolio" });
+  });
+});
+
+describe("the request it makes", () => {
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(json([]));
+  });
+
+  it("hits the versioned path on API_URL", async () => {
+    await getCareerEntries();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8000/api/v1/career/",
+      expect.anything(),
+    );
+  });
+
+  it("asks for JSON and lets Next cache it", async () => {
+    await getSkills();
+
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      headers: { Accept: "application/json" },
+      next: { revalidate: 300 },
+    });
+  });
+
+  it("encodes a slug so it cannot escape its path segment", async () => {
+    fetchMock.mockResolvedValue(json(null));
+
+    await getProject("../../admin/contacts");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:8000/api/v1/projects/slug/..%2F..%2Fadmin%2Fcontacts",
+    );
+  });
+});
+
+describe("API_URL", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("is read from the environment", async () => {
+    // Read at module scope, so the module has to be re-imported for a change
+    // to it to be visible.
+    vi.stubEnv("API_URL", "https://api.example.com");
+    vi.resetModules();
+
+    const { getProjects: reread } = await import("./api");
+    fetchMock.mockResolvedValue(json([]));
+
+    await reread();
+
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.example.com/api/v1/projects/");
+  });
+});

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -25,7 +25,26 @@ const REVALIDATE_SECONDS = 300;
 /** A hung backend must not hang the page render along with it. */
 const TIMEOUT_MS = 5000;
 
-async function getJson<T>(path: string, fallback: T): Promise<T> {
+/**
+ * What the caller is prepared to receive.
+ *
+ * `response.json()` returns `any`, and the cast that follows it is a promise
+ * the API makes rather than something checked. When the API keeps that promise
+ * the cast is free; when something between here and it does not — a gateway
+ * answering 200 with `{"detail": ...}`, a tunnel serving its own JSON — the
+ * cast hands a list-shaped variable something that is not a list, and the page
+ * throws on `.map()`. That is a 500 caused by a *successful* request, which is
+ * the one failure mode the rest of this module is built to rule out.
+ */
+type ShapeCheck = (data: unknown) => boolean;
+
+const isList: ShapeCheck = (data) => Array.isArray(data);
+
+/** A detail route sends one object; an array or a bare string is not it. */
+const isRecord: ShapeCheck = (data) =>
+  typeof data === "object" && data !== null && !Array.isArray(data);
+
+async function getJson<T>(path: string, fallback: T, isExpectedShape: ShapeCheck): Promise<T> {
   const url = `${API_URL}/api/v1${path}`;
 
   try {
@@ -42,7 +61,14 @@ async function getJson<T>(path: string, fallback: T): Promise<T> {
       return fallback;
     }
 
-    return (await response.json()) as T;
+    const data = await response.json();
+
+    if (!isExpectedShape(data)) {
+      console.error(`[api] unexpected shape from ${url}:`, data);
+      return fallback;
+    }
+
+    return data as T;
   } catch (error) {
     // Covers DNS failure, connection refused, and the timeout above.
     console.error(`[api] request to ${url} failed:`, error);
@@ -51,21 +77,21 @@ async function getJson<T>(path: string, fallback: T): Promise<T> {
 }
 
 export async function getProjects(): Promise<Project[]> {
-  return getJson<Project[]>("/projects/", []);
+  return getJson<Project[]>("/projects/", [], isList);
 }
 
 export async function getProject(slug: string): Promise<Project | null> {
-  return getJson<Project | null>(`/projects/slug/${encodeURIComponent(slug)}`, null);
+  return getJson<Project | null>(`/projects/slug/${encodeURIComponent(slug)}`, null, isRecord);
 }
 
 export async function getSkills(): Promise<Skill[]> {
-  return getJson<Skill[]>("/skills/", []);
+  return getJson<Skill[]>("/skills/", [], isList);
 }
 
 export async function getCertificates(): Promise<Certificate[]> {
-  return getJson<Certificate[]>("/certificates/", []);
+  return getJson<Certificate[]>("/certificates/", [], isList);
 }
 
 export async function getCareerEntries(): Promise<CareerEntry[]> {
-  return getJson<CareerEntry[]>("/career/", []);
+  return getJson<CareerEntry[]>("/career/", [], isList);
 }

--- a/apps/web/lib/contact.test.ts
+++ b/apps/web/lib/contact.test.ts
@@ -1,0 +1,206 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTACT_LIMITS,
+  type ContactValues,
+  EMPTY_CONTACT,
+  readContactForm,
+  validateContact,
+} from "./contact";
+
+/** A submission that should pass, so each test can vary one field from valid. */
+function valid(overrides: Partial<ContactValues> = {}): ContactValues {
+  return {
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+    subject: "About the analytical engine",
+    message: "I read your notes and would like to talk.",
+    ...overrides,
+  };
+}
+
+describe("validateContact", () => {
+  it("passes a filled-in form", () => {
+    expect(validateContact(valid())).toEqual({});
+  });
+
+  it("names every empty field and what to do about it", () => {
+    expect(validateContact(EMPTY_CONTACT)).toEqual({
+      name: "Enter your name.",
+      email: "Enter your email address.",
+      subject: "Enter a subject.",
+      message: "Write a message before sending.",
+    });
+  });
+
+  it("treats whitespace as empty, because the API strips it before its own check", () => {
+    // str_strip_whitespace on ContactCreate runs before min_length, so a field
+    // of spaces is rejected there too. Accepting it here would mean posting a
+    // message that the API refuses with a 422 we would have to explain.
+    expect(validateContact(valid({ message: "   \n\t  " }))).toEqual({
+      message: "Write a message before sending.",
+    });
+  });
+
+  describe("length", () => {
+    it("allows a field of exactly the limit", () => {
+      expect(validateContact(valid({ name: "a".repeat(CONTACT_LIMITS.name) }))).toEqual({});
+    });
+
+    it("rejects one character over, and says how far over", () => {
+      const name = "a".repeat(CONTACT_LIMITS.name + 1);
+
+      expect(validateContact(valid({ name }))).toEqual({
+        name: "Name is 101 characters. Trim it to 100.",
+      });
+    });
+
+    it("measures after trimming, so padding does not push a field over", () => {
+      // The API trims first and then measures. Measuring the untrimmed value
+      // here would reject a message the API would have stored.
+      const message = `  ${"a".repeat(CONTACT_LIMITS.message)}  `;
+
+      expect(validateContact(valid({ message }))).toEqual({});
+    });
+
+    it("reports the trimmed length, not the raw one", () => {
+      const subject = `   ${"a".repeat(CONTACT_LIMITS.subject + 2)}   `;
+
+      expect(validateContact(valid({ subject }))).toEqual({
+        subject: "Subject is 257 characters. Trim it to 255.",
+      });
+    });
+  });
+
+  describe("email", () => {
+    it("points at the missing @ when there is no @", () => {
+      expect(validateContact(valid({ email: "ada.example.com" }))).toEqual({
+        email: "That email address is missing an @.",
+      });
+    });
+
+    it("points at the domain when the @ is there but the domain is not", () => {
+      expect(validateContact(valid({ email: "ada@example" }))).toEqual({
+        email: "That email address needs a domain, like name@example.com.",
+      });
+    });
+
+    it("accepts the addresses a regex has no business rejecting", () => {
+      // The authoritative check is EmailStr on the API. Anything rejected here
+      // never reaches it, so this regex being over-strict is the failure mode
+      // that matters — the visitor cannot argue with it.
+      for (const email of [
+        "ada+portfolio@example.co.uk",
+        "ada.lovelace@sub.domain.example.com",
+        "a@b.co",
+        "ADA@EXAMPLE.COM",
+        "ada_lovelace-1842@example.io",
+      ]) {
+        expect(validateContact(valid({ email })), email).toEqual({});
+      }
+    });
+
+    it("reports emptiness rather than format for a blank address", () => {
+      expect(validateContact(valid({ email: "  " }))).toEqual({
+        email: "Enter your email address.",
+      });
+    });
+  });
+
+  it("reports every bad field at once, not just the first", () => {
+    // The form focuses the first field with an error and counts the rest; a
+    // validator that stopped early would make that count wrong.
+    const errors = validateContact({
+      name: "",
+      email: "nope",
+      subject: "",
+      message: "fine",
+    });
+
+    expect(Object.keys(errors).sort()).toEqual(["email", "name", "subject"]);
+  });
+});
+
+describe("readContactForm", () => {
+  it("reads the four fields", () => {
+    const form = new FormData();
+    form.set("name", "Ada");
+    form.set("email", "ada@example.com");
+    form.set("subject", "Hello");
+    form.set("message", "Hi there");
+
+    expect(readContactForm(form)).toEqual({
+      name: "Ada",
+      email: "ada@example.com",
+      subject: "Hello",
+      message: "Hi there",
+    });
+  });
+
+  it("returns empty strings for fields the post left out", () => {
+    // A hand-rolled POST, or a form whose markup drifted, must not produce
+    // `undefined` and crash `.trim()` in the validator.
+    expect(readContactForm(new FormData())).toEqual(EMPTY_CONTACT);
+  });
+
+  it("returns an empty string for a field posted as a file", () => {
+    const form = new FormData();
+    form.set("name", new Blob(["not a name"]), "name.txt");
+
+    expect(readContactForm(form).name).toBe("");
+  });
+
+  it("does not trim, so the form can refill exactly what was typed", () => {
+    const form = new FormData();
+    form.set("subject", "  spaced  ");
+
+    expect(readContactForm(form).subject).toBe("  spaced  ");
+  });
+});
+
+/**
+ * The limits in this module are a copy of the API's, and a copy drifts.
+ *
+ * Being stricter here rejects messages the API would have accepted; being
+ * looser hands the visitor a 422 that a field error could have explained. Both
+ * are silent — nothing fails until someone writes a long enough message — so
+ * the two files are compared directly rather than trusted.
+ */
+describe("CONTACT_LIMITS mirrors ContactCreate in apps/api", () => {
+  const schemaPath = fileURLToPath(new URL("../../api/app/schemas/portfolio.py", import.meta.url));
+
+  it("still finds the schema it is mirroring", () => {
+    expect(
+      () => readFileSync(schemaPath, "utf8"),
+      `Cannot read ${schemaPath}. If ContactCreate moved, update this test rather than deleting it.`,
+    ).not.toThrow();
+  });
+
+  it("agrees with the API on every field's maximum", () => {
+    const source = readFileSync(schemaPath, "utf8");
+
+    // Only the ContactCreate block: the file holds other models with their own
+    // max_length values, and matching across all of them would prove nothing.
+    const block = source.split("class ContactCreate")[1]?.split("\nclass ")[0] ?? "";
+    expect(block, "ContactCreate not found in the schema file").not.toBe("");
+
+    const fromApi = Object.fromEntries(
+      // Line-scoped on purpose: a pattern allowed to span lines would pair a
+      // field that has no max_length with the next field's number.
+      [...block.matchAll(/^ {4}(\w+):.*max_length=(\d+)/gm)].map(([, field, max]) => [
+        field,
+        Number(max),
+      ]),
+    );
+
+    expect(fromApi).toEqual({
+      name: CONTACT_LIMITS.name,
+      email: CONTACT_LIMITS.email,
+      subject: CONTACT_LIMITS.subject,
+      message: CONTACT_LIMITS.message,
+    });
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "type-check": "next typegen && tsc --noEmit"
+    "type-check": "next typegen && tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "node tests/e2e/build-fixture.mjs && playwright test"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -18,6 +21,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -25,7 +29,8 @@
     "eslint": "^9",
     "eslint-config-next": "16.3.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@10.5.1"
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,95 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * End-to-end tests against a real production build in a real browser.
+ *
+ * These cover the two things a unit test cannot reach: what a visitor sees when
+ * the API is not there, and what the contact form does with a 429 — states that
+ * only exist once a Server Action, a client component and a status code are all
+ * in play at once.
+ *
+ * The build is produced by tests/e2e/build-fixture.mjs before Playwright starts
+ * (see the `test:e2e` script), with no API reachable. It is not built here,
+ * because the build and the server need different values of `API_URL` and a
+ * `webServer` entry gets one environment.
+ */
+
+/**
+ * Not 3000 and 8000, which are occupied on the machine this is developed on —
+ * along with 3005-3011, 3042, 8010, 8011 and 8042, so the defaults below are
+ * chosen to be out of the way rather than conventional.
+ *
+ * The hazard is specific: a port that is already taken does not announce
+ * itself. An unrelated server answers, the suite passes or fails against
+ * software that is not this app, and the result means nothing. Hence
+ * `reuseExistingServer: false` on both entries below, which turns that into an
+ * immediate "address already in use" — and hence both being overridable when
+ * these two get taken as well.
+ */
+const WEB_PORT = Number(process.env.E2E_WEB_PORT ?? 3142);
+const STUB_PORT = Number(process.env.E2E_STUB_PORT ?? 8142);
+
+export const BASE_URL = `http://127.0.0.1:${WEB_PORT}`;
+export const STUB_URL = `http://127.0.0.1:${STUB_PORT}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  // `.test.ts` belongs to Vitest; only `.spec.ts` is Playwright's.
+  testMatch: /.*\.spec\.ts/,
+
+  // A test that only passes on a retry is a flaky test, and this suite has no
+  // timing-dependent assertions in it. CI retries once because a cold runner
+  // can miss a first paint; locally a failure should just be a failure.
+  retries: process.env.CI ? 1 : 0,
+  forbidOnly: !!process.env.CI,
+
+  /**
+   * On CI: `github` annotates the failing line in the diff, and `html` produces
+   * the report the workflow uploads on failure — which is where the trace and
+   * the screenshot from a retry actually become readable. Locally `list` is
+   * enough; an HTML report nobody opens is just a directory to gitignore.
+   */
+  reporter: process.env.CI
+    ? [["github"], ["list"], ["html", { open: "never" }]]
+    : [["list"]],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  /**
+   * Chromium alone. The suite asserts behaviour — status codes, copy, focus —
+   * not rendering, and none of it is engine-specific; adding WebKit and Firefox
+   * would triple both the CI browser download and the run for no new signal.
+   * The cross-browser question worth asking about this site is visual, and a
+   * screenshot review answers it better than a headless assertion would.
+   */
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+
+  webServer: [
+    {
+      command: `node tests/e2e/stub-api.mjs`,
+      url: `${STUB_URL}/__health`,
+      env: { E2E_STUB_PORT: String(STUB_PORT) },
+      // If something is already on this port, fail rather than test whatever it
+      // happens to be.
+      reuseExistingServer: false,
+      stdout: "pipe",
+    },
+    {
+      command: `pnpm exec next start --port ${WEB_PORT}`,
+      url: BASE_URL,
+      env: {
+        // Deliberately not the port the build ran against — see the header of
+        // build-fixture.mjs. The prerendered pages keep the fallbacks they were
+        // built with; anything rendered per request reaches the stub.
+        API_URL: STUB_URL,
+      },
+      reuseExistingServer: false,
+      stdout: "pipe",
+      timeout: 60_000,
+    },
+  ],
+});

--- a/apps/web/tests/e2e/build-fixture.mjs
+++ b/apps/web/tests/e2e/build-fixture.mjs
@@ -1,0 +1,92 @@
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Builds the app the e2e suite runs against, with no API reachable.
+ *
+ * ## Why the build is where the outage is simulated
+ *
+ * Every page in this app is prerendered — `next build` prints them as ○ Static
+ * with a 5-minute revalidate. So the moment lib/api.ts decides between real
+ * content and its fallback is *build* time, not request time, and pointing a
+ * running server at a dead API would prove nothing: it would serve HTML that
+ * was rendered while the API was up.
+ *
+ * Building against a closed port is therefore the real test of the promise in
+ * CLAUDE.md — the site renders when the backend is not there. It is also what
+ * the CI web job already does; the difference is that CI only learns the build
+ * did not throw, while the specs then open the pages and read them.
+ *
+ * The server started afterwards by playwright.config.ts points at the stub
+ * instead. That is not a contradiction: `process.env.API_URL` survives into the
+ * server bundle rather than being inlined at build time, so the prerendered
+ * pages keep their fallbacks while the Server Action behind the contact form —
+ * which runs per request — talks to the stub. One build, both states.
+ */
+
+const require = createRequire(import.meta.url);
+const webRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+/**
+ * Ports that are open when they should not be are a recurring trap on this
+ * machine: a server left over from an earlier session keeps answering, so the
+ * build quietly succeeds against stale content and the suite tests nothing.
+ * Every candidate is probed rather than assumed.
+ */
+const CANDIDATE_DEAD_PORTS = [8043, 8044, 8045, 9042, 9043];
+
+function isClosed(port) {
+  return new Promise((resolve) => {
+    const socket = connect({ port, host: "127.0.0.1" });
+    const settle = (closed) => {
+      socket.destroy();
+      resolve(closed);
+    };
+
+    socket.setTimeout(1000);
+    socket.once("connect", () => settle(false));
+    socket.once("timeout", () => settle(false));
+    // ECONNREFUSED: nothing is listening, which is exactly what is wanted.
+    socket.once("error", () => settle(true));
+  });
+}
+
+async function findClosedPort() {
+  for (const port of CANDIDATE_DEAD_PORTS) {
+    if (await isClosed(port)) return port;
+    console.warn(`[e2e] port ${port} has something listening on it; trying the next one`);
+  }
+
+  throw new Error(
+    `No closed port among ${CANDIDATE_DEAD_PORTS.join(", ")}. The build needs one that ` +
+      `refuses connections so the fallback path is the one exercised.`,
+  );
+}
+
+const deadPort = await findClosedPort();
+const apiUrl = `http://127.0.0.1:${deadPort}`;
+
+console.log(`[e2e] building against ${apiUrl} — nothing is listening there, which is the point`);
+
+// Spawned through Node with the resolved bin rather than a bare `next`, so this
+// does not depend on the shell or on PATH — the two differ between the Windows
+// machine this is developed on and the Linux runner in CI.
+const nextBin = require.resolve("next/dist/bin/next");
+
+const build = spawn(process.execPath, [nextBin, "build"], {
+  cwd: webRoot,
+  stdio: "inherit",
+  env: { ...process.env, API_URL: apiUrl },
+});
+
+build.on("exit", (code) => {
+  if (code !== 0) {
+    console.error(
+      "\n[e2e] the build failed with no API running. That is the failure this suite exists " +
+        "to catch: a read in lib/api.ts is no longer falling back.",
+    );
+  }
+  process.exit(code ?? 1);
+});

--- a/apps/web/tests/e2e/contact-form.spec.ts
+++ b/apps/web/tests/e2e/contact-form.spec.ts
@@ -1,0 +1,270 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { STUB_URL } from "../../playwright.config";
+
+/**
+ * The contact form's failure states, driven for real.
+ *
+ * `validateContact` is unit-tested in lib/contact.test.ts and is not repeated
+ * here. What is left is everything a pure function cannot answer: whether the
+ * Server Action's verdict reaches the screen, whether a rate-limited visitor is
+ * told when to come back, and whether a message that went nowhere is reported
+ * as such instead of appearing to have been sent.
+ *
+ * Which of those happens is decided by the `subject` — see tests/e2e/stub-api.mjs.
+ * The stub holds no mode state, so these run in any order and in parallel, and
+ * each test tags its subject so it can find its own request in the stub's log
+ * without seeing another test's.
+ */
+
+const MESSAGE = "I read your notes and would like to talk.";
+
+/**
+ * Open the contact section and wait for the page to stop moving.
+ *
+ * Two things shift the layout just after load: the jump to `#contact`, which
+ * moves the submit button about 1200px up the page, and the web fonts swapping
+ * in behind it. Playwright waits for a click target to hold still, so a click
+ * issued inside that window is retried — and the retry can land *after* the
+ * form has already posted, at which point it waits for a button the
+ * confirmation has replaced until the test times out.
+ *
+ * That failure looks exactly like a broken form and is not one, which is worth
+ * a helper rather than a comment on one test: with JavaScript enabled hydration
+ * happens to absorb the delay, so only the no-JS case failed, and only most of
+ * the time.
+ */
+async function openContactForm(page: Page) {
+  await page.goto("/#contact");
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+}
+
+async function fillForm(page: Page, subject: string) {
+  await page.getByLabel("Name", { exact: true }).fill("Ada Lovelace");
+  await page.getByLabel("Email", { exact: true }).fill("ada@example.com");
+  await page.getByLabel("Subject", { exact: true }).fill(subject);
+  await page.getByLabel("Message", { exact: true }).fill(MESSAGE);
+}
+
+/**
+ * Click Send, but not while the button is still moving.
+ *
+ * Playwright already waits for a click target to hold still. The problem is
+ * what it does when the wait is interrupted: submitting navigates, the button
+ * detaches, and Playwright treats a detach during an action as retryable — so
+ * it looks for "Send message" again on a page where the confirmation has
+ * replaced it, and waits there until the test times out. The form worked; the
+ * report says it did not.
+ *
+ * Settling first removes the interruption rather than the symptom. `expect.poll`
+ * rather than a fixed pause because the delay is a font swap and a hash scroll,
+ * neither of which takes a predictable length of time on CI.
+ */
+async function submit(page: Page) {
+  const button = page.getByRole("button", { name: "Send message" });
+  await expect(button).toBeVisible();
+
+  let previous: string | null = null;
+  await expect
+    .poll(
+      async () => {
+        const box = JSON.stringify(await button.boundingBox());
+        const held = box === previous;
+        previous = box;
+        return held;
+      },
+      { timeout: 10_000, message: "the submit button never stopped moving" },
+    )
+    .toBe(true);
+
+  await button.click();
+}
+
+/**
+ * A subject no other submission will carry.
+ *
+ * The stub keeps every request for the life of the run, so a test asserting
+ * "exactly one arrived" has to distinguish its own submission from another
+ * test's — and from *its own on a retry*, which CI does once before reporting a
+ * failure. Without this, a test that failed for an unrelated reason would fail
+ * its retry with "expected 1, received 2" and hide the original cause.
+ */
+function subjectFor(base: string) {
+  const { testId, retry, repeatEachIndex } = test.info();
+
+  return `${base} [${testId}#${retry}.${repeatEachIndex}]`;
+}
+
+/** What the stub recorded for this test alone. */
+async function requestsFor(page: Page, subject: string) {
+  const response = await page.request.get(`${STUB_URL}/__requests`);
+  const all = (await response.json()) as { body: { subject?: string } }[];
+
+  return all.filter((entry) => entry.body.subject === subject);
+}
+
+test.beforeEach(async ({ page }) => {
+  await openContactForm(page);
+});
+
+test("sends a valid message and confirms it", async ({ page }) => {
+  const subject = subjectFor("A real message");
+
+  await fillForm(page, subject);
+  await submit(page);
+
+  await expect(page.getByRole("heading", { name: "Message sent" })).toBeVisible();
+  // The confirmation replaces the form, so there is no ambiguity about whether
+  // anything was sent.
+  await expect(page.getByRole("button", { name: "Send message" })).toBeHidden();
+
+  expect(await requestsFor(page, subject)).toHaveLength(1);
+});
+
+test("trims what it stores, so the length check and the row agree", async ({ page }) => {
+  const subject = subjectFor("Padded values");
+
+  await page.getByLabel("Name", { exact: true }).fill("   Ada Lovelace   ");
+  await page.getByLabel("Email", { exact: true }).fill("  ada@example.com  ");
+  await page.getByLabel("Subject", { exact: true }).fill(`  ${subject}  `);
+  await page.getByLabel("Message", { exact: true }).fill(`  ${MESSAGE}  `);
+  await submit(page);
+
+  await expect(page.getByRole("heading", { name: "Message sent" })).toBeVisible();
+
+  const [sent] = await requestsFor(page, subject);
+  expect(sent.body).toMatchObject({
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+    subject,
+    message: MESSAGE,
+  });
+});
+
+test("stops an invalid submission in the browser without troubling the API", async ({ page }) => {
+  await submit(page);
+
+  await expect(page.getByText("4 fields need fixing")).toBeVisible();
+  await expect(page.getByText("Enter your name.")).toBeVisible();
+  await expect(page.getByText("Write a message before sending.")).toBeVisible();
+
+  // Focus lands on the first thing to fix. Without it the errors are visible to
+  // a sighted user and nowhere at all for a keyboard one, whose focus is still
+  // on the submit button.
+  await expect(page.getByLabel("Name", { exact: true })).toBeFocused();
+
+  // A round trip the browser could have saved. Every other test sends a
+  // non-empty subject, so anything recorded with an empty one came from here.
+  expect(await requestsFor(page, "")).toHaveLength(0);
+});
+
+test("says when to come back after a 429", async ({ page }) => {
+  await fillForm(page, "stub:429 please");
+  await submit(page);
+
+  // 2700 seconds from the stub, rendered as a duration rather than a number of
+  // seconds — the exact second is not useful to anyone.
+  await expect(page.getByText(/Try again in about 45 minutes/)).toBeVisible();
+  await expect(page.getByText(/five messages an hour/)).toBeVisible();
+});
+
+test("stays vague when a 429 carries no Retry-After", async ({ page }) => {
+  await fillForm(page, "stub:429-bare please");
+  await submit(page);
+
+  await expect(page.getByText(/Try again in a little while/)).toBeVisible();
+});
+
+test("keeps what was typed when the send is refused", async ({ page }) => {
+  const subject = "stub:429 keeps values";
+
+  await fillForm(page, subject);
+  await submit(page);
+
+  await expect(page.getByText(/Try again in about 45 minutes/)).toBeVisible();
+
+  // The visitor has to be able to send this somewhere else. Clearing the form
+  // under them would mean retyping it.
+  await expect(page.getByLabel("Message", { exact: true })).toHaveValue(MESSAGE);
+  await expect(page.getByLabel("Subject", { exact: true })).toHaveValue(subject);
+});
+
+test("offers the mailto when the form cannot deliver", async ({ page }) => {
+  await fillForm(page, "stub:429 offers email");
+  await submit(page);
+
+  const mailto = page
+    .getByRole("link", { name: "dangkhoipham80@gmail.com" })
+    .and(page.locator('[href^="mailto:"]'));
+
+  await expect(mailto.first()).toBeVisible();
+});
+
+test.describe("when the message goes nowhere", () => {
+  const OUTAGES = [
+    { subject: "stub:503 outage", why: "the API returns 5xx" },
+    { subject: "stub:hangup outage", why: "the connection drops" },
+  ];
+
+  for (const { subject, why } of OUTAGES) {
+    test(`says it was not sent when ${why}`, async ({ page }) => {
+      await fillForm(page, subject);
+      await submit(page);
+
+      // The opposite of lib/api.ts, and deliberately so: a failed read hides
+      // itself behind a fallback, a failed write must not. "Your message went
+      // nowhere" is the one thing the visitor has to be told.
+      await expect(page.getByText(/has not been sent/)).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Message sent" })).toBeHidden();
+
+      // And the text is still there to copy into an email.
+      await expect(page.getByLabel("Message", { exact: true })).toHaveValue(MESSAGE);
+    });
+  }
+});
+
+test("lands a 422 from the API on the field that caused it", async ({ page }) => {
+  // An address the browser regex accepts and email-validator does not. Reported
+  // as an outage it would be a lie the visitor cannot act on.
+  await fillForm(page, "stub:422 bad domain");
+  await submit(page);
+
+  await expect(page.getByText(/domain we cannot deliver to/)).toBeVisible();
+  await expect(page.getByLabel("Email", { exact: true })).toHaveAttribute("aria-invalid", "true");
+});
+
+test("forwards the visitor's address so the API rate-limits the right person", async ({ page }) => {
+  const subject = subjectFor("Forwarded header");
+
+  await page.setExtraHTTPHeaders({ "X-Forwarded-For": "203.0.113.7" });
+  await openContactForm(page);
+  await fillForm(page, subject);
+  await submit(page);
+
+  await expect(page.getByRole("heading", { name: "Message sent" })).toBeVisible();
+
+  // Without this the API sees the Next server's address and every visitor in
+  // the world shares one five-message bucket.
+  const [sent] = await requestsFor(page, subject);
+  expect(sent).toMatchObject({ forwardedFor: expect.stringContaining("203.0.113.7") });
+});
+
+test("works without JavaScript", async ({ browser }) => {
+  // The form's `action` is the Server Action itself rather than a wrapper, so a
+  // native form POST reaches it. This is the reason it is not a route handler,
+  // and nothing else in the suite would notice if it regressed.
+  const context = await browser.newContext({ javaScriptEnabled: false });
+  const page = await context.newPage();
+
+  try {
+    await openContactForm(page);
+    await fillForm(page, "No JavaScript");
+    await submit(page);
+
+    await expect(page.getByRole("heading", { name: "Message sent" })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});

--- a/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
+++ b/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The promise this site is built on: the API can be down and the site still
+ * works.
+ *
+ * It replaced a static SPA that could not break, so "the backend is asleep" has
+ * to produce an empty section rather than a 500. The CI web job builds with no
+ * API for the same reason, but a green build only means nothing threw — it says
+ * nothing about what ends up on the page. These tests open the pages.
+ *
+ * The pages below were prerendered against a closed port by
+ * tests/e2e/build-fixture.mjs. The `/projects/[slug]` tests are the stronger
+ * half: that route renders per request, so those failures happen live against
+ * the stub while the assertion runs.
+ */
+
+const PAGES = [
+  {
+    path: "/",
+    heading: "Phạm Đăng Khôi",
+    empty: ["No projects published yet.", "No skills published yet."],
+  },
+  {
+    path: "/career-journey",
+    heading: "Where I have worked and studied",
+    empty: ["No career entries published yet."],
+  },
+  {
+    path: "/certificates",
+    heading: "Courses and certifications",
+    empty: ["No certificates published yet."],
+  },
+];
+
+test.describe("pages built with no API behind them", () => {
+  for (const { path, heading, empty } of PAGES) {
+    test(`${path} answers 200 and says why it is empty`, async ({ page }) => {
+      const response = await page.goto(path);
+
+      expect(response?.status(), `${path} must not 5xx because the API is gone`).toBe(200);
+
+      for (const copy of empty) {
+        await expect(page.getByText(copy)).toBeVisible();
+      }
+    });
+
+    test(`${path} still has its heading and structure`, async ({ page }) => {
+      await page.goto(path);
+
+      // An empty section is the acceptable outcome; an empty *page* is not.
+      // Without this the tests above would pass on a blank document.
+      await expect(page.getByRole("heading", { level: 1 })).toHaveText(heading);
+      await expect(page.locator("h1")).toHaveCount(1);
+      await expect(page.getByRole("navigation")).toBeVisible();
+    });
+  }
+
+  test("the home page counts nothing rather than showing a broken count", async ({ page }) => {
+    await page.goto("/");
+
+    // The eyebrows interpolate `projects.length`. A fallback that was not an
+    // array would render "Projects · undefined" here, if it rendered at all.
+    await expect(page.getByText("Projects · 0")).toBeVisible();
+    await expect(page.getByText("Skills · 0")).toBeVisible();
+  });
+
+  test("the contact form is still usable when the content API is gone", async ({ page }) => {
+    await page.goto("/");
+
+    // The section's whole argument is that the mailto works when nothing else
+    // does, so it must survive the outage that makes it necessary.
+    await expect(page.getByRole("button", { name: "Send message" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "dangkhoipham80@gmail.com" }).first(),
+    ).toBeVisible();
+  });
+});
+
+/**
+ * `/projects/[slug]` is rendered on demand, so these exercise lib/api.ts at
+ * request time. Each slug makes the stub fail in a different way; the correct
+ * answer to all of them is the 404 page, because `getProject` returning null is
+ * indistinguishable from a project that does not exist — and a visitor can act
+ * on neither.
+ */
+test.describe("a project detail page when the read fails", () => {
+  const FAILURES = [
+    { slug: "stub-missing", why: "the API says 404" },
+    { slug: "stub-500", why: "the API 500s" },
+    { slug: "stub-hangup", why: "the connection drops mid-request" },
+    { slug: "stub-not-json", why: "the body is not JSON" },
+    { slug: "stub-wrong-shape", why: "the body is JSON of the wrong shape" },
+  ];
+
+  for (const { slug, why } of FAILURES) {
+    test(`404s, not 500s, when ${why}`, async ({ page }) => {
+      const response = await page.goto(`/projects/${slug}`);
+
+      expect(response?.status(), `${why} must not surface as a server error`).toBe(404);
+    });
+  }
+
+  test("renders the project when the read works", async ({ page }) => {
+    // The control. Without it every assertion above would still pass on a route
+    // that is broken for all inputs.
+    const response = await page.goto("/projects/a-real-slug");
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("Stubbed Project");
+    await expect(page.getByText("A project served by the e2e stub.")).toBeVisible();
+  });
+});

--- a/apps/web/tests/e2e/stub-api.mjs
+++ b/apps/web/tests/e2e/stub-api.mjs
@@ -1,0 +1,154 @@
+import { createServer } from "node:http";
+
+/**
+ * A stand-in for apps/api, so the e2e suite never touches a real backend.
+ *
+ * Pointing the tests at the actual API would make them depend on a database, on
+ * whatever rows happen to be in it, and — for the rate-limit case — on burning
+ * four real submissions to reach the fifth. Worse, the interesting states are
+ * the ones a healthy API will not produce on demand: 429, 5xx, a connection
+ * that drops mid-request.
+ *
+ * There is no mode switch and no shared state, so the specs can run in any
+ * order and in parallel. Instead each response is decided by what the request
+ * carries: a contact's `subject`, or a project's slug. The Server Action under
+ * test cannot tell the difference — it branches on the status code, and the
+ * status code is real.
+ */
+
+const PORT = Number(process.env.E2E_STUB_PORT ?? 8142);
+
+/** Every contact POST that arrived, so a spec can assert what was forwarded. */
+const received = [];
+
+/** Complete enough to render the detail page; the values are recognisable on purpose. */
+function project(slug) {
+  return {
+    id: 1,
+    slug,
+    title: "Stubbed Project",
+    description: "A project served by the e2e stub.",
+    long_description: "The long description, which the detail page renders.",
+    image_url: null,
+    github_url: "https://github.com/dangkhoipham80/portfolio",
+    live_url: null,
+    technologies: ["FastAPI", "Next.js"],
+    features: ["A feature"],
+    challenges: ["A challenge"],
+    started_on: "2025-01-01",
+    ended_on: null,
+    status: "in_progress",
+    featured: true,
+    published: true,
+    order: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: null,
+  };
+}
+
+function send(response, status, body, headers = {}) {
+  const payload = JSON.stringify(body);
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+    ...headers,
+  });
+  response.end(payload);
+}
+
+/**
+ * Drop the connection without answering.
+ *
+ * This is what a backend that has fallen over looks like from the Next server:
+ * `fetch` rejects, and the catch block in lib/api.ts — or in the Server Action —
+ * is the thing under test. Refusing to listen at all would test the same path,
+ * but then this server could not also serve the tests that need it up.
+ */
+function hangUp(response) {
+  response.socket?.destroy();
+}
+
+function readBody(request) {
+  return new Promise((resolve) => {
+    let raw = "";
+    request.on("data", (chunk) => (raw += chunk));
+    request.on("end", () => {
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+const server = createServer(async (request, response) => {
+  const { pathname } = new URL(request.url, `http://127.0.0.1:${PORT}`);
+
+  // Readiness for Playwright's webServer, and a way to prove in a failing run
+  // that the thing answering is this stub and not a leftover from an earlier
+  // session sitting on the same port.
+  if (pathname === "/__health") {
+    return send(response, 200, { stub: "portfolio-e2e" });
+  }
+
+  if (pathname === "/__requests") {
+    return send(response, 200, received);
+  }
+
+  if (request.method === "POST" && pathname === "/api/v1/contacts/") {
+    const body = await readBody(request);
+    received.push({ body, forwardedFor: request.headers["x-forwarded-for"] ?? null });
+
+    const subject = String(body.subject ?? "");
+
+    // Ordered longest-key-first: "stub:429-bare" also contains "stub:429".
+    if (subject.includes("stub:429-bare")) {
+      return send(response, 429, { detail: "Too many requests" });
+    }
+    if (subject.includes("stub:429")) {
+      // 2700s = 45 minutes, which the form should render as "about 45 minutes"
+      // rather than a raw number of seconds.
+      return send(response, 429, { detail: "Too many requests" }, { "retry-after": "2700" });
+    }
+    if (subject.includes("stub:503")) {
+      return send(response, 503, { detail: "Service unavailable" });
+    }
+    if (subject.includes("stub:hangup")) {
+      return hangUp(response);
+    }
+    if (subject.includes("stub:422")) {
+      // The shape FastAPI sends when EmailStr rejects an address that the
+      // browser-side regex let through.
+      return send(response, 422, {
+        detail: [{ loc: ["body", "email"], msg: "value is not a valid email address" }],
+      });
+    }
+
+    return send(response, 201, { id: 1, ...body, read: false, created_at: "2026-08-09T00:00:00Z" });
+  }
+
+  if (pathname.startsWith("/api/v1/projects/slug/")) {
+    const slug = decodeURIComponent(pathname.slice("/api/v1/projects/slug/".length));
+
+    if (slug === "stub-500") return send(response, 500, { detail: "Internal error" });
+    if (slug === "stub-missing") return send(response, 404, { detail: "Not found" });
+    if (slug === "stub-hangup") return hangUp(response);
+    if (slug === "stub-not-json") {
+      response.writeHead(200, { "content-type": "application/json" });
+      return response.end("<html>Service suspended</html>");
+    }
+    // A detail route answering with a list: valid JSON, 200, wrong shape.
+    if (slug === "stub-wrong-shape") return send(response, 200, []);
+
+    return send(response, 200, project(slug));
+  }
+
+  // The list routes are only reached during the e2e build, which deliberately
+  // runs against a closed port — so nothing here should ask for them.
+  return send(response, 404, { detail: "Not found" });
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`[stub-api] listening on http://127.0.0.1:${PORT}`);
+});

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,0 +1,72 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+/**
+ * Unit tests for the modules that are plain functions.
+ *
+ * The split with Playwright is deliberate and worth stating, because the
+ * tempting middle layer — jsdom plus a React testing library — is the one thing
+ * not used here. Anything that renders is tested in a real browser against a
+ * real production build (see playwright.config.ts); anything that does not is
+ * tested here, in Node, in milliseconds. A jsdom test of ContactForm would need
+ * a faked DOM, a faked `useActionState` and a stubbed Server Action, and would
+ * still not answer the only interesting question about that component, which is
+ * what a person sees after the API returns 429.
+ *
+ * So this project runs no component tests. That is a choice, not an omission.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirrors the `@/*` path in tsconfig.json. Vitest does not read
+      // tsconfig paths on its own, and without this the imports under test
+      // resolve here differently than they do in the app.
+      "@": fileURLToPath(new URL("./", import.meta.url)),
+    },
+    /**
+     * `lib/api.ts` starts with `import "server-only"`, whose export map sends
+     * every condition except `react-server` to a module that throws on import.
+     * That is the guard doing its job — but it makes the file untestable unless
+     * the runner asks for the same condition the RSC bundler does.
+     *
+     * Aliasing `server-only` to an empty file is the usual workaround and is
+     * worse: it switches the guard off for every module, including one added
+     * later that genuinely must not be reachable from a client component. This
+     * satisfies the export map rather than bypassing it.
+     */
+    conditions: ["react-server", "node", "import", "default"],
+  },
+  /**
+   * And again for the SSR pipeline, which is the one Vitest's `node`
+   * environment actually runs through. `resolve.conditions` alone is the
+   * client-side list and leaves this import resolving to the throwing file.
+   */
+  ssr: {
+    resolve: {
+      conditions: ["react-server", "node", "import", "default"],
+    },
+  },
+  test: {
+    // No DOM on purpose — see the note above.
+    environment: "node",
+    server: {
+      deps: {
+        /**
+         * `resolve.conditions` only reaches modules Vite itself resolves.
+         * Anything in node_modules is externalised by default and imported by
+         * Node, which has never heard of `react-server` — so without this the
+         * condition above is quietly ignored and the import throws.
+         */
+        inline: ["server-only"],
+      },
+    },
+    /**
+     * `.test.ts` is Vitest, `.spec.ts` is Playwright. Without the split Vitest
+     * collects the e2e specs, imports `@playwright/test` outside a Playwright
+     * runner and fails with an error that has nothing to do with the code.
+     */
+    include: ["**/*.test.ts"],
+    exclude: ["node_modules/**", ".next/**", "tests/e2e/**"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start": "pnpm --filter web start",
     "lint": "pnpm --filter web lint",
     "type-check": "pnpm --filter web type-check",
+    "test": "pnpm --filter web test",
+    "test:e2e": "pnpm --filter web test:e2e",
     "api:dev": "cd apps/api && python -m uvicorn app.main:app --reload --port 8000",
     "api:lint": "cd apps/api && python -m ruff check .",
     "api:test": "cd apps/api && python -m pytest -q"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         version: 2.1.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@types/node@20.19.43)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@20.19.43)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -29,6 +29,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.3
@@ -53,6 +56,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.43)(vite@8.2.1(@types/node@20.19.43)(jiti@2.7.0))
 
 packages:
 
@@ -442,8 +448,106 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -538,6 +642,12 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -728,6 +838,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -783,6 +922,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -849,6 +992,10 @@ packages:
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -965,6 +1112,9 @@ packages:
   es-iterator-helpers@1.4.0:
     resolution: {integrity: sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1106,9 +1256,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1157,6 +1314,16 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1446,8 +1613,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -1458,8 +1637,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -1470,8 +1661,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -1482,8 +1685,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -1494,8 +1709,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -1506,8 +1733,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   locate-path@6.0.0:
@@ -1626,6 +1863,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1657,6 +1898,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1667,6 +1911,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -1729,6 +1983,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -1805,12 +2064,21 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1878,9 +2146,20 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1949,6 +2228,90 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1968,6 +2331,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2362,7 +2730,59 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oxc-project/types@0.143.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2441,6 +2861,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -2621,6 +3048,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@20.19.43)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@20.19.43)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -2709,6 +3177,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -2768,6 +3238,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001809: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2945,6 +3417,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3177,7 +3651,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3224,6 +3704,12 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3515,34 +4001,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -3560,6 +4079,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   locate-path@6.0.0:
     dependencies:
@@ -3606,7 +4141,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.3.0(@babel/core@7.29.7)(@types/node@20.19.43)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@20.19.43)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -3625,6 +4160,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.3.0
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
+      '@playwright/test': 1.62.1
       sharp: 0.35.3(@types/node@20.19.43)
     transitivePeerDependencies:
       - '@babel/core'
@@ -3682,6 +4218,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.4: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3716,11 +4254,21 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -3791,6 +4339,26 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -3913,9 +4481,15 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -3996,10 +4570,16 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4114,6 +4694,45 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite@8.2.1(@types/node@20.19.43)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.43
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.10(@types/node@20.19.43)(vite@8.2.1(@types/node@20.19.43)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@20.19.43)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@20.19.43)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.43
+    transitivePeerDependencies:
+      - msw
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4158,6 +4777,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
`apps/web` had 0 tests and no runner. It now has 72, in two runners chosen by
what each can actually answer.

## The split

**Vitest — 46 tests, under a second, no browser.** The modules that are plain
functions: every way a request in `lib/api.ts` can fail (refused, timed out,
5xx, 404, a body that is not JSON, a body of the wrong shape), and the contact
form's field rules in `lib/contact.ts`. One test reads
`apps/api/app/schemas/portfolio.py` and compares the four field limits
directly — the comment claiming they mirror the API cannot enforce itself, and
drift there silently rejects messages the API would have accepted.

**Playwright — 26 tests in Chromium, ~30s, against a production build.** What
only exists once a page renders: the empty states, and the contact form's 429,
outage and 422 notices.

**No component tests, deliberately.** The jsdom layer between these two would
need a faked DOM, a faked `useActionState` and a stubbed Server Action to ask a
question Playwright already asks of the real thing.

## Why the e2e build is the design

Every page here is prerendered — `next build` prints them all as `○ Static`. So
`lib/api.ts` chooses between real content and its fallback at **build** time.
Pointing a running server at a dead API would prove nothing: it would serve HTML
rendered while the API was up, and pass no matter what.

So the fixture builds against a port it has probed and found closed, then serves
that same build with `API_URL` pointing at a stub. `process.env.API_URL` survives
into the server bundle rather than being inlined, so the prerendered pages keep
their fallbacks while the Server Action behind the contact form — which runs per
request — reaches the stub. One build, both states, and no real API is ever
contacted.

`/projects/[slug]` renders on demand, so those five tests exercise `lib/api.ts`
live: the API 404s, 500s, drops the connection, returns HTML, returns the wrong
shape. The right answer to all five is the 404 page. A sixth renders a real
project, so the other five cannot pass by being broken for every input.

## The bug this found

The fallback covered the API being *absent*, not the API *lying*. A 200 carrying
`{"detail": ...}` — an auth gateway, a tunnel serving its own JSON — reached the
page as a `Project[]` and `projects.map()` threw. **A 500 caused by a successful
request**, which is precisely the failure mode the module exists to rule out.

Each reader now states what it accepts; anything else logs and falls back.
Confirmed both ways: with the guard removed, `/projects/<any>` serves a 500 where
it now serves a 404. That is the one product change here (commit 1) and is
trivially revertable if you would rather keep it out of a test PR.

## CI

Added to the existing web job: `pnpm test`, then Chromium, then `pnpm test:e2e`.

**The browser cost, stated.** `playwright install` pulls ~130MB, so the binaries
are cached on the lockfile hash — too broad a key, and chosen for that: it
re-downloads when an unrelated package moves, but can never serve a Chromium
mismatched to `@playwright/test`. `--with-deps` still runs apt on a cache hit,
~20s that cannot be cached. Chromium only; the suite asserts status codes, copy
and focus, none of it engine-specific, so WebKit and Firefox would triple the
step for no new signal. On failure the HTML report uploads as an artifact.

`pnpm build` stays as its own step even though the e2e fixture builds again —
it is the command Vercel runs, and one extra build is worth not having two code
paths where one could quietly reuse a build made against a live API.

## Two flakes fixed before merge, not after

Both found by running the suite repeatedly rather than once:

- Submitting raced the post-load reflow (the `#contact` jump moves the button
  ~1200px). Playwright retried the click after the form had already posted, then
  waited for a button the confirmation had replaced — 4 of 5 runs failed, and it
  read exactly like a broken form. It is not: the no-JS POST works, verified
  directly. `submit()` now waits for the button to hold still.
- The stub's request log outlives a retry, so "exactly one arrived" would fail on
  CI's retry with the wrong reason and hide the original. Subjects are now tagged
  per invocation.

Full suite run 3× end to end: 78/78.

## Also

README's known-issues list claimed the contact form and CI were outstanding and
that the API had 69 tests (it has 87, verified by collection). Replaced with what
is actually outstanding.

## Verification

`pnpm lint`, `pnpm type-check`, `pnpm build`, `pnpm test` (46), `pnpm test:e2e`
(26) all green from a clean tree. No markup, styling or client component changed,
so there is no visual surface to review here.

Note for local runs: 3042 and 8042 are no longer free on this machine, so the e2e
defaults are 3142 and 8142, and both servers refuse to reuse anything already
listening rather than testing whatever answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
