### PR TITLE
feat(web): motion pass — hero boot sequence, live telemetry, zero client JS

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -49,6 +49,14 @@
   --font-display: var(--font-space-grotesk), ui-sans-serif, system-ui, sans-serif;
   --font-sans: var(--font-plex-sans), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-plex-mono), ui-monospace, monospace;
+
+  /*
+   * Motion tokens for the hero boot sequence — one duration, one easing,
+   * so every entering element arrives the same way. The easing decelerates
+   * hard: elements "arrive" rather than drift.
+   */
+  --dur-enter: 400ms;
+  --ease-enter: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /*
@@ -178,6 +186,118 @@
   }
 
   /*
+   * The hero boot sequence.
+   *
+   * One keyframe, one direction, applied to every entering element; the
+   * stagger comes from per-element animation-delay at the call site. The
+   * narrative is the site's subject: text registers, the topology's rails
+   * appear, nodes come online one by one, then data flows. `both` matters —
+   * it holds the `from` state through each element's delay, and under
+   * reduced motion (where the block below zeroes both duration and delay)
+   * it snaps everything straight to the resting state.
+   */
+  @keyframes hero-enter {
+    from {
+      opacity: 0;
+      translate: 0 10px;
+    }
+    to {
+      opacity: 1;
+      translate: 0 0;
+    }
+  }
+
+  .hero-item {
+    animation: hero-enter var(--dur-enter) var(--ease-enter) both;
+  }
+
+  /*
+   * The availability dot, in the vocabulary of a live-status indicator.
+   * 2.8s reads as calm telemetry, not urgency. Keyframe 0 is the fully
+   * visible state, so the single forced iteration under reduced motion
+   * leaves the dot resting visible at full size.
+   */
+  @keyframes status-pulse {
+    0%,
+    100% {
+      opacity: 1;
+      scale: 1;
+    }
+    50% {
+      opacity: 0.35;
+      scale: 0.7;
+    }
+  }
+
+  .status-dot {
+    animation: status-pulse 2.8s ease-in-out infinite;
+  }
+
+  /*
+   * Skill bars fill to their level as they scroll into view — a gauge
+   * coming up to reading, not a chart screenshot.
+   *
+   * The base rule always sets the final width, so the two guards fail
+   * closed: browsers without scroll-driven animations and users with
+   * reduced motion both get a full bar immediately. Nobody ever sees an
+   * empty bar.
+   */
+  /*
+   * Animates `scale`, not `width`: scroll-driven animation of layout
+   * properties silently fails to apply its before-entry state in current
+   * Chromium, so a width-based version never actually fills — it just sits
+   * at its final width. `scale` runs on the compositor and takes the
+   * percentage straight from --bar-w ("75%" reads as 0.75), so LEVEL_WIDTH
+   * stays the single source of the level scale.
+   */
+  @keyframes skill-fill {
+    from {
+      scale: 0 1;
+    }
+    to {
+      scale: var(--bar-w) 1;
+    }
+  }
+
+  .skill-bar-fill {
+    width: 100%;
+    transform-origin: left;
+    scale: var(--bar-w) 1;
+  }
+
+  @supports (animation-timeline: view()) {
+    @media (prefers-reduced-motion: no-preference) {
+      .skill-bar-fill {
+        animation: skill-fill linear both;
+        animation-timeline: view();
+        /* Finishes while the bar is still in the lower third — visible fill, no waiting. */
+        animation-range: entry 0% cover 35%;
+      }
+    }
+  }
+
+  /*
+   * Topology nodes respond to the pointer the way a service-mesh dashboard's
+   * do: the hovered node joins the data path's colour. Class selectors
+   * outrank SVG presentation attributes, so this overrides the inline
+   * stroke/fill without touching the markup. Sighted-only by design — the
+   * whole SVG is aria-hidden.
+   */
+  .topology-node rect,
+  .topology-node text {
+    transition: stroke 200ms, fill 200ms;
+  }
+
+  .topology-node:hover rect {
+    stroke: hsl(var(--primary));
+    fill: hsl(var(--primary) / 0.08);
+  }
+
+  .topology-node:hover text {
+    fill: hsl(var(--primary));
+  }
+
+  /*
    * Respect a reduced-motion preference for everything, including the smooth
    * scrolling above — vestibular triggers are not a per-component concern.
    */
@@ -190,6 +310,14 @@
     *::before,
     *::after {
       animation-duration: 0.01ms !important;
+      /*
+       * Delay too, not just duration: the boot sequence staggers elements up
+       * to ~750ms, and `hero-enter`'s fill-mode holds them invisible through
+       * their delay. Without this line a reduced-motion visitor would watch
+       * the hero pop in piece by piece — the exact choreography they asked
+       * not to see.
+       */
+      animation-delay: 0s !important;
       animation-iteration-count: 1 !important;
       transition-duration: 0.01ms !important;
     }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 import { ContactSection } from "@/components/contact-section";
 import { HeroTopology } from "@/components/hero-topology";
 import { ProjectCard } from "@/components/project-card";
