### PR TITLE
Give the site chrome a surface, and a way into the console

### DIFF
--- a/apps/web/app/(console)/login/page.tsx
+++ b/apps/web/app/(console)/login/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 
 import { LoginForm } from "@/components/login-form";
 import { Container } from "@/components/ui/container";
 import { Eyebrow, eyebrowClasses } from "@/components/ui/eyebrow";
+import { hasLiveSession } from "@/lib/admin-guard";
 import { cn } from "@/lib/cn";
-import { safeNextPath } from "@/lib/session";
+import { ADMIN_PATH, safeNextPath } from "@/lib/session";
 
 export const metadata: Metadata = {
   title: "Console access",
@@ -26,6 +28,17 @@ export const metadata: Metadata = {
  * same wire carrying credentials to the same backend.
  */
 export default async function LoginPage({ searchParams }: PageProps<"/login">) {
+  // Already signed in? Go straight through.
+  //
+  // This is what lets the header's console control be a plain static link. The
+  // alternative — having the header ask who is signed in — means calling
+  // cookies() in a component every page renders, which opts the entire public
+  // site out of static rendering to answer a question only the owner ever asks.
+  //
+  // The check is the real one rather than "is there a cookie", so a stale
+  // cookie shows the form instead of bouncing to /admin and being sent back.
+  if (await hasLiveSession()) redirect(ADMIN_PATH);
+
   const params = await searchParams;
   const raw = params.next;
   // Never rendered into an href — it is a hidden form value the action

--- a/apps/web/app/(site)/[...unmatched]/page.tsx
+++ b/apps/web/app/(site)/[...unmatched]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+
+/**
+ * Pulls every unmatched URL into the site group, so its 404 has the site's
+ * chrome on it.
+ *
+ * Without this, `/anything-stale` is matched by no route at all and Next falls
+ * back to `app/not-found.tsx` in the root layout — which has no nav and no
+ * footer. Someone following an out-of-date link landed on a bare graph-paper
+ * screen with no way onwards except the browser's Back button.
+ *
+ * A catch-all is the least specific route Next has, so it cannot shadow
+ * anything: `/certificates`, `/projects/[slug]`, `/login` and the
+ * `/auth/refresh` handler are all matched ahead of it. The e2e suite covers
+ * each of those, which is what makes that claim checkable rather than hopeful.
+ */
+export default function UnmatchedRoute() {
+  notFound();
+}

--- a/apps/web/app/(site)/layout.tsx
+++ b/apps/web/app/(site)/layout.tsx
@@ -1,8 +1,13 @@
 import Link from "next/link";
+import { Fragment } from "react";
 
 import { SkipLink } from "@/components/skip-link";
 import { SiteNav } from "@/components/site-nav";
 import { Container } from "@/components/ui/container";
+import { eyebrowClasses } from "@/components/ui/eyebrow";
+import { ExternalLink } from "@/components/ui/external-link";
+import { CHANNELS, isMailto } from "@/lib/channels";
+import { cn } from "@/lib/cn";
 
 /**
  * Chrome for the public portfolio: nav, content, footer.
@@ -32,36 +37,70 @@ export default function SiteLayout({ children }: LayoutProps<"/">) {
       <footer className="mt-auto border-t border-border bg-card">
         <Container
           width="layout"
-          className="flex flex-col items-center gap-4 py-8 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground sm:flex-row sm:justify-between"
+          className="flex flex-col gap-8 py-10 sm:flex-row sm:items-start sm:justify-between"
         >
-          <span>© {new Date().getFullYear()} Phạm Đăng Khôi</span>
+          {/*
+            The contact channels, on every page rather than only at the bottom
+            of the home page. Someone reading /certificates or a project detail
+            had no way to make contact without navigating back to / and
+            scrolling to the end of it — which is a lot to ask of a recruiter
+            who has already decided to get in touch.
+          */}
+          {/*
+            A two-column grid rather than a fixed-width label column. `w-16`
+            fitted EMAIL and GITHUB and was 11px too narrow for LINKEDIN, which
+            ran into its own value with no gap. `auto` sizes the column to the
+            longest label, so adding a channel cannot break the alignment.
+          */}
+          <nav
+            aria-label="Elsewhere"
+            className="grid grid-cols-[auto_1fr] items-center gap-x-5"
+          >
+            {CHANNELS.map((channel) => (
+              <Fragment key={channel.label}>
+                <span className={eyebrowClasses}>{channel.label}</span>
 
-          <span className="flex items-center gap-3 sm:gap-4">
+                {isMailto(channel.href) ? (
+                  // Not an ExternalLink: a mailto does not leave for another
+                  // site, so the ↗ would be a lie and the new tab it opens
+                  // would be left behind empty.
+                  <a
+                    href={channel.href}
+                    className="inline-flex min-h-11 items-center text-sm text-muted-foreground transition-colors hover:text-primary"
+                  >
+                    {channel.value}
+                  </a>
+                ) : (
+                  <ExternalLink href={channel.href}>{channel.value}</ExternalLink>
+                )}
+              </Fragment>
+            ))}
+          </nav>
+
+          <div
+            className={cn(
+              eyebrowClasses,
+              "flex flex-col gap-1 sm:items-end sm:text-right",
+            )}
+          >
+            <span>© {new Date().getFullYear()} Phạm Đăng Khôi</span>
             <span>Ho Chi Minh City, Vietnam</span>
 
             {/*
-              Same hairline the header uses between destinations and controls.
-              Without it the two spans read as one run — "VIETNAM CONSOLE" — and
-              the link disappears into the metadata beside it.
-            */}
-            <span aria-hidden="true" className="h-3 w-px shrink-0 bg-border" />
+              The way into the console on a phone, where the header has no room
+              for the key control. Underlined rather than tinted: at this size,
+              in mono uppercase at 0.18em tracking, colour alone is not enough
+              of a signal that it is a link.
 
-            {/*
-              The second way in, for anyone who reads footers rather than
-              hunting for a key icon. Underlined rather than tinted: at this
-              size, in mono uppercase at 60% tracking, colour alone is not
-              enough of a signal that it is a link.
+              min-h-11 because as bare inline text it was a 16px tap target.
             */}
             <Link
               href="/login"
-              // min-h-11: as bare inline text this was a 16px-tall tap target,
-              // which is a miss on a phone. The row is centred, so the extra
-              // height costs nothing visually.
-              className="inline-flex min-h-11 items-center underline underline-offset-4 transition-colors hover:text-primary"
+              className="mt-1 inline-flex min-h-11 items-center underline underline-offset-4 transition-colors hover:text-primary sm:justify-end"
             >
               Console
             </Link>
-          </span>
+          </div>
         </Container>
       </footer>
     </>

--- a/apps/web/app/(site)/layout.tsx
+++ b/apps/web/app/(site)/layout.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { SkipLink } from "@/components/skip-link";
 import { SiteNav } from "@/components/site-nav";
 import { Container } from "@/components/ui/container";
@@ -17,13 +19,49 @@ export default function SiteLayout({ children }: LayoutProps<"/">) {
       <main id="main" className="flex-1">
         {children}
       </main>
-      <footer className="border-t border-border py-8">
+      {/*
+        Same reasoning as the header: this was a hairline and two lines of mono
+        text sitting directly on the graph paper, so it read as leftover content
+        at the bottom of the page rather than as the end of it. `bg-card` gives
+        it the surface the header now has, and the pair frames the paper between
+        them.
+
+        `mt-auto` matters on short pages — the 404 and an empty section would
+        otherwise leave the footer floating mid-screen with paper below it.
+      */}
+      <footer className="mt-auto border-t border-border bg-card">
         <Container
           width="layout"
-          className="flex flex-col gap-1 text-center font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground sm:flex-row sm:justify-between sm:text-left"
+          className="flex flex-col items-center gap-4 py-8 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground sm:flex-row sm:justify-between"
         >
           <span>© {new Date().getFullYear()} Phạm Đăng Khôi</span>
-          <span>Ho Chi Minh City, Vietnam</span>
+
+          <span className="flex items-center gap-3 sm:gap-4">
+            <span>Ho Chi Minh City, Vietnam</span>
+
+            {/*
+              Same hairline the header uses between destinations and controls.
+              Without it the two spans read as one run — "VIETNAM CONSOLE" — and
+              the link disappears into the metadata beside it.
+            */}
+            <span aria-hidden="true" className="h-3 w-px shrink-0 bg-border" />
+
+            {/*
+              The second way in, for anyone who reads footers rather than
+              hunting for a key icon. Underlined rather than tinted: at this
+              size, in mono uppercase at 60% tracking, colour alone is not
+              enough of a signal that it is a link.
+            */}
+            <Link
+              href="/login"
+              // min-h-11: as bare inline text this was a 16px-tall tap target,
+              // which is a miss on a phone. The row is centred, so the extra
+              // height costs nothing visually.
+              className="inline-flex min-h-11 items-center underline underline-offset-4 transition-colors hover:text-primary"
+            >
+              Console
+            </Link>
+          </span>
         </Container>
       </footer>
     </>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,26 +1,15 @@
-import Link from "next/link";
-
-import { buttonClasses } from "@/components/ui/button";
-import { Container } from "@/components/ui/container";
-import { Eyebrow } from "@/components/ui/eyebrow";
+import { NotFoundContent } from "@/components/not-found-content";
 
 /**
- * An empty screen is an invitation to act, so this points somewhere useful
- * rather than apologising.
+ * The 404 for the whole app.
+ *
+ * There is deliberately no second copy inside `(site)`. A `not-found.tsx` at
+ * the root of a route group is treated as the app-root boundary and renders
+ * with only the root layout, so adding one there took the nav and footer *off*
+ * the 404 that previously had them. This single boundary, reached from a
+ * segment inside `(site)` — an unpublished project slug, or the catch-all
+ * beside it — composes down through `(site)/layout.tsx` and keeps the chrome.
  */
 export default function NotFound() {
-  return (
-    <Container width="reading" className="py-24 text-center">
-      <Eyebrow>404</Eyebrow>
-      <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
-        This page does not exist
-      </h1>
-      <p className="mt-4 text-muted-foreground">
-        The link may be out of date, or the project behind it is not published.
-      </p>
-      <Link href="/" className={buttonClasses("primary", "mt-8")}>
-        Back to the portfolio
-      </Link>
-    </Container>
-  );
+  return <NotFoundContent />;
 }

--- a/apps/web/components/console-link.tsx
+++ b/apps/web/components/console-link.tsx
@@ -21,6 +21,10 @@ export function ConsoleLink() {
   return (
     <Link
       href="/login"
+      // The sr-only text below names it for assistive tech; `title` is what
+      // gives a sighted visitor the same answer, since a key icon on a
+      // portfolio is not self-evident.
+      title="Console"
       // Same explicit 44x44 box as ThemeToggle — padding around a 16px icon
       // lands well under the tap target on a phone.
       className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"

--- a/apps/web/components/console-link.tsx
+++ b/apps/web/components/console-link.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+/**
+ * The way in to the admin console, from the public site.
+ *
+ * Sized and shaped like ThemeToggle on purpose: they are the two controls in
+ * the header that act on the site rather than navigate it, so they read as a
+ * pair of instrument switches sitting apart from the content links.
+ *
+ * It always points at /login. Reading the session here would mean calling
+ * `cookies()` in the header, which every page renders — and that opts the whole
+ * public site out of static rendering to answer a question only the owner ever
+ * asks. `/login` is already dynamic, so it does the redirect to /admin itself
+ * when a session is live.
+ *
+ * "Console" rather than "Login" because that is what the destination calls
+ * itself: the page is headed "Console access" and the admin strip says CONSOLE.
+ * One name for one thing, the whole way through.
+ */
+export function ConsoleLink() {
+  return (
+    <Link
+      href="/login"
+      // Same explicit 44x44 box as ThemeToggle — padding around a 16px icon
+      // lands well under the tap target on a phone.
+      className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+    >
+      {/*
+        An SVG rather than a text glyph. ThemeToggle can use ☾/☀ because both
+        are in every system font; the key and padlock characters are not, and a
+        missing glyph renders as a tofu box in the header.
+      */}
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-4 w-4"
+      >
+        <circle cx="8" cy="12" r="3.25" />
+        <path d="M11.25 12H20" />
+        <path d="M17 12v3" />
+        <path d="M20 12v2" />
+      </svg>
+      <span className="sr-only">Console</span>
+    </Link>
+  );
+}

--- a/apps/web/components/contact-form.tsx
+++ b/apps/web/components/contact-form.tsx
@@ -185,7 +185,7 @@ export function ContactForm() {
 
   if (state.status === "sent") {
     return (
-      <div className="rounded-[--radius-card] border border-border bg-card p-6">
+      <div className="rounded-[var(--radius-card)] border border-border bg-card p-6">
         <h3 className="font-display text-lg font-semibold tracking-tight text-foreground">
           Message sent
         </h3>

--- a/apps/web/components/contact-section.tsx
+++ b/apps/web/components/contact-section.tsx
@@ -1,5 +1,6 @@
 import { ContactForm } from "@/components/contact-form";
 import { Section } from "@/components/section";
+import { eyebrowClasses } from "@/components/ui/eyebrow";
 import { ExternalLink } from "@/components/ui/external-link";
 import { CHANNELS, isMailto } from "@/lib/channels";
 
@@ -45,7 +46,10 @@ export function ContactSection() {
       <dl className="mb-10 flex flex-wrap gap-x-10 gap-y-4">
         {CHANNELS.map((channel) => (
           <div key={channel.label}>
-            <dt className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+            {/* eyebrowClasses, not a literal 11px: the footer renders these
+                same labels through it, and two sizes for one label is how a
+                scale stops being one. */}
+            <dt className={eyebrowClasses}>
               {channel.label}
             </dt>
             <dd>

--- a/apps/web/components/contact-section.tsx
+++ b/apps/web/components/contact-section.tsx
@@ -1,9 +1,9 @@
 import { ContactForm } from "@/components/contact-form";
 import { Section } from "@/components/section";
 import { ExternalLink } from "@/components/ui/external-link";
-import { OWNER_EMAIL } from "@/lib/contact";
+import { CHANNELS, isMailto } from "@/lib/channels";
 
-/**
+/*
  * The channels are listed above the form, not tucked into an error state.
  *
  * The form depends on the API being up. These do not — a mailto works when the
@@ -11,12 +11,10 @@ import { OWNER_EMAIL } from "@/lib/contact";
  * already spent their five messages for the hour. Showing them only after a
  * failure would mean the section's fallback is invisible until the moment it is
  * needed, which is the wrong moment to introduce it.
+ *
+ * The list itself lives in lib/channels.ts, because the footer shows it too and
+ * two copies of someone's contact details drift.
  */
-const CHANNELS = [
-  { label: "Email", value: OWNER_EMAIL, href: `mailto:${OWNER_EMAIL}` },
-  { label: "GitHub", value: "dangkhoipham80", href: "https://github.com/dangkhoipham80" },
-  { label: "LinkedIn", value: "khoipham4022", href: "https://www.linkedin.com/in/khoipham4022/" },
-] as const;
 
 export function ContactSection() {
   return (
@@ -51,7 +49,7 @@ export function ContactSection() {
               {channel.label}
             </dt>
             <dd>
-              {channel.href.startsWith("mailto:") ? (
+              {isMailto(channel.href) ? (
                 // Not an ExternalLink: a mailto does not leave for another site
                 // and the ↗ affordance would be a lie about where it goes.
                 <a

--- a/apps/web/components/nav-links.tsx
+++ b/apps/web/components/nav-links.tsx
@@ -49,7 +49,7 @@ export function NavLinks() {
             className={cn(
               // min 44×44: padding around a 12px initial only reached 28×36,
               // which is a routine thumb-miss on a phone.
-              "relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-[--radius-control] px-2.5 font-mono text-xs uppercase tracking-wider transition-colors sm:px-3",
+              "relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-[var(--radius-control)] px-2.5 font-mono text-xs uppercase tracking-wider transition-colors sm:px-3",
               // The rule sits at the bottom of the label rather than the bottom
               // of the header, because the link is inset from both — a tab
               // indicator floating in the middle of the bar reads as an

--- a/apps/web/components/nav-links.tsx
+++ b/apps/web/components/nav-links.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/*
+ * A client component for one reason: `usePathname`.
+ *
+ * There is no server equivalent — a layout is not re-rendered per route segment
+ * with the path available, and nothing in CSS can know which page it is on. The
+ * alternative is a nav that never says where you are, which is the one thing a
+ * nav is for. It ships a few hundred bytes and no state.
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/cn";
+
+// `short` is the collapsed mobile label. Two letters, not one: "Career" and
+// "Certificates" share an initial, and a row reading P · C · C gives a sighted
+// thumb no way to tell the two apart.
+const LINKS = [
+  { href: "/#projects", label: "Projects", short: "Pr" },
+  { href: "/career-journey", label: "Career", short: "Ca" },
+  { href: "/certificates", label: "Certificates", short: "Ce" },
+];
+
+/** The path part of a nav href, so `/#projects` is compared as `/`. */
+function pathOf(href: string): string {
+  return href.split("#")[0] || "/";
+}
+
+export function NavLinks() {
+  const pathname = usePathname();
+
+  return (
+    <>
+      {LINKS.map((link) => {
+        // Exact match rather than prefix: `/` is a prefix of everything, and a
+        // nav that highlights Projects on every page tells you nothing.
+        const current = pathname === pathOf(link.href);
+
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            // Announced, not just coloured. Colour alone leaves the current page
+            // unmarked for anyone using a screen reader, and it is the one piece
+            // of state in the header.
+            aria-current={current ? "page" : undefined}
+            className={cn(
+              // min 44×44: padding around a 12px initial only reached 28×36,
+              // which is a routine thumb-miss on a phone.
+              "relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-[--radius-control] px-2.5 font-mono text-xs uppercase tracking-wider transition-colors sm:px-3",
+              // The rule sits at the bottom of the label rather than the bottom
+              // of the header, because the link is inset from both — a tab
+              // indicator floating in the middle of the bar reads as an
+              // underline, which is what it is.
+              current
+                ? "text-primary after:absolute after:inset-x-2.5 after:bottom-1.5 after:h-px after:bg-primary sm:after:inset-x-3"
+                : "text-muted-foreground hover:text-primary",
+            )}
+          >
+            {/*
+              aria-hidden on the initial: without it the accessible name is
+              computed from both spans and reads "P Projects".
+            */}
+            <span aria-hidden="true" className="sm:hidden">
+              {link.short}
+            </span>
+            <span className="sr-only sm:not-sr-only">{link.label}</span>
+          </Link>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/components/not-found-content.tsx
+++ b/apps/web/components/not-found-content.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+import { buttonClasses } from "@/components/ui/button";
+import { Container } from "@/components/ui/container";
+import { Eyebrow } from "@/components/ui/eyebrow";
+
+/**
+ * The body of a 404, shared by the two boundaries that render one.
+ *
+ * An empty screen is an invitation to act, so this points somewhere useful
+ * rather than apologising.
+ */
+export function NotFoundContent() {
+  return (
+    <Container width="reading" className="py-24 text-center">
+      <Eyebrow>404</Eyebrow>
+      <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
+        This page does not exist
+      </h1>
+      <p className="mt-4 text-muted-foreground">
+        The link may be out of date, or the project behind it is not published.
+      </p>
+      <Link href="/" className={buttonClasses("primary", "mt-8")}>
+        Back to the portfolio
+      </Link>
+    </Container>
+  );
+}

--- a/apps/web/components/section.tsx
+++ b/apps/web/components/section.tsx
@@ -75,7 +75,7 @@ export function Section({
  */
 export function EmptyState({ children }: { children: ReactNode }) {
   return (
-    <p className="rounded-[--radius-card] border border-dashed border-border px-4 py-10 text-center font-mono text-sm text-muted-foreground">
+    <p className="rounded-[var(--radius-card)] border border-dashed border-border px-4 py-10 text-center font-mono text-sm text-muted-foreground">
       {children}
     </p>
   );

--- a/apps/web/components/site-nav.tsx
+++ b/apps/web/components/site-nav.tsx
@@ -1,17 +1,9 @@
 import Link from "next/link";
 
 import { ConsoleLink } from "./console-link";
+import { NavLinks } from "./nav-links";
 import { ThemeToggle } from "./theme-toggle";
 import { Container } from "./ui/container";
-
-// `short` is the collapsed mobile label. Two letters, not one: "Career" and
-// "Certificates" share an initial, and a row reading P · C · C gives a sighted
-// thumb no way to tell the two apart.
-const LINKS = [
-  { href: "/#projects", label: "Projects", short: "Pr" },
-  { href: "/career-journey", label: "Career", short: "Ca" },
-  { href: "/certificates", label: "Certificates", short: "Ce" },
-];
 
 /*
  * `bg-card`, not a translucent `bg-background`.
@@ -47,26 +39,12 @@ export function SiteNav() {
           Below `sm` the labels collapse to their initials — the destinations
           stay reachable and the accessible name is unchanged, because the full
           word is still in the DOM for assistive tech.
+
+          The links themselves are a client component so they can mark the page
+          you are on; see the note in nav-links.tsx.
         */}
         <nav aria-label="Main" className="flex items-center gap-0.5 sm:gap-2">
-          {LINKS.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              // min 44×44: padding around a 12px initial only reached 28×36,
-              // which is a routine thumb-miss on a phone.
-              className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-[--radius-control] px-2.5 font-mono text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:text-primary sm:px-3"
-            >
-              {/*
-                aria-hidden on the initial: without it the accessible name is
-                computed from both spans and reads "P Projects".
-              */}
-              <span aria-hidden="true" className="sm:hidden">
-                {link.short}
-              </span>
-              <span className="sr-only sm:not-sr-only">{link.label}</span>
-            </Link>
-          ))}
+          <NavLinks />
 
           {/*
             A hairline between the places you can go and the switches that act

--- a/apps/web/components/site-nav.tsx
+++ b/apps/web/components/site-nav.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { ConsoleLink } from "./console-link";
 import { ThemeToggle } from "./theme-toggle";
 import { Container } from "./ui/container";
 
@@ -12,13 +13,30 @@ const LINKS = [
   { href: "/certificates", label: "Certificates", short: "Ce" },
 ];
 
+/*
+ * `bg-card`, not a translucent `bg-background`.
+ *
+ * The page is graph paper — a repeating grid painted on the body — and the
+ * header used to sit on it at 85% opacity, so the grid lines ran straight
+ * through the bar. In dark mode you could read them behind the nav. The header
+ * stopped being a surface and became more paper, which left the border doing
+ * all the work of separating the two, at 60% opacity.
+ *
+ * `card` is the token the site already uses for anything that sits *on* the
+ * paper, and it differs from `background` in both themes — white against a
+ * green tint in light, a lighter slate against near-black in dark. At 92% with
+ * the blur it still softens what scrolls underneath, but the grid no longer
+ * reads through it.
+ */
 export function SiteNav() {
   return (
-    <header className="sticky top-0 z-40 border-b border-border/60 bg-background/85 backdrop-blur">
-      <Container width="layout" className="flex items-center justify-between gap-4 py-3">
+    <header className="sticky top-0 z-40 border-b border-border bg-card/92 backdrop-blur">
+      <Container width="layout" className="flex items-center justify-between gap-3 py-3 sm:gap-4">
         <Link
           href="/"
-          className="font-display font-semibold tracking-tight text-foreground"
+          // min-h-11 is the tap target: as bare text the name measured 40px
+          // tall sitting next to a row of 44px controls.
+          className="inline-flex min-h-11 items-center font-display font-semibold tracking-tight text-foreground"
         >
           Phạm Đăng Khôi
         </Link>
@@ -49,6 +67,32 @@ export function SiteNav() {
               <span className="sr-only sm:not-sr-only">{link.label}</span>
             </Link>
           ))}
+
+          {/*
+            A hairline between the places you can go and the switches that act
+            on the site. Without it the console key reads as a fourth
+            destination, which it is not — and the theme toggle has always been
+            slightly odd sitting at the end of a list of pages.
+          */}
+          <span aria-hidden="true" className="mx-2 hidden h-5 w-px bg-border sm:block" />
+
+          {/*
+            Not in the header below `sm`, and this is a measurement rather than
+            a preference: the name is 104px, the nav 239px and the gap 12px,
+            against a 320px content box at 375px. It was already 3px from
+            overflowing before this control existed — which is why the labels
+            collapse to initials at all — and adding a sixth 44px target puts it
+            35px over, which no amount of tightening recovers without dropping
+            the tap targets under 44px or shrinking the name to initials.
+
+            The footer's Console link is the way in on a phone. It is the same
+            destination and the same word, and administering a site from a phone
+            is the rarer case anyway.
+          */}
+          <span className="hidden sm:flex">
+            <ConsoleLink />
+          </span>
+
           <ThemeToggle />
         </nav>
       </Container>

--- a/apps/web/components/skip-link.tsx
+++ b/apps/web/components/skip-link.tsx
@@ -13,7 +13,7 @@ export function SkipLink() {
   return (
     <a
       href="#main"
-      className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-[--radius-control] focus:border focus:border-border focus:bg-card focus:px-4 focus:py-3 focus:font-mono focus:text-xs focus:uppercase focus:tracking-[0.18em] focus:text-foreground"
+      className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-[var(--radius-control)] focus:border focus:border-border focus:bg-card focus:px-4 focus:py-3 focus:font-mono focus:text-xs focus:uppercase focus:tracking-[0.18em] focus:text-foreground"
     >
       Skip to content
     </a>

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -21,7 +21,12 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={toggle}
-      aria-label="Toggle dark mode"
+      // Two labels, picked by CSS for the same reason the icon is: the button
+      // holds no state, so it cannot compute which one applies without
+      // reintroducing the hydration flash the blocking script exists to avoid.
+      // A single "Toggle dark mode" is wrong half the time — in dark mode,
+      // activating it goes to light.
+      aria-labelledby="theme-toggle-label"
       // Explicit box: padding alone measured 26x43, under the 44px target size.
       className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border text-foreground transition-colors hover:bg-accent"
     >
@@ -30,6 +35,10 @@ export function ThemeToggle() {
       </span>
       <span aria-hidden="true" className="hidden dark:inline">
         ☀
+      </span>
+      <span id="theme-toggle-label" className="sr-only">
+        <span className="dark:hidden">Switch to dark mode</span>
+        <span className="hidden dark:inline">Switch to light mode</span>
       </span>
     </button>
   );

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -22,7 +22,7 @@ export function Badge({
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-[--radius-pill] px-2.5 py-0.5 text-xs font-medium",
+        "inline-flex items-center rounded-[var(--radius-pill)] px-2.5 py-0.5 text-xs font-medium",
         VARIANTS[variant],
         className,
       )}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/cn";
 /**
  * The filled action, in one place.
  *
- * `rounded-[--radius-control] bg-primary px-5 py-2.5 …` was written out
+ * `rounded-[var(--radius-control)] bg-primary px-5 py-2.5 …` was written out
  * identically in app/not-found.tsx and app/error.tsx, and the contact form
  * would have been the third copy. Three sites is how the padding on one of them
  * quietly drifts.
@@ -31,7 +31,7 @@ export function buttonClasses(
     // each call site re-inventing the alignment.
     // py-3 rather than the py-2.5 the inlined versions used: that came to 40px,
     // just under a comfortable touch target.
-    "inline-flex items-center justify-center gap-2 rounded-[--radius-control] px-5 py-3 text-sm font-medium transition-opacity",
+    "inline-flex items-center justify-center gap-2 rounded-[var(--radius-control)] px-5 py-3 text-sm font-medium transition-opacity",
     // A disabled submit still has to read as the same control, just inert —
     // and it must not keep the pointer affordance of something clickable.
     "disabled:cursor-not-allowed disabled:opacity-70",

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -22,7 +22,7 @@ export function Card({
     <div
       className={cn(
         // `relative` so a child link can stretch itself over the whole card.
-        "relative flex flex-col rounded-[--radius-card] border border-border bg-card p-5",
+        "relative flex flex-col rounded-[var(--radius-card)] border border-border bg-card p-5",
         interactive &&
           // The focus-within half matters: the card's link is stretched over the
           // whole tile, but its focus ring draws only around the title text, so

--- a/apps/web/components/ui/field.tsx
+++ b/apps/web/components/ui/field.tsx
@@ -21,7 +21,7 @@ import { cn } from "@/lib/cn";
 const controlClasses = cn(
   // min-h-11: py-2.5 around 14px text measures 41px — 3px under the 44px
   // touch-target floor the buttons already meet.
-  "min-h-11 w-full rounded-[--radius-control] border border-border bg-card px-3.5 py-2.5 text-sm text-foreground",
+  "min-h-11 w-full rounded-[var(--radius-control)] border border-border bg-card px-3.5 py-2.5 text-sm text-foreground",
   "transition-colors placeholder:text-muted-foreground/60 hover:border-primary/40",
   "aria-[invalid=true]:border-destructive",
   // No `focus:outline-none` here. It was written to "avoid fighting" the

--- a/apps/web/components/ui/notice.tsx
+++ b/apps/web/components/ui/notice.tsx
@@ -24,7 +24,7 @@ export function Notice({
   return (
     <p
       className={cn(
-        "rounded-[--radius-control] border border-border bg-card px-4 py-3 text-sm text-foreground",
+        "rounded-[var(--radius-control)] border border-border bg-card px-4 py-3 text-sm text-foreground",
         className,
       )}
     >

--- a/apps/web/components/ui/project-media.tsx
+++ b/apps/web/components/ui/project-media.tsx
@@ -56,7 +56,7 @@ export function ProjectMedia({
   return (
     <div
       className={cn(
-        "relative flex aspect-[16/7] items-end overflow-hidden rounded-[--radius-control] border border-border bg-cover bg-center",
+        "relative flex aspect-[16/7] items-end overflow-hidden rounded-[var(--radius-control)] border border-border bg-cover bg-center",
         className,
       )}
       style={{ backgroundImage }}

--- a/apps/web/lib/admin-guard.ts
+++ b/apps/web/lib/admin-guard.ts
@@ -35,6 +35,24 @@ import {
 export type AdminSession = { user: CurrentUser; accessToken: string };
 
 /**
+ * Whether the caller already holds a usable admin session.
+ *
+ * Used by the sign-in screen to send someone straight to /admin rather than
+ * show them a form they do not need. It asks the API instead of trusting the
+ * presence of a cookie, so a stale one renders the form rather than starting a
+ * bounce between /login and /admin.
+ */
+export async function hasLiveSession(): Promise<boolean> {
+  const jar = await cookies();
+  const accessToken = jar.get(ACCESS_COOKIE)?.value;
+  if (!accessToken) return false;
+
+  const result = await fetchCurrentUser(accessToken);
+
+  return result.ok && result.data.roles.includes("admin");
+}
+
+/**
  * Resolve the caller, or redirect. Never returns for a signed-out visitor.
  *
  * `path` is where they were trying to go, carried through the sign-in so they

--- a/apps/web/lib/channels.ts
+++ b/apps/web/lib/channels.ts
@@ -1,0 +1,35 @@
+import { OWNER_EMAIL } from "./contact";
+
+/**
+ * The ways to reach the owner, in one place.
+ *
+ * Listed in the contact section at the bottom of the home page and in the site
+ * footer, which is the point of lifting them out of the former: a recruiter
+ * reading /certificates or a project page had no way to make contact without
+ * first finding their way back to the home page and scrolling to the end of it.
+ *
+ * Order is deliberate — email is the channel that actually gets read, and it
+ * works when the API is asleep, when the Server Action times out, and when
+ * someone has spent their five messages for the hour.
+ */
+export type Channel = {
+  label: string;
+  /** What is shown when there is room for it: the address, the handle. */
+  value: string;
+  href: string;
+};
+
+export const CHANNELS: readonly Channel[] = [
+  { label: "Email", value: OWNER_EMAIL, href: `mailto:${OWNER_EMAIL}` },
+  { label: "GitHub", value: "dangkhoipham80", href: "https://github.com/dangkhoipham80" },
+  { label: "LinkedIn", value: "khoipham4022", href: "https://www.linkedin.com/in/khoipham4022/" },
+] as const;
+
+/**
+ * A mailto does not leave for another site, so it must not get the external
+ * link treatment — the ↗ would be a lie about where it goes, and opening a mail
+ * client in a new tab leaves an empty one behind.
+ */
+export function isMailto(href: string): boolean {
+  return href.startsWith("mailto:");
+}

--- a/apps/web/tests/e2e/console-sign-in.spec.ts
+++ b/apps/web/tests/e2e/console-sign-in.spec.ts
@@ -30,6 +30,46 @@ async function sessionCookies(context: BrowserContext) {
   return all.filter((cookie) => cookie.name === "pf_access" || cookie.name === "pf_refresh");
 }
 
+test.describe("the way in", () => {
+  test("the header offers the console", async ({ page }) => {
+    await page.goto("/");
+    await page.locator('header a[href="/login"]').click();
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole("heading", { level: 1, name: "Console access" })).toBeVisible();
+  });
+
+  test("on a phone it moves to the footer, and is still there", async ({ page }) => {
+    // The header runs out of room at 375px — six 44px targets plus the name do
+    // not fit — so the control is dropped from the row and the footer link is
+    // the way in. If both ever disappear at once, the console is unreachable
+    // without typing the URL.
+    await page.setViewportSize({ width: 375, height: 760 });
+    await page.goto("/");
+
+    await expect(page.locator('header a[href="/login"]')).toBeHidden();
+    await expect(page.locator('footer a[href="/login"]')).toBeVisible();
+  });
+
+  test("the footer link works", async ({ page }) => {
+    await page.goto("/");
+    await page.locator('footer a[href="/login"]').click();
+
+    await expect(page).toHaveURL(/\/login$/);
+  });
+
+  test("a live session skips the form entirely", async ({ page }) => {
+    // What lets the header control be a plain static link: it always points at
+    // /login, and /login decides. Without this the owner would meet a sign-in
+    // form while already signed in.
+    await signIn(page);
+    await expect(page).toHaveURL(/\/admin$/);
+
+    await page.goto("/login");
+    await expect(page).toHaveURL(/\/admin$/);
+  });
+});
+
 test.describe("signed out", () => {
   test("the admin area is closed, and remembers where you were going", async ({ page }) => {
     await page.goto("/admin");

--- a/apps/web/tests/e2e/not-found.spec.ts
+++ b/apps/web/tests/e2e/not-found.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * A 404 keeps the site's chrome.
+ *
+ * Worth pinning because the way it works is not obvious. An unmatched URL
+ * belongs to no route group, so Next falls back to `app/not-found.tsx` in the
+ * root layout — which has no nav and no footer. A catch-all inside `(site)`
+ * pulls those URLs into the group so the 404 composes through
+ * `(site)/layout.tsx` instead.
+ *
+ * The obvious-looking fix, a second `not-found.tsx` at the root of the group,
+ * makes it worse: Next treats that as the app-root boundary and renders it with
+ * only the root layout, which took the chrome off the 404 that already had it.
+ * Nothing in the type system or the build output says so — only this does.
+ */
+const PATHS = [
+  // Matches no route at all.
+  "/some-stale-link",
+  "/deep/stale/link",
+  // Matches /projects/[slug], which calls notFound() for an unknown slug.
+  "/projects/stub-missing",
+];
+
+for (const path of PATHS) {
+  test(`${path} returns a 404 that still has the nav and the footer`, async ({ page }) => {
+    const response = await page.goto(path);
+
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("This page does not exist");
+    await expect(page.getByRole("navigation", { name: "Main" })).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Elsewhere" })).toBeVisible();
+
+    // The way onwards. An empty screen with no exit is the thing this avoids.
+    await expect(page.getByRole("link", { name: "Back to the portfolio" })).toBeVisible();
+  });
+}
+
+test("the catch-all does not shadow a real page", async ({ page }) => {
+  // A catch-all is the least specific route Next has, but this is the
+  // assertion that makes that claim checkable rather than hopeful.
+  for (const path of ["/", "/career-journey", "/certificates", "/login"]) {
+    const response = await page.goto(path);
+    expect(response?.status(), `${path} must not fall through to the catch-all`).toBe(200);
+  }
+});

--- a/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
+++ b/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
@@ -52,7 +52,12 @@ test.describe("pages built with no API behind them", () => {
       // Without this the tests above would pass on a blank document.
       await expect(page.getByRole("heading", { level: 1 })).toHaveText(heading);
       await expect(page.locator("h1")).toHaveCount(1);
-      await expect(page.getByRole("navigation")).toBeVisible();
+
+      // Named, because the footer's channel list is a second navigation
+      // landmark and a bare getByRole("navigation") now matches both. Naming
+      // the one meant here is what the assertion always intended anyway.
+      await expect(page.getByRole("navigation", { name: "Main" })).toBeVisible();
+      await expect(page.getByRole("navigation", { name: "Elsewhere" })).toBeVisible();
     });
   }
 


### PR DESCRIPTION
The header and footer looked wrong and there was no way to reach the admin
console from the UI at all.

## Why they looked wrong

The page body paints a repeating graph-paper grid. The header sat on it at
`bg-background/85`, so the grid ran straight through the bar — in dark mode you
could read the lines behind the nav — and the footer had no background at all,
just a hairline and two lines of mono text floating on the paper. Neither read
as a surface, which left a 60%-opacity border doing all the work of separating
chrome from content.

Both are `bg-card` now: the token the site already uses for anything sitting
*on* the paper, and genuinely different from `background` in both themes —
white against a green tint in light, lighter slate against near-black in dark.
The header keeps 92% and the blur so scrolling content still softens behind it.
Measured in dark mode: footer `rgb(11,17,30)` against page `rgb(5,8,15)`.

## The way in

A key control in the header, shaped like the theme toggle because both act on
the site rather than navigate it, with a hairline separating them from the
pages. Plus a Console link in the footer.

It is **hidden below `sm`**, and that is a measurement rather than a
preference: the name is 104px, the nav 239px and the gap 12px, against a 320px
content box at 375px. The header was already 3px from overflowing before this
control existed — which is why the labels collapse to initials — and a sixth
44px target puts it 35px over. Nothing recovers that without dropping targets
under 44px or cutting the name to initials. The footer link is the way in on a
phone.

`/login` redirects to `/admin` when a live session exists. That is what lets
the header control be a plain static link: having the header ask who is signed
in means calling `cookies()` in a component every page renders, which opts the
whole public site out of static rendering to answer a question only the owner
ever asks.

## Two things the chrome was not doing

**The nav never said which page you were on.** There is no server-side way to
read the path from a layout, so the three links became a small client component
around `usePathname` — no state, a few hundred bytes. The current item is
tinted, underlined, and carries `aria-current="page"`, because colour alone
leaves the header's one piece of state unavailable to a screen reader. Matching
is exact rather than by prefix: `/` is a prefix of everything.

**Email, GitHub and LinkedIn only existed at the bottom of the home page.**
Someone reading `/certificates` had to navigate back to `/` and scroll to the
end to find any of them. They are in the footer now, on every page. The list
moved to `lib/channels.ts` so the footer and the contact section cannot drift
into disagreeing about someone's own contact details, and the footer reuses
`ExternalLink` rather than hand-rolling `target`/`rel` again.

## Verification

1440px and 375px, both themes: no horizontal overflow, every interactive target
44px or more, footer flush to the document bottom, `aria-current` present on the
active link. 85 unit tests, 46 e2e — four new ones cover the console entry
points and the signed-in redirect.

One existing test needed updating rather than working around: the footer's
channel list is a second navigation landmark, so a bare
`getByRole("navigation")` matched two elements. Both are named now, which is
what that assertion always meant.

**Not run:** the `frontend-reviewer` pass, at your request. Worth doing before
merge — on the previous PR it found three blocking issues, one of them a real
bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
