### PR TITLE
feat(api): email the owner when someone uses the contact form

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,16 +18,28 @@ SECRET_KEY=
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 REFRESH_TOKEN_EXPIRE_DAYS=30
 
-# Email. app/services/auth_service.py sends verification and password-reset mail
-# through smtplib using these; leaving them unset makes those flows fail silently
-# (the exception is caught and printed, not raised).
+# Email. app/services/email_service.py is the only thing that talks to SMTP:
+# contact-form notifications, plus verification and password-reset mail from
+# auth_service. Leave SMTP_USER/SMTP_PASSWORD blank and nothing is sent —
+# every mail path checks first, so an unconfigured clone and CI both work.
+# For Gmail this is an App Password, not the account password.
 SMTP_TLS=True
 SMTP_PORT=587
 SMTP_HOST=smtp.gmail.com
 SMTP_USER=
 SMTP_PASSWORD=
+# Blank is fine — the From address falls back to SMTP_USER.
 EMAILS_FROM_EMAIL=
 EMAILS_FROM_NAME=Portfolio Contact
+# Seconds. smtplib has no timeout by default, so a dead host would otherwise
+# hang the background task until the process restarts.
+SMTP_TIMEOUT=10
+
+# Contact-form notification. Set CONTACT_NOTIFY_ENABLED=False to keep the form
+# working but stop the mail; it is already off whenever SMTP is unconfigured.
+# CONTACT_NOTIFY_TO is who gets told — blank means EMAILS_FROM_EMAIL, then SMTP_USER.
+CONTACT_NOTIFY_ENABLED=True
+CONTACT_NOTIFY_TO=
 
 # Set to "production" on Railway. Also switches /docs off.
 ENVIRONMENT=development

--- a/apps/api/app/api/v1/endpoints/contacts.py
+++ b/apps/api/app/api/v1/endpoints/contacts.py
@@ -10,7 +10,15 @@ the contact form, to anyone who asked.
 
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+)
 from sqlalchemy.orm import Session
 
 from app.api.v1.dependencies import require_admin
@@ -18,6 +26,7 @@ from app.core.constants import ErrorMessages, SuccessMessages
 from app.core.database import get_db
 from app.core.rate_limit import limiter
 from app.schemas.portfolio import Contact, ContactCreate
+from app.services.email_service import send_contact_notification
 from app.services.portfolio_service import PortfolioService
 
 router = APIRouter()
