### PR TITLE
build(api): containerise for Fly.io, and make the app's logs visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ blob-report/
 *.njsproj
 *.sln
 *.sw?
+# Vercel CLI link metadata, and the .env.local it writes when linking. Both are
+# per-developer, not shared. `vercel link` appends its own entries here and its
+# suggestion is `.env*`, which is too broad for this repo: it matches the
+# .env.example files that are meant to be committed.
+.vercel
+.env
+.env.*
+!.env.example

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,29 @@
+# The first entry is the only one that matters for safety: .env holds the Neon
+# URL, the JWT signing key and the SMTP app password. Docker COPY does not
+# consult .gitignore, so without this line `COPY . .` bakes all three into an
+# image layer — readable by anyone who can pull it, and still there after a
+# later layer deletes the file.
+.env
+.env.*
+!.env.example
+
+.venv/
+venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+
+# Tests and their fixtures are not needed to serve traffic, and the suite talks
+# to a real database — nothing that runs it should be in the image.
+tests/
+scripts/
+
+.git/
+.gitignore
+README.md
+Procfile
+runtime.txt
+fly.toml
+Dockerfile
+.dockerignore

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,45 @@
+# Fly.io runs containers, so this replaces the buildpack that Procfile and
+# runtime.txt were written for. Python 3.11 to match runtime.txt and the CI job
+# — the point of pinning the minor version is that a syntax or stdlib feature
+# which works on the 3.13 installed locally cannot reach production untested.
+FROM python:3.11-slim
+
+# PYTHONUNBUFFERED matters more than it looks: without it the interpreter block-
+# buffers stdout when it is a pipe rather than a terminal, so `fly logs` shows
+# nothing until 8KB has accumulated. The failure that most needs a log line —
+# a crash at startup — is exactly the one that never produces enough output.
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Dependencies before source, so editing a Python file does not re-run pip.
+# psycopg2-binary ships a manylinux wheel, so no build toolchain is needed here;
+# switching to plain psycopg2 would mean adding gcc and libpq-dev.
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY alembic.ini .
+COPY alembic/ alembic/
+COPY app/ app/
+
+# Nothing here needs root, and a container that never writes to its own
+# filesystem should not be able to.
+RUN useradd --create-home --uid 1000 api && chown -R api:api /app
+USER api
+
+EXPOSE 8080
+
+# Migrations are NOT run here — see the header of Procfile for why. fly.toml
+# runs them as a release_command, on a separate machine, before this starts.
+#
+# --proxy-headers so request.client.host is the visitor rather than Fly's edge.
+# app/core/rate_limit.py reads X-Forwarded-For itself in production, but its
+# fallback and every access log line go through request.client.
+CMD ["uvicorn", "app.main:app", \
+     "--host", "0.0.0.0", \
+     "--port", "8080", \
+     "--proxy-headers", \
+     "--forwarded-allow-ips", "*"]

--- a/apps/api/Procfile
+++ b/apps/api/Procfile
@@ -1,3 +1,8 @@
+# Not the active deploy path. Fly.io builds the Dockerfile beside this file and
+# takes its settings from fly.toml. Kept because this plus runtime.txt is all a
+# buildpack host (Railway, Render) needs, so switching back is a decision rather
+# than a rewrite.
+#
 # Migrations are deliberately NOT run here. Chaining `alembic upgrade head &&`
 # into the web process means a failed migration takes every instance down with
 # no way back, and concurrent instances race for the migration lock on rollouts.

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -12,6 +12,17 @@ from app.core.config import settings
 from app.core.database import engine
 from app.core.rate_limit import limiter
 
+# Uvicorn configures handlers for its own loggers and nothing else, so the
+# application's loggers had none, and Python fell back to logging.lastResort —
+# a stderr handler fixed at WARNING. Errors did still come out; every
+# logger.info() in this codebase was discarded. That is why "Database reachable"
+# below produced no output under `docker logs`, which matters more now that the
+# logs are the only view of this process there is.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
 logger = logging.getLogger(__name__)
 
 

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -7,10 +7,19 @@
 
 app = "khoi-portfolio-api"
 