@@ -38,11 +40,11 @@ export default async function HomePage() {
         */}
         <Container width="layout" className="grid items-start gap-12 lg:grid-cols-[1.1fr_1fr]">
           <div>
-            <Eyebrow>Backend · Data · AI</Eyebrow>
-            <h1 className="mt-4 font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+            <Eyebrow className="hero-item">Backend · Data · AI</Eyebrow>
+            <h1 className="hero-item mt-4 font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl [animation-delay:80ms]">
               Phạm Đăng Khôi
             </h1>
-            <p className="mt-5 max-w-xl text-lg text-muted-foreground">
+            <p className="hero-item mt-5 max-w-xl text-lg text-muted-foreground [animation-delay:180ms]">
               I build the parts you do not see: APIs, schemas, queues and the
               services between them. Software engineering student at FPT
               University, working in Python and Java, moving toward data and AI
@@ -53,8 +55,8 @@ export default async function HomePage() {
               uses: the one fact a recruiter scans for, styled as a health check
               rather than a banner.
             */}
-            <p className="mt-8 flex items-center gap-2.5 font-mono text-xs uppercase tracking-[0.18em] text-primary">
-              <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
+            <p className="hero-item mt-8 flex items-center gap-2.5 font-mono text-xs uppercase tracking-[0.18em] text-primary [animation-delay:280ms]">
+              <span aria-hidden="true" className="status-dot h-1.5 w-1.5 rounded-full bg-primary" />
               Open to mid-level+ roles
             </p>
           </div>
