### PR TITLE
feat(api): send the contact notification as HTML, in the site's own palette

### DIFF
--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -22,21 +22,40 @@ because the operator can.
 import logging
 import smtplib
 from email.message import EmailMessage
+from html import escape
+from urllib.parse import quote
 
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
 
-def send_email(to_email: str, subject: str, body: str, *, reply_to: str | None = None) -> None:
-    """Send one plain-text message. Raises on any SMTP failure."""
+def send_email(
+    to_email: str,
+    subject: str,
+    body: str,
+    *,
+    reply_to: str | None = None,
+    html: str | None = None,
+) -> None:
+    """Send one message. Raises on any SMTP failure.
+
+    ``body`` is the plain-text part and is never optional. Passing ``html`` adds
+    it as an alternative rather than a replacement: the result is
+    multipart/alternative, and a client that cannot or will not render HTML —
+    a terminal reader, a screen reader set to prefer text, Gmail's "plain text
+    only" — still gets the whole message rather than a blank one.
+    """
     message = EmailMessage()
     message["From"] = f"{settings.EMAILS_FROM_NAME} <{settings.emails_from_address}>"
     message["To"] = to_email
     message["Subject"] = subject
     if reply_to:
         message["Reply-To"] = reply_to
+
     message.set_content(body)
+    if html:
+        message.add_alternative(html, subtype="html")
 
     # `with` rather than an explicit quit(): the old version leaked the
     # connection whenever login() or send_message() raised, because quit() was
