### PR TITLE
feat(web): scale the layout to the screen it is actually viewed on

### DIFF
--- a/apps/web/app/career-journey/page.tsx
+++ b/apps/web/app/career-journey/page.tsx
@@ -14,7 +14,14 @@ export default async function CareerJourneyPage() {
   const entries = await getCareerEntries();
 
   return (
-    <Section level="h1" eyebrow="Career" title="Where I have worked and studied">
+    <Section
+      level="h1"
+      // layout so the page shares the nav's outer edge; the max-w on the list
+      // keeps the highlight lines at a reading measure inside it.
+      width="layout"
+      eyebrow="Career"
+      title="Where I have worked and studied"
+    >
       {entries.length === 0 ? (
         <EmptyState>No career entries published yet.</EmptyState>
       ) : (
@@ -23,7 +30,7 @@ export default async function CareerJourneyPage() {
          * history is genuinely a sequence — the order carries meaning a reader
          * needs. Projects are not, which is why they are an unordered grid.
          */
-        <ol className="relative space-y-12 border-l border-border pl-7">
+        <ol className="relative max-w-3xl space-y-12 border-l border-border pl-7">
           {entries.map((entry) => (
             <li key={entry.id} className="relative">
               <span

--- a/apps/web/app/certificates/page.tsx
+++ b/apps/web/app/certificates/page.tsx
@@ -19,13 +19,16 @@ export default async function CertificatesPage() {
   return (
     <Section
       level="h1"
+      width="layout"
       eyebrow={`Certificates · ${certificates.length}`}
       title="Courses and certifications"
     >
       {certificates.length === 0 ? (
         <EmptyState>No certificates published yet.</EmptyState>
       ) : (
-        <div className="grid gap-6 sm:grid-cols-2">
+        // A dangling odd card spans the row — a half-filled last row reads as
+        // missing data. Three columns at lg, same as the project grid.
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 sm:max-lg:[&>*:nth-child(odd):last-child]:col-span-2">
           {certificates.map((certificate) => (
             <Card key={certificate.id} className="gap-3">
               <div className="flex items-start justify-between gap-3">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -72,10 +72,24 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
         <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />
       </head>
       <body className="flex min-h-full flex-col font-sans">
+        {/*
+          First tab stop on every page. Without it a keyboard user walks all
+          five nav stops before any content — on the home page the form's
+          submit button was tab stop 23.
+        */}
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-[--radius-control] focus:border focus:border-border focus:bg-card focus:px-4 focus:py-3 focus:font-mono focus:text-xs focus:uppercase focus:tracking-[0.18em] focus:text-foreground"
+        >
+          Skip to content
+        </a>
         <SiteNav />
-        <main className="flex-1">{children}</main>
+        <main id="main" className="flex-1">{children}</main>
         <footer className="border-t border-border py-8">
-          <Container className="flex flex-col gap-1 text-center font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground sm:flex-row sm:justify-between sm:text-left">
+          <Container
+            width="layout"
+            className="flex flex-col gap-1 text-center font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground sm:flex-row sm:justify-between sm:text-left"
+          >
             <span>© {new Date().getFullYear()} Phạm Đăng Khôi</span>
             <span>Ho Chi Minh City, Vietnam</span>
           </Container>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -30,11 +30,16 @@ export default async function HomePage() {
 
   return (
     <>
-      <section className="py-16 sm:py-24">
-        <Container className="grid items-center gap-12 md:grid-cols-[1.1fr_1fr]">
+      <section className="py-20 sm:py-28 lg:py-36">
+        {/*
+          Two columns at lg, not md: at exactly 768px the h1 wraps against a
+          half-width diagram and both look cramped. Stacked-until-1024 gives
+          each its full measure instead.
+        */}
+        <Container width="layout" className="grid items-start gap-12 lg:grid-cols-[1.1fr_1fr]">
           <div>
             <Eyebrow>Backend · Data · AI</Eyebrow>
-            <h1 className="mt-4 font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            <h1 className="mt-4 font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
               Phạm Đăng Khôi
             </h1>
             <p className="mt-5 max-w-xl text-lg text-muted-foreground">
@@ -43,21 +48,36 @@ export default async function HomePage() {
               University, working in Python and Java, moving toward data and AI
               engineering.
             </p>
+            {/*
+              A status line, in the same dot-plus-mono shape the career timeline
+              uses: the one fact a recruiter scans for, styled as a health check
+              rather than a banner.
+            */}
+            <p className="mt-8 flex items-center gap-2.5 font-mono text-xs uppercase tracking-[0.18em] text-primary">
+              <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
+              Open to mid-level+ roles
+            </p>
           </div>
 
-          <HeroTopology className="justify-self-center md:justify-self-end" />
+          <HeroTopology className="justify-self-center lg:justify-self-stretch" />
         </Container>
       </section>
 
       <Section
         id="projects"
+        width="layout"
         eyebrow={`Projects · ${projects.length}`}
         title="Things I have built"
       >
         {projects.length === 0 ? (
           <EmptyState>No projects published yet.</EmptyState>
         ) : (
-          <div className="grid gap-6 sm:grid-cols-2">
+          /*
+            Three columns at lg keeps text-only cards at a readable width in the
+            layout container. In the two-column range a dangling odd card spans
+            the row — half-filled last rows read as missing data, not layout.
+          */
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 sm:max-lg:[&>*:nth-child(odd):last-child]:col-span-2">
             {projects.map((project) => (
               <ProjectCard key={project.id} project={project} />
             ))}
@@ -65,11 +85,17 @@ export default async function HomePage() {
         )}
       </Section>
 
-      <Section id="skills" eyebrow={`Skills · ${skills.length}`} title="What I work with">
+      <Section
+        id="skills"
+        tinted
+        width="layout"
+        eyebrow={`Skills · ${skills.length}`}
+        title="What I work with"
+      >
         {skills.length === 0 ? (
           <EmptyState>No skills published yet.</EmptyState>
         ) : (
-          <div className="grid gap-x-12 gap-y-10 sm:grid-cols-2">
+          <div className="grid gap-x-12 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
             {groupByCategory(skills).map(([category, entries]) => (
               <div key={category}>
                 <Eyebrow>{category}</Eyebrow>

--- a/apps/web/app/projects/[slug]/page.tsx
+++ b/apps/web/app/projects/[slug]/page.tsx
@@ -39,7 +39,7 @@ function DetailList({ title, items }: { title: string; items: string[] }) {
 
   return (
     <div>
-      <Eyebrow>{title}</Eyebrow>
+      <Eyebrow as="h2">{title}</Eyebrow>
       <ul className="mt-4 space-y-2.5">
         {items.map((item) => (
           <li key={item} className="flex gap-2.5 text-sm text-foreground">
@@ -103,7 +103,7 @@ export default async function ProjectPage({ params }: PageProps<"/projects/[slug
 
         {project.technologies.length > 0 ? (
           <>
-            <Eyebrow className="mt-10">Stack</Eyebrow>
+            <Eyebrow as="h2" className="mt-10">Stack</Eyebrow>
             <ul className="mt-4 flex flex-wrap gap-1.5">
               {project.technologies.map((tech) => (
                 <li key={tech}>

--- a/apps/web/components/contact-section.tsx
+++ b/apps/web/components/contact-section.tsx
@@ -31,7 +31,7 @@ export function ContactSection() {
       // where the text is under this component's control.
       eyebrow="Contact"
       title="Send me a message"
-      description="Open to internships and graduate roles in backend, data and AI engineering. Anything that lands here reaches my inbox."
+      description="Open to mid-level roles and above in backend, data and AI engineering. Anything that lands here reaches my inbox."
     >
       {/*
         A description list, because that is what this is: a stable key and its

--- a/apps/web/components/hero-topology.tsx
+++ b/apps/web/components/hero-topology.tsx
@@ -45,7 +45,10 @@ export function HeroTopology({ className }: { className?: string }) {
     <svg
       viewBox="0 0 400 240"
       aria-hidden="true"
-      className={cn("h-auto w-full max-w-md", className)}
+      // Capped only while the hero is a single column. Once the two-column
+      // grid is active the diagram fills its column — at that scale it reads
+      // as the architecture it depicts, not as an icon beside the text.
+      className={cn("h-auto w-full max-w-lg lg:max-w-none", className)}
     >
       {/* Static rails, so the graph still reads as connected when motion is off. */}
       {EDGES.map((edge) => (

--- a/apps/web/components/project-card.tsx
+++ b/apps/web/components/project-card.tsx
@@ -5,11 +5,26 @@ import { Card } from "@/components/ui/card";
 import { Eyebrow } from "@/components/ui/eyebrow";
 import { ExternalLink } from "@/components/ui/external-link";
 import { ProjectMedia } from "@/components/ui/project-media";
+import { cn } from "@/lib/cn";
 import { formatPeriod } from "@/lib/format";
-import type { Project } from "@/lib/types";
+import type { Project, ProjectStatus } from "@/lib/types";
 
 /** Beyond this the tag row wraps to three lines and swamps the card. */
 const VISIBLE_TAGS = 5;
+
+/*
+ * The card's top edge in the status colour — the same signal the StatusBadge
+ * carries, in a second position, the way a CI pipeline paints a build row.
+ * With no project images this is what makes a text-only card read as designed
+ * rather than as a card whose image failed to load. Spelled out per status
+ * because Tailwind scans source for complete class names.
+ */
+const STATUS_BORDER: Record<ProjectStatus, string> = {
+  completed: "border-t-green-700 dark:border-t-green-400",
+  in_progress: "border-t-blue-700 dark:border-t-blue-400",
+  on_hold: "border-t-yellow-700 dark:border-t-yellow-400",
+  dropped: "border-t-red-700 dark:border-t-red-400",
+};
 
 export function ProjectCard({ project }: { project: Project }) {
   const period = formatPeriod(project.started_on, project.ended_on);
@@ -17,7 +32,7 @@ export function ProjectCard({ project }: { project: Project }) {
   const overflow = project.technologies.length - shown.length;
 
   return (
-    <Card interactive className="gap-4">
+    <Card interactive className={cn("gap-4 border-t-2", STATUS_BORDER[project.status])}>
       <ProjectMedia
         slug={project.slug}
         title={project.title}

--- a/apps/web/components/section.tsx
+++ b/apps/web/components/section.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { Container } from "@/components/ui/container";
 import { Eyebrow } from "@/components/ui/eyebrow";
+import { cn } from "@/lib/cn";
 
 export function Section({
   id,
@@ -21,6 +22,13 @@ export function Section({
    * and stretching one to 5xl leaves a very long line and a lot of dead space.
    */
   width = "wide",
+  /**
+   * A one-step background tint. The page's sections were separated by nothing
+   * but a 1px rule, so four of them read as one undifferentiated column.
+   * Alternating a section onto `bg-muted` is the same convention as striping
+   * rows in a query result: it marks a layer boundary without decorating it.
+   */
+  tinted = false,
   children,
 }: {
   id?: string;
@@ -29,13 +37,20 @@ export function Section({
   title: string;
   description?: string;
   level?: "h1" | "h2";
-  width?: "wide" | "reading";
+  width?: "wide" | "layout" | "reading";
+  tinted?: boolean;
   children: ReactNode;
 }) {
   const Heading = level;
 
   return (
-    <section id={id} className="border-t border-border/60 py-16 sm:py-20">
+    <section
+      id={id}
+      className={cn(
+        "border-t border-border/60 py-16 sm:py-20 lg:py-24",
+        tinted && "bg-muted",
+      )}
+    >
       <Container width={width}>
         {eyebrow ? <Eyebrow className="mb-3">{eyebrow}</Eyebrow> : null}
         <Heading className="font-display text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">

--- a/apps/web/components/site-nav.tsx
+++ b/apps/web/components/site-nav.tsx
@@ -3,16 +3,19 @@ import Link from "next/link";
 import { ThemeToggle } from "./theme-toggle";
 import { Container } from "./ui/container";
 
+// `short` is the collapsed mobile label. Two letters, not one: "Career" and
+// "Certificates" share an initial, and a row reading P · C · C gives a sighted
+// thumb no way to tell the two apart.
 const LINKS = [
-  { href: "/#projects", label: "Projects" },
-  { href: "/career-journey", label: "Career" },
-  { href: "/certificates", label: "Certificates" },
+  { href: "/#projects", label: "Projects", short: "Pr" },
+  { href: "/career-journey", label: "Career", short: "Ca" },
+  { href: "/certificates", label: "Certificates", short: "Ce" },
 ];
 
 export function SiteNav() {
   return (
     <header className="sticky top-0 z-40 border-b border-border/60 bg-background/85 backdrop-blur">
-      <Container className="flex items-center justify-between gap-4 py-4">
+      <Container width="layout" className="flex items-center justify-between gap-4 py-3">
         <Link
           href="/"
           className="font-display font-semibold tracking-tight text-foreground"
@@ -32,15 +35,16 @@ export function SiteNav() {
             <Link
               key={link.href}
               href={link.href}
-              // Padding, not just text: a 12px label is not a tap target.
-              className="rounded-[--radius-control] px-2.5 py-2.5 font-mono text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:text-primary sm:px-3"
+              // min 44×44: padding around a 12px initial only reached 28×36,
+              // which is a routine thumb-miss on a phone.
+              className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-[--radius-control] px-2.5 font-mono text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:text-primary sm:px-3"
             >
               {/*
                 aria-hidden on the initial: without it the accessible name is
                 computed from both spans and reads "P Projects".
               */}
               <span aria-hidden="true" className="sm:hidden">
-                {link.label.charAt(0)}
+                {link.short}
               </span>
               <span className="sr-only sm:not-sr-only">{link.label}</span>
             </Link>

--- a/apps/web/components/ui/container.tsx
+++ b/apps/web/components/ui/container.tsx
@@ -9,13 +9,17 @@ import { cn } from "@/lib/cn";
  * the project detail page had drifted to `max-w-3xl` — so the site changed
  * width when you clicked into a project. Reading measure genuinely wants to be
  * narrower than a card grid, so that is a `width` prop rather than an accident.
+ *
+ * Three tiers: `layout` (7xl) for the shell and the sections that put cards or
+ * a diagram side by side — at 5xl those left a third of a 1500px screen empty.
+ * `wide` (5xl) for dense single-purpose grids, `reading` (2xl) for prose.
  */
 export function Container({
   width = "wide",
   className,
   children,
 }: {
-  width?: "wide" | "reading";
+  width?: "wide" | "layout" | "reading";
   className?: string;
   children: ReactNode;
 }) {
@@ -23,7 +27,11 @@ export function Container({
     <div
       className={cn(
         "mx-auto w-full px-5 sm:px-6",
-        width === "wide" ? "max-w-5xl" : "max-w-2xl",
+        width === "layout"
+          ? "max-w-7xl"
+          : width === "wide"
+            ? "max-w-5xl"
+            : "max-w-2xl",
         className,
       )}
     >

--- a/apps/web/components/ui/eyebrow.tsx
+++ b/apps/web/components/ui/eyebrow.tsx
@@ -20,11 +20,18 @@ export const eyebrowClasses =
   "font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground";
 
 export function Eyebrow({
+  as: Tag = "p",
   className,
   children,
 }: {
+  /**
+   * `h2` where the label is a real section heading — the project detail
+   * page's Stack/Features/Challenges labels are the only structure below its
+   * h1, and as <p> they were invisible to heading navigation.
+   */
+  as?: "p" | "h2";
   className?: string;
   children: ReactNode;
 }) {
-  return <p className={cn(eyebrowClasses, className)}>{children}</p>;
+  return <Tag className={cn(eyebrowClasses, className)}>{children}</Tag>;
 }

--- a/apps/web/components/ui/field.tsx
+++ b/apps/web/components/ui/field.tsx
@@ -19,7 +19,9 @@ import { cn } from "@/lib/cn";
  */
 
 const controlClasses = cn(
-  "w-full rounded-[--radius-control] border border-border bg-card px-3.5 py-2.5 text-sm text-foreground",
+  // min-h-11: py-2.5 around 14px text measures 41px — 3px under the 44px
+  // touch-target floor the buttons already meet.
+  "min-h-11 w-full rounded-[--radius-control] border border-border bg-card px-3.5 py-2.5 text-sm text-foreground",
   "transition-colors placeholder:text-muted-foreground/60 hover:border-primary/40",
   "aria-[invalid=true]:border-destructive",
   // No `focus:outline-none` here. It was written to "avoid fighting" the


### PR DESCRIPTION
## What this fixes (measured on production at 1497×950)

| Problem | Now |
|---|---|
| Content capped at 1024px — 236px dead each side | `layout` Container tier (1280px); nav, hero, grids and footer share one edge |
| Hero 457px with an empty lower half, small floating SVG | Two columns from `lg`, topology fills its column, availability status line |
| h1 only 48px | 60px at `lg` |
| 4 sections split by a single 1px rule | Skills sits on a `bg-muted` tint band; `lg:py-24` breathing room |
| Text-only cards read as unfinished | 2px status-coloured top edge — the StatusBadge signal in a second position |

## Also in this PR — from driving the live site with frontend-reviewer

- **Skip-to-content link** (first tab stop; submit button was tab stop 23)
- **Nav tap targets 44×44** (were 28×36) with distinct two-letter mobile labels (`Pr / Ca / Ce` — both C-pages collapsed to the same initial)
- Form inputs to 44px min-height
- Project detail Stack/Features/Challenges are real `h2`s (new `as` prop on Eyebrow); heading navigation works below the h1
- Project + certificate grids: 3-up at `lg`, dangling odd card spans its row in the 2-col range
- Availability copy now says **mid-level+ roles** (hero status line, contact description) per owner

## Deliberately not done

- `ProjectMedia` still returns null without an image — the status border is the answer to imageless cards; real images remain a content task (admin-UI plan is separate)
- `lib/api.ts` untouched; build verified green against a downed API (empty states render)
- No palette changes, no new client components (still exactly 3 `"use client"` files)

## Open questions for a future pass

- Reviewer flags the green-light/purple-dark brand split as a should-fix (a recruiter in dark mode sees a different-coloured site). Kept as-is — it is the site's most distinctive decision; owner's call.
- Dark `--primary` at 65% lightness measures 4.60:1 on cards — passes AA with 0.1 to spare; 67% would buy headroom.
- Hero bio and career DB entry still say "student" — stale now that the owner is mid-level; needs his wording.

## Verification

- frontend-reviewer drove the dev server at 1497×950 and 375×667, both themes: **no Blocking findings**; both Should-fixes (edge misalignment, C/C initials) fixed and re-verified
- Screenshotted every page in both modes; no horizontal overflow at 375px; reduced-motion kills the wire animation; one h1 per page
- 46 unit + 26 e2e tests green; production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)