-# Singapore is the closest region to both the owner and the Neon database.
-# Latency to the database is on the critical path of every request; latency to
-# Vercel's build machines is not, since content is fetched at build time.
-primary_region = "sin"
+# us-east, because that is where the callers are — and no visitor is one of
+# them. apps/web/lib/api.ts is `server-only`, so the browser never contacts
+# this API: every request comes from a Vercel build, an ISR revalidation or the
+# contact Server Action, all of which run in Vercel's us-east region. The Neon
+# database is in us-east-2 as well.
+#
+# This was first deployed to Singapore on the theory that being near the owner
+# mattered. It does not, and it cost. Measured from inside the machine,
+# /api/v1/projects/ answers in 51ms here (median of 6, max 140ms). From sin the
+# same endpoint took ~0.84s measured from a client in Vietnam, with one sample
+# at 3.08s — against the 5s budget in lib/api.ts, because every database round
+# trip was crossing the Pacific to reach Neon in us-east-2.
+primary_region = "iad"
 
 [build]
 

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -1,0 +1,59 @@
+# Fly.io deployment for the content API.
+#
+# Nothing secret belongs in this file — it is committed. DATABASE_URL,
+# SECRET_KEY and the SMTP credentials are set with `fly secrets set`, which
+# stores them encrypted and injects them as environment variables at boot.
+# pydantic-settings reads them the same way it reads .env locally.
+
+app = "khoi-portfolio-api"
+
+# Singapore is the closest region to both the owner and the Neon database.
+# Latency to the database is on the critical path of every request; latency to
+# Vercel's build machines is not, since content is fetched at build time.
+primary_region = "sin"
+
+[build]
+
+[deploy]
+  # A separate, short-lived machine runs this before any new version takes
+  # traffic; if it exits non-zero the deploy is aborted and the old version
+  # keeps serving. That is the whole reason migrations are not in the Dockerfile
+  # CMD — see the header of Procfile.
+  release_command = "python -m alembic upgrade head"
+
+[env]
+  # Switches /docs and /redoc off, and makes app/core/rate_limit.py trust
+  # X-Forwarded-For — which is correct here and only here, because Fly's proxy
+  # is what sets it. Without this every visitor shares one rate-limit bucket
+  # and five contact submissions lock the form for everyone.
+  ENVIRONMENT = "production"
+  DEBUG = "False"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+
+  # Always on, deliberately. Fly can stop idle machines and start them on the
+  # next request, which would cut the bill to well under a dollar — but
+  # apps/web/lib/api.ts gives up on a read after 5s and the contact form's
+  # Server Action after 8s, and Fly does not document how long a cold start
+  # takes. Saving ~$1.50/month by betting the contact form on an undocumented
+  # number is the wrong trade for the one page a recruiter might actually use.
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  # Hits the root route, which returns a static JSON body and touches no
+  # database. A health check that queried Postgres would fail whenever Neon
+  # scaled its compute to zero, and Fly would restart a perfectly healthy app.
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "15s"
+    method = "GET"
+    path = "/"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
First half of the cutover. This is the config that lets the API be deployed; the
deploy itself and the Vercel `API_URL` switch follow once the app exists.

## Why Fly, in one line

The decision was not about price but about cold start against two numbers already
hardcoded in this repo: `lib/api.ts` gives up on a read after **5s**, and the
contact form's Server Action after **8s**. Render's free tier sleeps after 15
minutes and takes about a minute to wake, which misses both — a visitor arriving
cold would get the outage notice on the contact form, and the ISR revalidation
would cache an empty page for the next 5 minutes. Fly at ~$2.02/month for a
256MB always-on machine has no cold start to lose to.

## What was verified, and how

Built the image and ran it against the real database, not just `docker build`:

- `GET /api/v1/projects/` → 200 in 0.73s with real content
- `GET /` → 200 in 0.05s
- `/docs` and `/api/v1/openapi.json` → 404 under `ENVIRONMENT=production`
- runs as uid 1000, not root
- image is 208MB

## .dockerignore is the load-bearing file here

`COPY` does not consult `.gitignore`. Without it, `apps/api/.env` — the Neon URL,
the JWT signing key and the SMTP app password — is baked into an image layer,
readable by anyone who can pull it and still present after a later layer deletes
it. Confirmed absent: `find / -name .env` inside the built image returns nothing.

## auto_stop_machines is off on purpose

Fly can stop idle machines and start them on demand, which would take this under
$0.50/month. Fly does not document how long that start takes, and the two
timeouts above are what would pay for a wrong guess. Saving ~$1.50/month by
betting the contact form on an undocumented number is the wrong trade.

Migrations run as a `release_command` on a separate machine — the reasoning was
already written at the top of `Procfile` and now has somewhere to apply.

## The logging change

Not planned; found while reading `docker logs` and noticing the app had produced
no lines of its own. Uvicorn configures handlers for its own loggers and nothing
else, so the application's loggers had none and Python fell back to
`logging.lastResort`, a stderr handler fixed at WARNING. Errors did come out.
Every `logger.info()` in this codebase was dropped — `"Database reachable"` in
the lifespan had never once printed. In a container that is nearly all the
visibility there is.

Three lines of `basicConfig` in `app/main.py`. `docker logs` now shows
`2026-08-09 12:35:26,115 INFO app.main: Database reachable`.

Note the two classes in `app/api/v1/middleware.py` are still dead code — they are
defined and never wired in, for the CORS reason documented at the bottom of that
file. This change does not resurrect them.

## Vercel

`apps/web/vercel.json` pins `framework: nextjs` from the repo. The project is
currently set to `vite` in the dashboard, which is why every deploy since #19 has
built Next and then gone looking for `dist`. Pinning it in a committed file means
the setting is reviewable rather than a thing someone remembers.

Two dashboard steps remain and are not code: Root Directory → `apps/web`, and the
`API_URL` environment variable once the Fly app has a hostname.

## Not deployed yet

`fly.toml` names the app `khoi-portfolio-api`; if that name is taken the file
changes with it. Nothing here is live until `fly deploy` runs and `API_URL` is
pointed at it, and the old Vite site keeps serving until then.

87 tests pass, ruff clean.