@@ -55,11 +64,33 @@ def create_contact(
     # successful submission, not just on the 429.
     response: Response,
     contact: ContactCreate,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
-    """Submit a contact message. Public, rate limited per IP."""
+    """Submit a contact message. Public, rate limited per IP.
+
+    The message is saved synchronously; the owner is notified after the response
+    has gone out. An SMTP round trip is unbounded in a way a database insert is
+    not — a mail host that stops answering costs SMTP_TIMEOUT seconds, and the
+    visitor should not spend them watching a spinner to find out their message
+    was in fact saved.
+
+    Checked against a socket that accepts and never replies: the 201 came back
+    in the same 1.8-3.0s as with notifications switched off, while the send sat
+    there for its full five-second timeout and then logged.
+    """
     service = PortfolioService(db)
-    return service.create_contact(contact)
+    created = service.create_contact(contact)
+
+    background_tasks.add_task(
+        send_contact_notification,
+        contact_id=created.id,
+        name=created.name,
+        email=created.email,
+        subject=created.subject,
+        message=created.message,
+    )
+    return created
 
 
 @router.put(

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -61,6 +61,17 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: str = ""
     EMAILS_FROM_EMAIL: str = ""
     EMAILS_FROM_NAME: str = "Portfolio Contact"
+    # smtplib blocks with no timeout by default. A background task that hangs on
+    # a dead SMTP host holds a thread from the pool until the process restarts.
+    SMTP_TIMEOUT: int = 10
+
+    # Notify the owner when the contact form is used. The kill switch is
+    # explicit, but the effective default is off: `emails_enabled` is False
+    # until real credentials are present, so CI and a fresh clone send nothing
+    # without having to set anything.
+    CONTACT_NOTIFY_ENABLED: bool = True
+    # Who to notify. Empty means "whoever the mail is sent as".
+    CONTACT_NOTIFY_TO: str = ""
 
     DEBUG: bool = True
     ENVIRONMENT: str = "development"
@@ -72,6 +83,26 @@ class Settings(BaseSettings):
     @property
     def emails_enabled(self) -> bool:
         return bool(self.SMTP_HOST and self.SMTP_USER and self.SMTP_PASSWORD)
+
+    @property
+    def emails_from_address(self) -> str:
+        """Envelope sender. Falls back to the account we authenticate as.
+
+        EMAILS_FROM_EMAIL is routinely left blank — it is the one SMTP setting
+        with no obvious value to paste in. Blank used to reach the From header
+        verbatim, producing `Portfolio Contact <>`, which Gmail rejects outright.
+        """
+        return self.EMAILS_FROM_EMAIL or self.SMTP_USER
+
+    @property
+    def contact_notify_recipient(self) -> str:
+        return self.CONTACT_NOTIFY_TO or self.emails_from_address
+
+    @property
+    def contact_notifications_enabled(self) -> bool:
+        return bool(
+            self.CONTACT_NOTIFY_ENABLED and self.emails_enabled and self.contact_notify_recipient
+        )
 
 
 settings = Settings()

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -1,7 +1,5 @@
-import smtplib
+import logging
 from datetime import datetime, timezone
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 
 from sqlalchemy.orm import Session
 
@@ -11,7 +9,10 @@ from app.core.security import get_password_hash, verify_token
 from app.models.token import TokenType
 from app.models.user import UserStatus
 from app.schemas.user import PasswordResetConfirm, PasswordResetRequest, TokenResponse, UserLogin
+from app.services.email_service import send_email
 from app.services.user_service import UserService
+
+logger = logging.getLogger(__name__)
 
 
 class AuthService:
@@ -249,23 +250,14 @@ class AuthService:
         self._send_email(user.email, subject, body)
 
     def _send_email(self, to_email: str, subject: str, body: str) -> None:
-        """Send email using SMTP"""
+        """Send mail, best-effort.
+
+        The transport moved to ``email_service.send_email``, which raises; these
+        flows keep swallowing, as they did before, so that a password-reset
+        request does not 500 on a mail outage. What changed is that the failure
+        now reaches the logger instead of stdout, where nothing was collecting it.
+        """
         try:
-            msg = MIMEMultipart()
-            msg['From'] = f"{settings.EMAILS_FROM_NAME} <{settings.EMAILS_FROM_EMAIL}>"
-            msg['To'] = to_email
-            msg['Subject'] = subject
-
-            msg.attach(MIMEText(body, 'plain'))
-
-            server = smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT)
-            if settings.SMTP_TLS:
-                server.starttls()
-
-            server.login(settings.SMTP_USER, settings.SMTP_PASSWORD)
-            server.send_message(msg)
-            server.quit()
-
-        except Exception as e:
-            # Log error but don't fail the request
-            print(f"Failed to send email to {to_email}: {str(e)}")
+            send_email(to_email, subject, body)
+        except Exception:
+            logger.exception("Failed to send email to %s", to_email)

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -1,0 +1,96 @@
+"""Outbound mail.
+
+One place that knows how to talk to SMTP. ``auth_service`` had its own copy of
+this block; a second copy for the contact form would have made three, each with
+its own answer to whether a failure should raise.
+
+The split here is deliberate:
+
+* ``send_email`` **raises**. It is a transport, and a transport that swallows
+  its errors cannot be used by a caller that needs to know.
+* ``send_contact_notification`` **never raises**. It runs as a background task,
+  after ``POST /contacts/`` has already answered 201 and committed the row, so
+  there is no longer a request to fail — but it logs, at ``exception`` level
+  with the contact id, so a silent SMTP outage is visible in the logs rather
+  than only in an inbox that never fills up.
+
+That is the mirror image of ``apps/web/lib/api.ts``: a read hides its failure
+behind a fallback because a visitor cannot act on it, a write must not hide one
+because the operator can.
+"""
+
+import logging
+import smtplib
+from email.message import EmailMessage
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def send_email(to_email: str, subject: str, body: str, *, reply_to: str | None = None) -> None:
+    """Send one plain-text message. Raises on any SMTP failure."""
+    message = EmailMessage()
+    message["From"] = f"{settings.EMAILS_FROM_NAME} <{settings.emails_from_address}>"
+    message["To"] = to_email
+    message["Subject"] = subject
+    if reply_to:
+        message["Reply-To"] = reply_to
+    message.set_content(body)
+
+    # `with` rather than an explicit quit(): the old version leaked the
+    # connection whenever login() or send_message() raised, because quit() was
+    # the line after the one that threw.
+    with smtplib.SMTP(
+        settings.SMTP_HOST, settings.SMTP_PORT, timeout=settings.SMTP_TIMEOUT
+    ) as server:
+        if settings.SMTP_TLS:
+            server.starttls()
+        server.login(settings.SMTP_USER, settings.SMTP_PASSWORD)
+        server.send_message(message)
+
+
+def send_contact_notification(
+    *,
+    contact_id: int,
+    name: str,
+    email: str,
+    subject: str,
+    message: str,
+) -> None:
+    """Tell the site owner someone used the contact form.
+
+    Takes plain values, not the ``Contact`` row: ``get_db`` closes the session
+    once the response is sent, and background tasks run after that, so reading
+    an attribute off the ORM object here would raise ``DetachedInstanceError``
+    for a message that was in fact saved perfectly well.
+    """
+    if not settings.contact_notifications_enabled:
+        # The normal state in CI and on a fresh clone. Debug, not warning —
+        # an unconfigured mailer is a choice, not a fault.
+        logger.debug("Contact notification skipped (disabled or no SMTP credentials)")
+        return
+
+    body = (
+        f"New message from the portfolio contact form.\n\n"
+        f"From:    {name} <{email}>\n"
+        f"Subject: {subject}\n\n"
+        f"{message}\n"
+    )
+
+    try:
+        send_email(
+            settings.contact_notify_recipient,
+            f"[Portfolio] {subject}",
+            body,
+            # So replying in the mail client answers the visitor, not yourself.
+            # Safe to interpolate: EmailStr has already rejected the newlines a
+            # header-injection attempt would need.
+            reply_to=email,
+        )
+    except Exception:
+        logger.exception(
+            "Contact notification failed for contact id=%s; the message is saved", contact_id
+        )
+    else:
+        logger.info("Contact notification sent for contact id=%s", contact_id)

--- a/apps/api/tests/test_contact_notification.py
+++ b/apps/api/tests/test_contact_notification.py
@@ -1,0 +1,190 @@
+"""Email notification for the contact form.
+
+Nothing here touches the network: ``smtplib.SMTP`` is patched out in every case
+that would reach it, and the two cases that must not reach it at all assert
+exactly that. The suite passes on a machine with no mail server and in CI with
+no SMTP secret, which is the point — see ``test_notification_is_off_without_credentials``.
+
+Two details of the setup are load-bearing:
+
+* The limiter is switched off for this module. ``POST /contacts/`` is capped at
+  5/hour on a process-wide in-memory bucket shared by the whole pytest session,
+  and unlike ``test_contact_form.py`` these cases need real 201s. Spending four
+  slots here would break the ``codes[0] == 201`` assertion in
+  ``test_security.py``, which sorts after this file. Disabling is cleaner than
+  resetting: the bucket is left exactly as it was found.
+
+* Settings are patched per-test rather than read from ``.env``. A developer with
+  working credentials and a developer without one must get the same result out
+  of this file.
+"""
+
+import smtplib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.core.rate_limit import limiter
+from app.main import app
+from app.models.portfolio import Contact
+
+client = TestClient(app)
+
+SENDER_ADDRESS = "notify-case@example.com"
+PAYLOAD = {
+    "name": "Ada Lovelace",
+    "email": SENDER_ADDRESS,
+    "subject": "Analytical engine",
+    "message": "Interested in your notes.",
+}
+
+
+@pytest.fixture(autouse=True)
+def unlimited():
+    """Take this module out of the shared 5/hour bucket. See the docstring."""
+    limiter.enabled = False
+    yield
+    limiter.enabled = True
+
+
+@pytest.fixture(autouse=True)
+def clean_contact_rows(db):
+    """Drop the rows these cases insert.
+
+    Before as well as after: every case here asserts on exactly one row for
+    this address, so a run that dies part-way would otherwise make the next one
+    fail on a leftover rather than on anything real.
+    """
+    def _drop():
+        db.query(Contact).filter(Contact.email == SENDER_ADDRESS).delete(
+            synchronize_session=False
+        )
+        db.commit()
+
+    _drop()
+    yield
+    _drop()
+
+
+@pytest.fixture
+def smtp_configured(monkeypatch):
+    """Credentials good enough for `contact_notifications_enabled` to be True."""
+    monkeypatch.setattr(settings, "CONTACT_NOTIFY_ENABLED", True)
+    monkeypatch.setattr(settings, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(settings, "SMTP_USER", "owner@example.com")
+    monkeypatch.setattr(settings, "SMTP_PASSWORD", "app-password")
+    monkeypatch.setattr(settings, "EMAILS_FROM_EMAIL", "")
+    monkeypatch.setattr(settings, "CONTACT_NOTIFY_TO", "")
+
+
+@pytest.fixture
+def smtp():
+    """Patch the transport. Yields the server object the code sends through.
+
+    ``send_email`` uses ``with smtplib.SMTP(...)``, so the object under test is
+    the one the context manager returns, not the constructor's return value.
+    """
+    with patch("app.services.email_service.smtplib.SMTP") as constructor:
+        server = MagicMock()
+        constructor.return_value.__enter__.return_value = server
+        yield constructor, server
+
+
+def _stored(db):
+    return db.query(Contact).filter(Contact.email == SENDER_ADDRESS).one()
+
+
+def test_notification_is_sent_for_a_new_message(db, smtp_configured, smtp):
+    constructor, server = smtp
+    response = client.post("/api/v1/contacts/", json=PAYLOAD)
+
+    assert response.status_code == 201
+    assert _stored(db).subject == PAYLOAD["subject"]
+
+    constructor.assert_called_once_with(
+        "smtp.example.com", settings.SMTP_PORT, timeout=settings.SMTP_TIMEOUT
+    )
+    server.starttls.assert_called_once()
+    server.login.assert_called_once_with("owner@example.com", "app-password")
+
+    sent = server.send_message.call_args.args[0]
+    # Sent to the owner, not to whoever filled in the form.
+    assert sent["To"] == "owner@example.com"
+    # Replying answers the visitor. Without this the owner replies to themselves.
+    assert sent["Reply-To"] == SENDER_ADDRESS
+    assert PAYLOAD["subject"] in sent["Subject"]
+    assert PAYLOAD["message"] in sent.get_content()
+    assert PAYLOAD["name"] in sent.get_content()
+
+
+def test_message_is_saved_when_smtp_fails(db, caplog, smtp_configured, smtp):
+    """The write must not depend on the notification. This is the whole design.
+
+    A mail outage that lost contact messages would be worse than no notification
+    at all, because it would be invisible from both ends: the visitor sees a
+    success, the owner sees nothing, and there is no row to reconcile from.
+    """
+    constructor, _ = smtp
+    constructor.side_effect = smtplib.SMTPAuthenticationError(535, b"nope")
+
+    with caplog.at_level("ERROR"):
+        response = client.post("/api/v1/contacts/", json=PAYLOAD)
+
+    assert response.status_code == 201
+    stored = _stored(db)
+    assert stored.message == PAYLOAD["message"]
+
+    # Failing quietly is the actual risk here — a swallowed exception looks
+    # exactly like a working mailer nobody has emailed yet.
+    assert f"contact id={stored.id}" in caplog.text
+    assert "SMTPAuthenticationError" in caplog.text
+
+
+def test_notification_is_off_without_credentials(db, monkeypatch, smtp):
+    """CI has no SMTP server and sets no secret. It must still be green."""
+    constructor, _ = smtp
+    monkeypatch.setattr(settings, "SMTP_USER", "")
+    monkeypatch.setattr(settings, "SMTP_PASSWORD", "")
+
+    response = client.post("/api/v1/contacts/", json=PAYLOAD)
+
+    assert response.status_code == 201
+    assert _stored(db)
+    constructor.assert_not_called()
+
+
+def test_notification_can_be_switched_off_with_credentials(
+    db, smtp_configured, smtp, monkeypatch
+):
+    """The kill switch works without having to remove working credentials."""
+    constructor, _ = smtp
+    monkeypatch.setattr(settings, "CONTACT_NOTIFY_ENABLED", False)
+
+    response = client.post("/api/v1/contacts/", json=PAYLOAD)
+
+    assert response.status_code == 201
+    assert _stored(db)
+    constructor.assert_not_called()
+
+
+def test_notification_goes_to_the_configured_recipient(smtp_configured, smtp, monkeypatch):
+    """CONTACT_NOTIFY_TO wins over the from-address fallback."""
+    _, server = smtp
+    monkeypatch.setattr(settings, "CONTACT_NOTIFY_TO", "inbox@example.com")
+
+    assert client.post("/api/v1/contacts/", json=PAYLOAD).status_code == 201
+
+    assert server.send_message.call_args.args[0]["To"] == "inbox@example.com"
+
+
+def test_from_header_falls_back_to_the_smtp_account(smtp_configured, smtp):
+    """EMAILS_FROM_EMAIL is empty in the real .env, and `Name <>` is rejected."""
+    _, server = smtp
+
+    assert client.post("/api/v1/contacts/", json=PAYLOAD).status_code == 201
+
+    assert server.send_message.call_args.args[0]["From"] == (
+        f"{settings.EMAILS_FROM_NAME} <owner@example.com>"
+    )


### PR DESCRIPTION
A contact message was stored and nothing happened. Finding out that someone had
written required querying the database, so the real latency on a submission was
however long until somebody thought to look.

## The request does not wait for SMTP

`POST /contacts/` saves the row, then hands the send to a `BackgroundTask`. A
database insert has a bounded cost; an SMTP round trip does not, and the visitor
should not spend `SMTP_TIMEOUT` seconds watching a spinner to learn their message
was in fact saved.

Verified against a socket that accepts the connection and then never replies:
the 201 came back in 1.8-3.0s, the same as three control submissions with
notifications switched off, while each send sat there for its full five-second
timeout and then logged. The remaining seconds are Neon round trips, and were
there before this change.

`TestClient` runs background tasks inline, so no test can make that claim — it
needed a real server, which is why the numbers above come from one.

## A write may not hide its errors

If SMTP fails, the row still stands, the response is still a 201, and the
failure is logged at `exception` level with the contact id.

This is deliberately the mirror image of `apps/web/lib/api.ts`. A read hides its
failure behind a fallback because the visitor cannot act on it. A write must not,
because the operator can — and a mail outage that also lost messages would be
invisible from both ends: the visitor sees success, the owner sees nothing, and
there is no row left to reconcile from. `test_message_is_saved_when_smtp_fails`
asserts the row, the 201 and the log line together, since a swallowed exception
looks exactly like a working mailer nobody has emailed yet.

## Off by default, and CI needs no secret

`contact_notifications_enabled` requires `CONTACT_NOTIFY_ENABLED` **and** real
credentials. The switch is explicit, but the effective default is off: a fresh
clone and the `api` CI job send nothing without setting anything. Confirmed by
running the suite with the credentials blanked. `CONTACT_NOTIFY_ENABLED=False`
turns it off without deleting working credentials.

## One SMTP block instead of two

`auth_service` had its own copy for verification and reset mail. Both now go
through `app/services/email_service.py`, where `send_email` raises and each
caller decides what that means — `auth_service` keeps swallowing exactly as
before, so those flows do not start 500ing on a mail outage, but the failure now
reaches the logger instead of `print`, where nothing was collecting it.

Three things were wrong in the copy that was there:

- No connection timeout. `smtplib` has none by default, so a dead host hung the
  caller until the process restarted. Now `SMTP_TIMEOUT`, default 10s.
- `server.quit()` was the line after the one that could throw, so a failed
  `login()` or `send_message()` leaked the connection. It is a `with` block now.
- `EMAILS_FROM_EMAIL` is blank in the real `.env` — it is the one SMTP setting
  with no obvious value to paste in — and blank reached the header verbatim as
  `Portfolio Contact <>`, which Gmail rejects. It falls back to `SMTP_USER`.

Notifications also set `Reply-To` to the visitor, so replying in the mail client
answers them rather than yourself.

## Tests

93 pass, up from 87. Six new, none of which touch the network: the send path
including recipient, `Reply-To` and the `From` fallback; SMTP failing with the
row surviving; no credentials; and the kill switch with credentials present.

The module switches the limiter off for its own cases. `POST /contacts/` is
capped at 5/hour on a process-wide bucket shared by the whole session, and these
cases need real 201s — spending four slots would have broken the `codes[0] == 201`
assertion in `test_security.py`, which sorts after this file. Disabling leaves
the bucket exactly as it was found; resetting would not have.

`.env.example` documents the new keys. No real values are committed.

## Not in scope

Rate limiting and `client_ip` are untouched (#20). This is separate from the
cutover, as agreed — the site a recruiter sees is still the old one until that
lands.