@@ -108,13 +110,26 @@ export default async function HomePage() {
                           {levelLabel(skill.level)}
                         </span>
                       </div>
+                      {/*
+                        overflow-clip, not overflow-hidden: `hidden` makes the
+                        track a scroll container, and the fill's view() timeline
+                        then measures entry into this 4px track instead of the
+                        viewport — the scroll fill silently never runs.
+                      */}
                       <div
-                        className="mt-1.5 h-1 overflow-hidden rounded-full bg-accent"
+                        className="mt-1.5 h-1 overflow-clip rounded-full bg-accent"
                         role="presentation"
                       >
+                        {/*
+                          Level via custom property, not a width style: the
+                          skill-fill keyframe scales the bar up to var(--bar-w)
+                          as it scrolls into view, and the base rule rests at
+                          the same value where scroll-driven animation is
+                          unsupported or motion is reduced.
+                        */}
                         <div
-                          className="h-full rounded-full bg-primary"
-                          style={{ width: LEVEL_WIDTH[skill.level] }}
+                          className="skill-bar-fill h-full rounded-full bg-primary"
+                          style={{ "--bar-w": LEVEL_WIDTH[skill.level] } as CSSProperties}
                         />
                       </div>
                     </li>

--- a/apps/web/components/hero-topology.tsx
+++ b/apps/web/components/hero-topology.tsx
@@ -10,9 +10,10 @@ import { cn } from "@/lib/cn";
  * says the whole thing at a glance.
  *
  * Inline SVG on the server: no canvas, no WebGL, no client component, no
- * hydration, nothing competing with LCP. The motion is one CSS keyframe on the
- * edge strokes, so `prefers-reduced-motion` stops it through the global rule
- * rather than needing its own escape hatch.
+ * hydration, nothing competing with LCP. All motion is CSS — the boot-order
+ * entrance (`hero-enter`) and the packet flow on the edges — so
+ * `prefers-reduced-motion` stops the lot through the global rule rather than
+ * needing its own escape hatch.
  *
  * Decorative by definition — the information is in the prose beside it — so the
  * whole graphic is hidden from assistive tech instead of narrating a diagram
@@ -40,6 +41,22 @@ const EDGES = [
   { d: "M237,120 C272,120 276,195 306,195", delay: "1.05s" },
 ];
 
+/*
+ * The boot order, one delay per node in NODES order: Client registers, the
+ * API comes up, then its dependencies. Inline style rather than a Tailwind
+ * arbitrary class because the values are indexed at render time and the
+ * scanner would never see them.
+ */
+const NODE_BOOT_DELAY_MS = [450, 525, 600, 675, 750];
+
+/*
+ * When the wires start flowing. Kafka's entrance technically runs until
+ * 1.15s, but the deceleration easing has it visually settled well before
+ * that — 0.8s starts the first flow the moment the graph reads as complete,
+ * without a dead beat at the end of the boot.
+ */
+const FLOW_START = "0.8s";
+
 export function HeroTopology({ className }: { className?: string }) {
   return (
     <svg
@@ -51,31 +68,41 @@ export function HeroTopology({ className }: { className?: string }) {
       className={cn("h-auto w-full max-w-lg lg:max-w-none", className)}
     >
       {/* Static rails, so the graph still reads as connected when motion is off. */}
-      {EDGES.map((edge) => (
-        <path
-          key={`rail-${edge.d}`}
-          d={edge.d}
-          fill="none"
-          stroke="hsl(var(--border))"
-          strokeWidth="1.5"
-        />
-      ))}
+      <g className="hero-item [animation-delay:350ms]">
+        {EDGES.map((edge) => (
+          <path
+            key={`rail-${edge.d}`}
+            d={edge.d}
+            fill="none"
+            stroke="hsl(var(--border))"
+            strokeWidth="1.5"
+          />
+        ))}
+      </g>
 
-      {EDGES.map((edge) => (
-        <path
-          key={`flow-${edge.d}`}
-          d={edge.d}
-          fill="none"
-          stroke="hsl(var(--primary))"
-          strokeWidth="2"
-          strokeLinecap="round"
-          className="wire-flow"
-          style={{ animationDelay: edge.delay }}
-        />
-      ))}
+      <g className="hero-item [animation-delay:350ms]">
+        {EDGES.map((edge) => (
+          <path
+            key={`flow-${edge.d}`}
+            d={edge.d}
+            fill="none"
+            stroke="hsl(var(--primary))"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="wire-flow"
+            // Held until the last node's entrance lands — flow through a
+            // half-built graph would break the boot narrative.
+            style={{ animationDelay: `calc(${FLOW_START} + ${edge.delay})` }}
+          />
+        ))}
+      </g>
 
-      {NODES.map((node) => (
-        <g key={node.id}>
+      {NODES.map((node, i) => (
+        <g
+          key={node.id}
+          className="topology-node hero-item"
+          style={{ animationDelay: `${NODE_BOOT_DELAY_MS[i]}ms` }}
+        >
           <rect
             x={node.x}
             y={node.y}


### PR DESCRIPTION
## The signature moment

The hero now plays a **boot sequence** on load — the page's subject acted out:

1. Text registers: eyebrow → h1 → paragraph → availability line (0–280 ms stagger)
2. The topology's rails fade in (350 ms)
3. Nodes come online in dependency order: Client → FastAPI → Postgres → Redis → Kafka (450–750 ms)
4. Only then does data start flowing on the wires (from 800 ms)

One keyframe (`hero-enter`), one easing, both defined once as `@theme` motion tokens (`--dur-enter`, `--ease-enter`). Everything else on the page stays quiet.

## Live signals

- **Availability dot pulses** at a calm 2.8 s — an uptime indicator in the site's monitoring vocabulary
- **Skill bars fill to their level on scroll** via CSS scroll-driven animation (`animation-timeline: view()`) behind `@supports` + `prefers-reduced-motion` guards; the base rule always rests at the final value, so no browser and no user ever sees an empty bar
- **Topology nodes highlight on hover** — primary stroke + faint tint, the way a service-mesh dashboard inspects a node

## Two real bugs found while verifying (both in-browser, not in review-by-reading)

- Scroll-driven animation of `width` never applies its before-entry state in current Chromium — the fill was a silent no-op. Animating `scale` (which takes `LEVEL_WIDTH`'s percentages directly: `scale: 75% 1`) fixes it on the compositor.
- The bar track's `overflow-hidden` made it a *scroll container*, so `view()` measured entry into a 4 px box instead of the viewport. `overflow-clip` clips without creating one. Measured before/after: `scale 0 → 0.33 → 0.75` tracking scroll.

## Reduced motion (the pass/fail item)

The global reduced-motion block now zeroes `animation-delay` too — `fill-mode: both` holds boot elements invisible *through* their delay, so duration alone wasn't enough. Verified with media emulation: every element at opacity 1 instantly, bars full, dot static, zero stagger.

## Discipline

- **Zero new client components** — still exactly 3 `"use client"` files; boot, pulse, scroll-fill and hover are all CSS on server components
- No new dependencies, no canvas/WebGL, tokens not literals
- Scope guards held: no stat counters, no typing cursors, no scroll-reveal-everything, no page transitions

## Verification

- frontend-reviewer drove the dev server: **no Blocking findings**; both Should-fixes (the no-op scroll fill, an overpromising timing comment) fixed and re-measured
- Boot sequence, hover, pulse and fill verified in both themes at 1497×950 and 375×667; no horizontal overflow; no console errors
- 46 unit + 26 e2e green; production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)