@@ -48,6 +67,139 @@ def send_email(to_email: str, subject: str, body: str, *, reply_to: str | None =
             server.starttls()
         server.login(settings.SMTP_USER, settings.SMTP_PASSWORD)
         server.send_message(message)
+
+
+# Lifted from apps/web/app/globals.css so the mail and the site are visibly the
+# same thing. Resolved to hex here because no mail client evaluates a CSS custom
+# property, and several still drop a `<style>` block entirely — every rule below
+# is inline for the same reason.
+_BACKGROUND = "#ebfaeb"  # --background   120 60% 95%
+_CARD = "#ffffff"  # --card         0 0% 100%
+_INK = "#0f1729"  # --foreground   222 47% 11%
+_PRIMARY = "#1c721c"  # --primary      120 60% 28%
+_BORDER = "#c2d6c2"  # --border       120 20% 80%
+_MUTED = "#586a84"  # --muted-foreground 215.4 20% 43%
+
+# Space Grotesk and IBM Plex are webfonts, and a webfont in an email is a
+# request most clients refuse. The stacks fall back to what the reading device
+# already has; the *roles* survive even when the exact faces do not.
+_SANS = "'Space Grotesk','Segoe UI',Roboto,Helvetica,Arial,sans-serif"
+_MONO = "'IBM Plex Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace"
+
+
+def _notification_text(*, name: str, email: str, subject: str, message: str) -> str:
+    """The plain-text part. Also the whole message for anyone who prefers text."""
+    return (
+        f"New message from the portfolio contact form.\n\n"
+        f"From:    {name} <{email}>\n"
+        f"Subject: {subject}\n\n"
+        f"{message}\n"
+    )
+
+
+def _notification_html(*, name: str, email: str, subject: str, message: str) -> str:
+    """The HTML part.
+
+    Every interpolated value goes through ``escape`` first, and that is not a
+    formality: all four come from a public form that anyone on the internet can
+    submit. Without it a name of ``<img src=x onerror=...>`` is markup in a mail
+    the owner opens, and the closing ``</td>`` in a message body would be enough
+    to take the layout apart by accident.
+
+    Tables and inline styles rather than flexbox and a stylesheet, because
+    Outlook renders mail through Word's HTML engine, which supports neither.
+    """
+    safe_name = escape(name)
+    safe_email = escape(email)
+    safe_subject = escape(subject)
+    # Escape first, then add the breaks — the other order would turn a literal
+    # "<br>" typed by a visitor into a real line break.
+    safe_message = escape(message).replace("\n", "<br>")
+
+    # Shown by the inbox list next to the subject, and hidden in the message
+    # itself. Without one, clients fill that space with whatever text comes
+    # first, which here would be the words "New message from the portfolio
+    # contact form" on every single mail.
+    preheader = escape(message[:120].replace("\n", " "))
+
+    return f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light">
+<title>{safe_subject}</title>
+</head>
+<body style="margin:0;padding:0;background:{_BACKGROUND};">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">{preheader}</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+       style="background:{_BACKGROUND};padding:32px 16px;">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+             style="max-width:560px;background:{_CARD};border:1px solid {_BORDER};
+                    border-radius:12px;overflow:hidden;">
+        <tr>
+          <td style="padding:28px 28px 0 28px;">
+            <p style="margin:0 0 6px 0;font-family:{_MONO};font-size:11px;
+                      letter-spacing:0.12em;text-transform:uppercase;color:{_PRIMARY};">
+              New contact message
+            </p>
+            <h1 style="margin:0;font-family:{_SANS};font-size:20px;line-height:1.35;
+                       font-weight:600;color:{_INK};">
+              {safe_subject}
+            </h1>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 28px 0 28px;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                   style="font-family:{_MONO};font-size:13px;color:{_MUTED};">
+              <tr>
+                <td style="padding:0 12px 6px 0;white-space:nowrap;">from</td>
+                <td style="padding:0 0 6px 0;color:{_INK};">{safe_name}</td>
+              </tr>
+              <tr>
+                <td style="padding:0 12px 0 0;white-space:nowrap;">email</td>
+                <td style="padding:0;">
+                  <a href="mailto:{safe_email}"
+                     style="color:{_PRIMARY};text-decoration:underline;">{safe_email}</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 28px 4px 28px;">
+            <div style="border-top:1px solid {_BORDER};padding-top:20px;
+                        font-family:{_SANS};font-size:15px;line-height:1.6;color:{_INK};">
+              {safe_message}
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 28px 28px 28px;">
+            <a href="mailto:{safe_email}?subject=Re:%20{quote(subject)}"
+               style="display:inline-block;background:{_PRIMARY};color:#ffffff;
+                      font-family:{_SANS};font-size:14px;font-weight:600;
+                      text-decoration:none;padding:10px 18px;border-radius:8px;">
+              Reply to {safe_name}
+            </a>
+          </td>
+        </tr>
+      </table>
+      <p style="max-width:560px;margin:16px auto 0 auto;font-family:{_MONO};
+                font-size:11px;line-height:1.6;color:{_MUTED};text-align:center;">
+        Sent by the contact form on khoipham.vercel.app.<br>
+        Replying to this mail answers {safe_name} directly.
+      </p>
+    </td>
+  </tr>
+</table>
+</body>
+</html>
+"""
 
 
 def send_contact_notification(
@@ -71,12 +223,8 @@ def send_contact_notification(
         logger.debug("Contact notification skipped (disabled or no SMTP credentials)")
         return
 
-    body = (
-        f"New message from the portfolio contact form.\n\n"
-        f"From:    {name} <{email}>\n"
-        f"Subject: {subject}\n\n"
-        f"{message}\n"
-    )
+    body = _notification_text(name=name, email=email, subject=subject, message=message)
+    html = _notification_html(name=name, email=email, subject=subject, message=message)
 
     try:
         send_email(
@@ -87,6 +235,7 @@ def send_contact_notification(
             # Safe to interpolate: EmailStr has already rejected the newlines a
             # header-injection attempt would need.
             reply_to=email,
+            html=html,
         )
     except Exception:
         logger.exception(

--- a/apps/api/tests/test_contact_notification.py
+++ b/apps/api/tests/test_contact_notification.py
@@ -115,8 +115,80 @@ def test_notification_is_sent_for_a_new_message(db, smtp_configured, smtp):
     # Replying answers the visitor. Without this the owner replies to themselves.
     assert sent["Reply-To"] == SENDER_ADDRESS
     assert PAYLOAD["subject"] in sent["Subject"]
-    assert PAYLOAD["message"] in sent.get_content()
-    assert PAYLOAD["name"] in sent.get_content()
+
+    text = sent.get_body(preferencelist=("plain",)).get_content()
+    assert PAYLOAD["message"] in text
+    assert PAYLOAD["name"] in text
+
+
+def test_mail_carries_both_a_text_and_an_html_part(smtp_configured, smtp):
+    """HTML is an alternative, not a replacement.
+
+    A client that will not render HTML — a terminal reader, or Gmail set to
+    plain text — must still get the message rather than an empty body. Asserting
+    the multipart type is not enough on its own: a message with only an HTML
+    part and no text one would still be a valid multipart/alternative.
+    """
+    _, server = smtp
+
+    assert client.post("/api/v1/contacts/", json=PAYLOAD).status_code == 201
+
+    sent = server.send_message.call_args.args[0]
+    assert sent.get_content_type() == "multipart/alternative"
+
+    text = sent.get_body(preferencelist=("plain",))
+    html = sent.get_body(preferencelist=("html",))
+    assert text is not None and html is not None
+    assert PAYLOAD["message"] in text.get_content()
+    assert PAYLOAD["subject"] in html.get_content()
+
+
+def test_html_escapes_what_the_visitor_typed(smtp_configured, smtp):
+    """All four fields come from a form anyone on the internet can post to.
+
+    Unescaped, a name of `<img src=x onerror=...>` is markup in a mail the owner
+    opens, and a stray `</td>` in a message body takes the layout apart by
+    accident. Mail clients strip most of it, which is exactly why this is easy
+    to leave broken and not notice.
+    """
+    _, server = smtp
+    hostile = {
+        **PAYLOAD,
+        "name": "<script>alert(1)</script>",
+        "subject": "Sales & <b>marketing</b>",
+        "message": "before</td></table>after",
+    }
+
+    assert client.post("/api/v1/contacts/", json=hostile).status_code == 201
+
+    html = server.send_message.call_args.args[0].get_body(preferencelist=("html",)).get_content()
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "Sales &amp; &lt;b&gt;marketing&lt;/b&gt;" in html
+    assert "</td></table>after" not in html
+    assert "&lt;/td&gt;&lt;/table&gt;after" in html
+
+
+def test_newlines_in_the_message_survive_as_line_breaks(smtp_configured, smtp):
+    """A paragraph typed as three lines should not arrive as one.
+
+    The escape has to happen first: escaping after inserting the `<br>` tags
+    would escape those too, and doing it in that order is the obvious mistake.
+    So a visitor who literally types `<br>` must see it as text.
+    """
+    _, server = smtp
+
+    assert (
+        client.post(
+            "/api/v1/contacts/", json={**PAYLOAD, "message": "one\ntwo\nliteral <br> here"}
+        ).status_code
+        == 201
+    )
+
+    html = server.send_message.call_args.args[0].get_body(preferencelist=("html",)).get_content()
+
+    assert "one<br>two<br>literal &lt;br&gt; here" in html
 
 
 def test_message_is_saved_when_smtp_fails(db, caplog, smtp_configured, smtp):


### PR DESCRIPTION
The notification worked and read like a cron job reporting in:

```
New message from the portfolio contact form.

From:    Sarah Chen <sarah.chen@northwind.io>
Subject: Backend engineer role at Northwind
```

Now it is `multipart/alternative`, using the resolved values of the tokens in
`apps/web/app/globals.css` — the same green, the same ink, mono for the meta
rows and sans for the message — so the mail and the site are recognisably one
thing.

## The text part did not go away

HTML is an *alternative*, not a replacement. A terminal reader, a screen reader
set to prefer text, or Gmail in plain-text mode gets the full message rather
than an empty body. `test_mail_carries_both_a_text_and_an_html_part` asserts
both parts exist and both carry content — asserting the multipart type alone
would pass for a message with an HTML part and nothing else.

## Escaping is the part that is not decoration

All four fields come from a form anyone on the internet can post to. Unescaped,
a name of `<img src=x onerror=...>` is markup in a mail the owner opens, and a
stray `</td>` in a message body takes the layout apart with nobody intending
anything. Mail clients strip most of it, which is precisely why this is easy to
leave broken and never notice.

`escape` runs **before** newlines become `<br>`. The other order escapes the
tags it just inserted, and it is the obvious mistake to make — so a visitor
typing a literal `<br>` is a test case.

## Why tables and inline styles

Outlook renders mail through Word's HTML engine: no flexbox, no grid. Several
clients drop a `<style>` block entirely, so every rule is inline. And no client
evaluates a CSS custom property, so the tokens are resolved to hex here with the
HSL they came from in a comment beside each one.

A preheader was added too. Without one the inbox list fills that space with
whatever text comes first — which was "New message from the portfolio contact
form" on every single mail. It now shows the opening of what the person wrote.

## Verified by looking at it

Rendered in a browser and checked at 560px and at mobile width; computed styles
confirmed against the tokens rather than eyeballed. Then sent through Gmail with
real SMTP credentials and read in the inbox, because a string assertion cannot
tell you an email looks like a machine wrote it.

96 tests pass, ruff clean.