### PR TITLE
Add the blog API: posts, Markdown bodies, and a publication date

### DIFF
--- a/apps/api/alembic/versions/a9c4d7e13f56_add_posts_table.py
+++ b/apps/api/alembic/versions/a9c4d7e13f56_add_posts_table.py
@@ -1,0 +1,73 @@
+"""add the posts table for the blog
+
+Revision ID: a9c4d7e13f56
+Revises: c7a3f5e21b08
+Create Date: 2026-08-11 19:04:12.883517
+
+A new table with no data to move, so this is the cheap kind of migration. Three
+things were still decided by hand rather than taken from autogenerate:
+
+``published`` gets ``server_default=false``, matching ``career_entries`` in
+b2f1c7d94a30 rather than the model's Python-side ``default=False``. The ORM
+always supplies the value, but ``INSERT`` from psql or a future backfill does
+not, and a NOT NULL column with no default turns that into an error instead of a
+draft.
+
+``tags`` is ``json``, not ``jsonb``, to match every other list column in this
+schema. That costs the containment operator, which is why
+``PortfolioService.get_posts`` filters by tag in Python — the note is there.
+Switching the whole schema to jsonb is a separate change, not a thing to do to
+one new table.
+
+``published_at`` is nullable and carries no index. Null is the normal state of a
+draft, and the table is expected to hold tens of rows, so the ordering scan is
+free; an index here would be decoration.
+
+``downgrade()`` drops the table, and with it every post ever written. That is
+reversible only while the table is empty, which it is on the way in — this
+migration creates it. Anyone reaching for the downgrade later is deleting
+content, not undoing a schema change.
+
+``ci.yml`` runs ``fly deploy`` on a push to main touching ``apps/api`` and the
+release command applies migrations, so this runs unattended against production.
+A CREATE TABLE is safe to run that way; nothing existing is touched.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a9c4d7e13f56'
+down_revision = 'c7a3f5e21b08'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'posts',
+        sa.Column('slug', sa.String(length=255), nullable=False),
+        sa.Column('title', sa.String(length=255), nullable=False),
+        sa.Column('excerpt', sa.Text(), nullable=True),
+        sa.Column('body', sa.Text(), nullable=False),
+        sa.Column('tags', sa.JSON(), nullable=True),
+        sa.Column('cover_image', sa.String(length=500), nullable=True),
+        sa.Column('published', sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column('published_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=True,
+        ),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_posts_id'), 'posts', ['id'], unique=False)
+    op.create_index(op.f('ix_posts_slug'), 'posts', ['slug'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_posts_slug'), table_name='posts')
+    op.drop_index(op.f('ix_posts_id'), table_name='posts')
+    op.drop_table('posts')

--- a/apps/api/app/api/v1/api.py
+++ b/apps/api/app/api/v1/api.py
@@ -5,6 +5,7 @@ from app.api.v1.endpoints import (
     career,
     certificates,
     contacts,
+    posts,
     projects,
     skills,
     users,
@@ -21,4 +22,5 @@ api_router.include_router(projects.router, prefix="/projects", tags=["projects"]
 api_router.include_router(skills.router, prefix="/skills", tags=["skills"])
 api_router.include_router(certificates.router, prefix="/certificates", tags=["certificates"])
 api_router.include_router(career.router, prefix="/career", tags=["career"])
+api_router.include_router(posts.router, prefix="/posts", tags=["blog"])
 api_router.include_router(contacts.router, prefix="/contacts", tags=["contacts"])

--- a/apps/api/app/api/v1/endpoints/posts.py
+++ b/apps/api/app/api/v1/endpoints/posts.py
@@ -1,0 +1,78 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.v1.dependencies import get_optional_admin, require_admin
+from app.core.constants import ErrorMessages, SuccessMessages
+from app.core.database import get_db
+from app.schemas.portfolio import Post, PostCreate, PostUpdate
+from app.services.portfolio_service import PortfolioService
+
+router = APIRouter()
+
+@router.get("/", response_model=List[Post])
+def get_posts(
+    tag: Optional[str] = Query(None, description="Only posts carrying this tag"),
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get published posts, newest first; admins also see drafts"""
+    service = PortfolioService(db)
+    return service.get_posts(tag=tag, include_unpublished=viewer is not None)
+
+@router.get("/slug/{slug}", response_model=Post)
+def get_post_by_slug(
+    slug: str,
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get a specific post by slug"""
+    service = PortfolioService(db)
+    post = service.get_post_by_slug(slug, include_unpublished=viewer is not None)
+    if not post:
+        raise HTTPException(status_code=404, detail=ErrorMessages.POST_NOT_FOUND)
+    return post
+
+@router.get("/{post_id}", response_model=Post)
+def get_post(
+    post_id: int,
+    db: Session = Depends(get_db),
+    viewer = Depends(get_optional_admin)
+):
+    """Get a specific post by ID"""
+    service = PortfolioService(db)
+    # A draft 404s for anonymous callers rather than 403ing, as everywhere
+    # else: whether an unpublished post exists at that id is itself not public.
+    post = service.get_post(post_id, include_unpublished=viewer is not None)
+    if not post:
+        raise HTTPException(status_code=404, detail=ErrorMessages.POST_NOT_FOUND)
+    return post
+
+@router.post("/", response_model=Post, dependencies=[Depends(require_admin)])
+def create_post(post: PostCreate, db: Session = Depends(get_db)):
+    """Create a new post"""
+    service = PortfolioService(db)
+    return service.create_post(post)
+
+@router.put("/{post_id}", response_model=Post, dependencies=[Depends(require_admin)])
+def update_post(
+    post_id: int,
+    post: PostUpdate,
+    db: Session = Depends(get_db)
+):
+    """Update an existing post"""
+    service = PortfolioService(db)
+    updated_post = service.update_post(post_id, post)
+    if not updated_post:
+        raise HTTPException(status_code=404, detail=ErrorMessages.POST_NOT_FOUND)
+    return updated_post
+
+@router.delete("/{post_id}", dependencies=[Depends(require_admin)])
+def delete_post(post_id: int, db: Session = Depends(get_db)):
+    """Delete a post"""
+    service = PortfolioService(db)
+    success = service.delete_post(post_id)
+    if not success:
+        raise HTTPException(status_code=404, detail=ErrorMessages.POST_NOT_FOUND)
+    return {"message": SuccessMessages.POST_DELETED}

--- a/apps/api/app/core/constants.py
+++ b/apps/api/app/core/constants.py
@@ -35,6 +35,9 @@ class ErrorMessages:
     # Career related
     CAREER_ENTRY_NOT_FOUND = "Career entry not found"
 
+    # Blog related
+    POST_NOT_FOUND = "Post not found"
+
     # Role & Permission related
     ROLE_NOT_FOUND = "Role not found"
     PERMISSION_NOT_FOUND = "Permission not found"
@@ -61,3 +64,4 @@ class SuccessMessages:
     SKILL_DELETED = "Skill deleted successfully"
     CERTIFICATE_DELETED = "Certificate deleted successfully"
     CAREER_ENTRY_DELETED = "Career entry deleted successfully"
+    POST_DELETED = "Post deleted successfully"

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -4,6 +4,7 @@ from .portfolio import (
     CareerEntry,
     Certificate,
     Contact,
+    Post,
     Project,
     ProjectStatus,
     Skill,
@@ -20,5 +21,5 @@ __all__ = [
     "Token", "TokenType",
     "Role", "Permission", "UserRole", "RolePermission",
     "Contact", "Project", "ProjectStatus", "Skill", "SkillLevel",
-    "Certificate", "CareerEntry"
+    "Certificate", "CareerEntry", "Post"
 ] 

--- a/apps/api/app/models/portfolio.py
+++ b/apps/api/app/models/portfolio.py
@@ -84,6 +84,32 @@ class CareerEntry(BaseModel):
     published = Column(Boolean, nullable=False, default=False)
 
 
+class Post(BaseModel):
+    """A blog post.
+
+    ``body`` holds Markdown, not HTML. The API stores and returns it verbatim
+    and never renders it — the web app does that server-side through a
+    sanitising pipeline, so no untrusted HTML is stored here waiting to be
+    trusted by whatever reads the column next.
+    """
+
+    __tablename__ = "posts"
+
+    slug = Column(String(255), unique=True, index=True, nullable=False)
+    title = Column(String(255), nullable=False)
+    # Shown on the index card and used as the meta description. Optional: a
+    # post without one falls back to the opening of the body.
+    excerpt = Column(Text)
+    body = Column(Text, nullable=False)
+    tags = Column(JSON)  # list[str]
+    cover_image = Column(String(500))
+    published = Column(Boolean, nullable=False, default=False)
+    # When the post first went live, which is not `created_at` — that is when
+    # the draft row was made, and a post written over a fortnight would carry
+    # the wrong date into the feed and the sitemap. Null until it is published.
+    published_at = Column(DateTime(timezone=True))
+
+
 class Contact(BaseModel):
     __tablename__ = "contacts"
 

--- a/apps/api/app/schemas/portfolio.py
+++ b/apps/api/app/schemas/portfolio.py
@@ -157,6 +157,40 @@ class CareerEntry(CareerEntryBase):
     created_at: datetime
     updated_at: Optional[datetime] = None
 
+# Post Schemas
+class PostBase(BaseModel):
+    title: str
+    excerpt: Optional[str] = None
+    # Markdown. See the note on the model: the API neither renders nor
+    # sanitises it, because it is not HTML on the way in or the way out.
+    body: str
+    tags: StringList = []
+    cover_image: Optional[str] = None
+    published: bool = False
+    # Writable so a post can be backdated to when it was actually written. Left
+    # out, the service stamps it the first time the post is published.
+    published_at: Optional[datetime] = None
+
+class PostCreate(PostBase):
+    slug: Optional[str] = None
+
+class PostUpdate(BaseModel):
+    title: Optional[str] = None
+    excerpt: Optional[str] = None
+    body: Optional[str] = None
+    tags: Optional[List[str]] = None
+    cover_image: Optional[str] = None
+    published: Optional[bool] = None
+    published_at: Optional[datetime] = None
+
+class Post(PostBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    slug: str
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
 # Contact Schemas
 class ContactBase(BaseModel):
     name: str

--- a/apps/api/app/services/portfolio_service.py
+++ b/apps/api/app/services/portfolio_service.py
@@ -1,15 +1,18 @@
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
 from app.core.slugs import unique_slug
-from app.models.portfolio import CareerEntry, Certificate, Contact, Project, Skill
+from app.models.portfolio import CareerEntry, Certificate, Contact, Post, Project, Skill
 from app.schemas.portfolio import (
     CareerEntryCreate,
     CareerEntryUpdate,
     CertificateCreate,
     CertificateUpdate,
     ContactCreate,
+    PostCreate,
+    PostUpdate,
     ProjectCreate,
     ProjectUpdate,
     SkillCreate,
@@ -28,13 +31,19 @@ class PortfolioService:
     def __init__(self, db: Session):
         self.db = db
 
-    def _create_with_slug(self, model, payload, title_field: str = "title"):
-        """Insert a slugged row, deriving the slug from its title if absent."""
+    def _create_with_slug(self, model, payload, title_field: str = "title", prepare=None):
+        """Insert a slugged row, deriving the slug from its title if absent.
+
+        ``prepare`` runs on the built row before it is added, for fields the
+        payload does not carry — the publication stamp is the only one so far.
+        """
         data = payload.model_dump()
         requested = data.pop("slug", None) or getattr(payload, title_field)
         data["slug"] = unique_slug(self.db, model, requested)
 
         record = model(**data)
+        if prepare is not None:
+            prepare(record)
         self.db.add(record)
         self.db.commit()
         self.db.refresh(record)
@@ -225,6 +234,78 @@ class PortfolioService:
             return False
 
         self.db.delete(db_entry)
+        self.db.commit()
+        return True
+
+    # Post methods
+    @staticmethod
+    def _stamp_publication(record) -> None:
+        """Record when a post first went live.
+
+        Set once and never moved. Unpublishing a post to fix a typo and
+        publishing it again keeps the original date, so the index does not
+        reshuffle and a date already sitting in someone's feed reader stays
+        true. An explicit ``published_at`` in the payload wins over this — that
+        is how a post gets backdated.
+        """
+        if record.published and record.published_at is None:
+            record.published_at = datetime.now(timezone.utc)
+
+    def get_posts(
+        self,
+        tag: Optional[str] = None,
+        include_unpublished: bool = False,
+    ) -> List[Post]:
+        query = self.db.query(Post)
+        if not include_unpublished:
+            query = query.filter(Post.published.is_(True))
+        # Newest first. Drafts have no publication date and sort to the end,
+        # which is where the admin list wants them.
+        posts = query.order_by(Post.published_at.desc().nullslast(), Post.id.desc()).all()
+
+        if tag:
+            # In Python, not SQL. `tags` is a plain JSON column, and Postgres
+            # has no containment operator for `json` — only `jsonb` — so the
+            # SQL form would need a cast that SQLite could not run in the test
+            # suite. There are tens of posts, not thousands.
+            posts = [post for post in posts if tag in (post.tags or [])]
+
+        return posts
+
+    def get_post(self, post_id: int, include_unpublished: bool = False) -> Optional[Post]:
+        query = self.db.query(Post).filter(Post.id == post_id)
+        if not include_unpublished:
+            query = query.filter(Post.published.is_(True))
+        return query.first()
+
+    def get_post_by_slug(
+        self, slug: str, include_unpublished: bool = False
+    ) -> Optional[Post]:
+        query = self.db.query(Post).filter(Post.slug == slug)
+        if not include_unpublished:
+            query = query.filter(Post.published.is_(True))
+        return query.first()
+
+    def create_post(self, post: PostCreate) -> Post:
+        return self._create_with_slug(Post, post, prepare=self._stamp_publication)
+
+    def update_post(self, post_id: int, post: PostUpdate) -> Optional[Post]:
+        db_post = self.get_post(post_id, include_unpublished=True)
+        if not db_post:
+            return None
+
+        self._apply_update(db_post, post)
+        self._stamp_publication(db_post)
+        self.db.commit()
+        self.db.refresh(db_post)
+        return db_post
+
+    def delete_post(self, post_id: int) -> bool:
+        db_post = self.get_post(post_id, include_unpublished=True)
+        if not db_post:
+            return False
+
+        self.db.delete(db_post)
         self.db.commit()
         return True
 

--- a/apps/api/scripts/seed_content.py
+++ b/apps/api/scripts/seed_content.py
@@ -16,7 +16,7 @@ duplicates, and re-running after editing an entry here pushes the edit through.
 import argparse
 import os
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -25,6 +25,7 @@ from app.core.slugs import slugify
 from app.models.portfolio import (
     CareerEntry,
     Certificate,
+    Post,
     Project,
     ProjectStatus,
     Skill,
@@ -375,6 +376,195 @@ CAREER_ENTRIES = [
 ]
 
 
+# Bodies are Markdown; the web app renders them server-side through a
+# sanitising pipeline. Each of these is about something that actually happened
+# in this repository, which is the only kind of post worth putting on a
+# portfolio — the commits are there to check them against.
+#
+# `published_at` is set explicitly rather than left to the service to stamp:
+# these are being backfilled, so "now" would be a lie and would order them by
+# whenever the seed happened to run.
+POSTS = [
+    {
+        "title": "Every corner on my site was square for three weeks",
+        "excerpt": (
+            "Tailwind v4 compiled my design token to invalid CSS. Type-check, "
+            "lint, build and a full frontend review all passed anyway."
+        ),
+        "tags": ["Tailwind", "CSS", "Debugging"],
+        "published_at": datetime(2026, 8, 9, tzinfo=timezone.utc),
+        "body": """\
+The radius scale on this site lives in one place, as a set of custom properties
+in `globals.css`:
+
+```css
+@theme {
+  --radius-card: 0.875rem;
+  --radius-control: 0.5rem;
+  --radius-pill: 9999px;
+}
+```
+
+Components then reach for a token instead of picking a number. That was the
+theory. In practice every card, every button and every badge on the site had
+perfectly square corners, and had done since the design system landed.
+
+## What was actually emitted
+
+The class was written `rounded-[--radius-card]`. Tailwind v4 treats the contents
+of square brackets as a literal value and substitutes it directly, so what
+reached the stylesheet was:
+
+```css
+border-radius: --radius-card;
+```
+
+That is not a length. It is not `var(--radius-card)`, it is the bare token name,
+and the browser does what the spec tells it to do with a declaration it cannot
+parse: it drops it silently. No console warning, no failed build. The element
+falls back to `border-radius: 0` and looks deliberate.
+
+The fix is four characters:
+
+```
+rounded-[var(--radius-card)]
+```
+
+## Why nothing caught it
+
+This is the part worth keeping. The change passed `tsc`, ESLint, `next build`,
+and a review pass by an agent that had screenshots of the rendered page in front
+of it. Every one of those checks is looking at either the class name — which is
+correct, the token exists and is spelled right — or at a page whose square
+corners read as a design decision rather than a bug.
+
+The check that would have caught it is the one nobody runs: opening devtools and
+asking the element what its computed `border-radius` is.
+
+```js
+getComputedStyle(document.querySelector('.card')).borderRadius  // "0px"
+```
+
+I have since written that down as a rule in the repo's `CLAUDE.md`. When a token
+stops applying, nothing fails loudly — so verify the emitted stylesheet, not the
+class name.
+""",
+    },
+    {
+        "title": "A portfolio that stays up when its backend doesn't",
+        "excerpt": (
+            "This site replaced a static SPA that could not break. Adding a "
+            "database was not allowed to take that away."
+        ),
+        "tags": ["Next.js", "FastAPI", "Reliability"],
+        "published_at": datetime(2026, 8, 6, tzinfo=timezone.utc),
+        "body": """\
+The version of this portfolio before this one was a Vite SPA with every project,
+skill and certificate hardcoded into a component array. It was unmaintainable,
+and it had exactly one virtue: it could not go down for any reason short of
+Vercel itself going down.
+
+Moving the content into a Postgres database behind a FastAPI service gave me an
+admin console and a content model. It also gave me a free-tier backend that goes
+to sleep, and a new way for the front page to return a 500 — to a recruiter, on
+the one visit I get.
+
+## Every read has a fallback
+
+So the fetch layer has one rule, applied without exception: a reader returns a
+fallback rather than throwing.
+
+```ts
+export async function getProjects(): Promise<Project[]> {
+  return getJson<Project[]>("/projects/", [], isList);
+}
+```
+
+`getJson` catches connection refused, DNS failure and a five-second timeout, logs
+the reason server-side so the failure is not actually silent, and hands back the
+fallback. The page then renders an empty state that was designed rather than
+left bare. A sleeping API costs a visitor a section, not the site.
+
+## The failure I did not expect
+
+The interesting case was not the backend being down. It was the backend being
+*up* and answering with something else — a gateway returning `200` with a JSON
+error body, a tunnel serving its own payload. `response.json()` returns `any`,
+and the cast that follows it is a promise rather than a check. Hand a
+list-shaped variable an object and the page throws on `.map()`.
+
+That is a 500 caused by a successful request, which is the one failure mode the
+rest of the module exists to rule out. So the shape is checked before the cast:
+
+```ts
+const isList: ShapeCheck = (data) => Array.isArray(data);
+```
+
+Cheap, and it closes the gap between "the request worked" and "the response is
+what I said it was".
+""",
+    },
+    {
+        "title": "Make the safe thing the default: published-only reads",
+        "excerpt": (
+            "A visibility filter you have to remember to apply is a leak "
+            "waiting for the day you forget."
+        ),
+        "tags": ["FastAPI", "Security", "API design"],
+        "published_at": datetime(2026, 8, 2, tzinfo=timezone.utc),
+        "body": """\
+Every content table in this API has a `published` flag, and every read route is
+world-readable. The only thing between an unfinished draft and the public
+internet is a `WHERE published = true`.
+
+The tempting shape is a parameter that turns the filter on:
+
+```python
+def get_projects(self, only_published: bool = False): ...
+```
+
+Written that way, a route that never thought about visibility leaks everything.
+The failure is silent, it looks like working code, and you find out when a draft
+shows up in a search result.
+
+## Inverted, with the default on the safe side
+
+```python
+def get_projects(self, include_unpublished: bool = False) -> List[Project]:
+    query = self.db.query(Project)
+    if not include_unpublished:
+        query = query.filter(Project.published.is_(True))
+    ...
+```
+
+Now a caller that forgets to think about visibility gets the published set. To
+see drafts you have to ask for them by name, in a way that is obvious in review.
+
+The routes ask like this:
+
+```python
+service.get_projects(include_unpublished=viewer is not None)
+```
+
+where `viewer` comes from `get_optional_admin` — a dependency that returns the
+admin if a valid token is present and `None` otherwise, and crucially does not
+raise. A stale token in a visitor's browser must mean "anonymous", not "401";
+otherwise one expired session breaks the whole public site.
+
+## 404, not 403
+
+One more detail that is easy to get wrong. Fetching a draft by id as an
+anonymous caller returns 404, not 403. A 403 confirms that a row exists at that
+id, and whether an unpublished post exists is itself not public information.
+
+There are tests for each of these, asked from outside as an anonymous HTTP
+client, because a filter exercised only by the code that sets it is not tested
+at all.
+""",
+    },
+]
+
+
 def _upsert(db, model, key_field, key_value, values, dry_run):
     """Insert or update one row, reporting which it did."""
     existing = db.query(model).filter(getattr(model, key_field) == key_value).first()
@@ -433,6 +623,14 @@ def seed(dry_run: bool = False) -> None:
             record(
                 _upsert(db, CareerEntry, "slug", slugify(label), values, dry_run),
                 label,
+            )
+
+        print("Posts")
+        for entry in POSTS:
+            values = dict(entry, published=True)
+            record(
+                _upsert(db, Post, "slug", slugify(entry["title"]), values, dry_run),
+                entry["title"],
             )
 
         if dry_run:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -8,7 +8,10 @@ import pytest
 
 from app.core.database import SessionLocal
 from app.core.rate_limit import limiter
+from app.models.role import Role, UserRole
+from app.models.token import TokenType
 from app.models.user import User, UserStatus
+from app.services.user_service import UserService
 
 
 @pytest.fixture(autouse=True)
@@ -85,3 +88,25 @@ def make_user(db):
 
     for email in made:
         _drop_user(db, email)
+
+
+@pytest.fixture
+def admin_token(db, make_user):
+    """A bearer token for a real admin user.
+
+    Goes through UserService.create_token rather than signing a JWT by hand,
+    because get_current_user_dependency also checks the token has a live row —
+    a hand-signed token is rejected before the admin check is ever reached.
+
+    Lives here rather than beside one test file: both the content tests and the
+    blog tests need an admin, and the second copy is where the two drift.
+    """
+    admin_role = db.query(Role).filter(Role.name == "admin").first()
+    if admin_role is None:
+        pytest.skip("no admin role in this database; run scripts/init_auth_tables.py")
+
+    user = make_user("content-admin@example.invalid")
+    db.add(UserRole(user_id=user.id, role_id=admin_role.id))
+    db.commit()
+
+    return UserService(db).create_token(user.id, TokenType.ACCESS, expires_in_minutes=10)

--- a/apps/api/tests/test_blog_api.py
+++ b/apps/api/tests/test_blog_api.py
@@ -1,0 +1,272 @@
+"""Blog endpoints: draft visibility, ordering, and the publication stamp.
+
+The draft/published cases are the same question ``test_content_api.py`` asks of
+the other content types, asked again here because the answer comes from a new
+set of service methods rather than a shared one — a filter is only tested where
+it is written.
+
+The publication stamp is the part that is genuinely new. ``published_at`` drives
+the order of the index, the ``<time>`` on each post, the sitemap's
+``lastmod`` and the RSS ``pubDate``, and it is derived by the service rather
+than supplied by the caller. That makes it worth pinning down: when it is set,
+when it must not move, and who can override it.
+
+Runs against whatever ``DATABASE_URL`` points at and inserts rows; each test
+cleans up what it made.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.slugs import unique_slug
+from app.main import app
+from app.models.portfolio import Post
+
+client = TestClient(app)
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def track_post(db):
+    """Remove post rows a test created, including ones made through the API."""
+    made = []
+
+    def _track(post_id: int) -> int:
+        made.append(post_id)
+        return post_id
+
+    yield _track
+
+    for post_id in made:
+        db.query(Post).filter(Post.id == post_id).delete()
+    db.commit()
+
+
+@pytest.fixture
+def make_post(db, track_post):
+    def _make(title, *, published: bool, published_at=None, tags=None):
+        record = Post(
+            slug=unique_slug(db, Post, title),
+            title=title,
+            body="Seeded by the test suite.",
+            tags=tags,
+            published=published,
+            published_at=published_at,
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        track_post(record.id)
+        return record
+
+    return _make
+
+
+def _create_via_api(admin_token, track_post, **payload):
+    """POST a post as the admin and register it for cleanup."""
+    body = {"title": "Written By The Suite", "body": "# Hello", **payload}
+    response = client.post("/api/v1/posts/", json=body, headers=_auth(admin_token))
+    assert response.status_code == 200, response.text
+    created = response.json()
+    track_post(created["id"])
+    return created
+
+
+# --- draft visibility ------------------------------------------------------
+
+def test_a_draft_post_is_not_in_the_public_list(make_post):
+    draft = make_post("Unfinished Thoughts", published=False)
+
+    slugs = [p["slug"] for p in client.get("/api/v1/posts/").json()]
+
+    assert draft.slug not in slugs
+
+
+def test_a_published_post_is_in_the_public_list(make_post):
+    """Baseline: without this the test above could pass on an empty list."""
+    live = make_post("Finished Thoughts", published=True)
+
+    slugs = [p["slug"] for p in client.get("/api/v1/posts/").json()]
+
+    assert live.slug in slugs
+
+
+def test_fetching_a_draft_post_by_id_is_a_404_not_a_403(make_post):
+    """403 would confirm the row exists. Whether a draft exists is not public."""
+    draft = make_post("Secret Draft Post", published=False)
+
+    assert client.get(f"/api/v1/posts/{draft.id}").status_code == 404
+
+
+def test_fetching_a_draft_post_by_slug_is_a_404(make_post):
+    draft = make_post("Secret Draft Post By Slug", published=False)
+
+    assert client.get(f"/api/v1/posts/slug/{draft.slug}").status_code == 404
+
+
+def test_an_admin_sees_draft_posts(make_post, admin_token):
+    draft = make_post("Visible To The Author", published=False)
+
+    response = client.get("/api/v1/posts/", headers=_auth(admin_token))
+
+    assert draft.slug in [p["slug"] for p in response.json()]
+
+
+def test_a_bogus_token_still_gets_the_public_list(make_post):
+    """A stale token in a visitor's browser means anonymous, not 401."""
+    live = make_post("Readable Without Credentials", published=True)
+
+    response = client.get("/api/v1/posts/", headers=_auth("not-a-real-token"))
+
+    assert response.status_code == 200
+    assert live.slug in [p["slug"] for p in response.json()]
+
+
+def test_writing_posts_needs_admin():
+    payload = {"title": "Unauthorised", "body": "nope"}
+
+    assert client.post("/api/v1/posts/", json=payload).status_code in (401, 403)
+
+
+def test_deleting_a_post_needs_admin(make_post):
+    live = make_post("Not Yours To Delete", published=True)
+
+    assert client.delete(f"/api/v1/posts/{live.id}").status_code in (401, 403)
+
+
+# --- ordering --------------------------------------------------------------
+
+def test_posts_are_listed_newest_first(make_post):
+    """The index reads as a feed, so the newest publication date leads."""
+    now = datetime.now(timezone.utc)
+    older = make_post("Older Post", published=True, published_at=now - timedelta(days=30))
+    newer = make_post("Newer Post", published=True, published_at=now - timedelta(days=1))
+
+    slugs = [p["slug"] for p in client.get("/api/v1/posts/").json()]
+
+    assert slugs.index(newer.slug) < slugs.index(older.slug)
+
+
+def test_drafts_sort_after_published_posts_for_an_admin(make_post, admin_token):
+    """A draft has no publication date; NULLS LAST is what keeps it off the top."""
+    live = make_post(
+        "Published And Dated",
+        published=True,
+        published_at=datetime.now(timezone.utc) - timedelta(days=365),
+    )
+    draft = make_post("Draft With No Date", published=False)
+
+    slugs = [p["slug"] for p in client.get("/api/v1/posts/", headers=_auth(admin_token)).json()]
+
+    assert slugs.index(live.slug) < slugs.index(draft.slug)
+
+
+# --- the publication stamp -------------------------------------------------
+
+def test_a_draft_has_no_publication_date(admin_token, track_post):
+    created = _create_via_api(admin_token, track_post, title="Still A Draft", published=False)
+
+    assert created["published_at"] is None
+
+
+def test_publishing_stamps_the_date(admin_token, track_post):
+    created = _create_via_api(admin_token, track_post, title="About To Go Live", published=False)
+
+    updated = client.put(
+        f"/api/v1/posts/{created['id']}",
+        json={"published": True},
+        headers=_auth(admin_token),
+    ).json()
+
+    assert updated["published_at"] is not None
+
+
+def test_republishing_keeps_the_original_date(admin_token, track_post):
+    """Unpublishing to fix a typo must not reorder the feed or rewrite history."""
+    created = _create_via_api(admin_token, track_post, title="Briefly Retracted", published=True)
+    original = created["published_at"]
+    assert original is not None
+
+    def put(body):
+        return client.put(
+            f"/api/v1/posts/{created['id']}", json=body, headers=_auth(admin_token)
+        ).json()
+
+    put({"published": False})
+    republished = put({"published": True})
+
+    assert republished["published_at"] == original
+
+
+def test_an_explicit_publication_date_is_kept(admin_token, track_post):
+    """Backdating a post that was written before the blog existed."""
+    backdated = "2020-01-02T03:04:05Z"
+
+    created = _create_via_api(
+        admin_token,
+        track_post,
+        title="Written Long Ago",
+        published=True,
+        published_at=backdated,
+    )
+
+    assert created["published_at"].startswith("2020-01-02T03:04:05")
+
+
+# --- slugs and shapes ------------------------------------------------------
+
+def test_a_slug_is_derived_from_the_title(admin_token, track_post):
+    created = _create_via_api(admin_token, track_post, title="Hello, World!!")
+
+    assert created["slug"] == "hello-world"
+
+
+def test_an_explicit_slug_is_honoured(admin_token, track_post):
+    """A post's URL is the one thing worth hand-setting: it is permanent."""
+    created = _create_via_api(
+        admin_token, track_post, title="A Long Editorial Title", slug="short-url"
+    )
+
+    assert created["slug"] == "short-url"
+
+
+def test_a_post_with_no_tags_serialises_them_as_empty_not_null(make_post):
+    """The JSON column is nullable; a NULL would 500 the list on the way out."""
+    live = make_post("No Tags At All", published=True, tags=None)
+
+    assert client.get(f"/api/v1/posts/{live.id}").json()["tags"] == []
+
+
+def test_the_body_is_returned_verbatim(admin_token, track_post):
+    """The API stores Markdown and does not render or escape it."""
+    markdown = "# Heading\n\nSome *emphasis* and `code`.\n"
+
+    created = _create_via_api(admin_token, track_post, body=markdown)
+
+    assert created["body"] == markdown
+
+
+# --- tags ------------------------------------------------------------------
+
+def test_the_tag_filter_selects_matching_posts(make_post):
+    tagged = make_post("Tagged Post", published=True, tags=["Tailwind", "CSS"])
+    untagged = make_post("Differently Tagged Post", published=True, tags=["FastAPI"])
+
+    slugs = [p["slug"] for p in client.get("/api/v1/posts/?tag=Tailwind").json()]
+
+    assert tagged.slug in slugs
+    assert untagged.slug not in slugs
+
+
+def test_the_tag_filter_still_excludes_drafts(make_post):
+    """Two filters compose here, and the publish one has to survive."""
+    draft = make_post("Tagged But Unpublished", published=False, tags=["Tailwind"])
+
+    slugs = [p["slug"] for p in client.get("/api/v1/posts/?tag=Tailwind").json()]
+
+    assert draft.slug not in slugs

--- a/apps/api/tests/test_content_api.py
+++ b/apps/api/tests/test_content_api.py
@@ -19,9 +19,6 @@ from fastapi.testclient import TestClient
 from app.core.slugs import slugify, unique_slug
 from app.main import app
 from app.models.portfolio import CareerEntry, Certificate, Project, ProjectStatus, Skill, SkillLevel
-from app.models.role import Role, UserRole
-from app.models.token import TokenType
-from app.services.user_service import UserService
 
 client = TestClient(app)
 
@@ -51,25 +48,6 @@ def make_project(db):
     for project_id in made:
         db.query(Project).filter(Project.id == project_id).delete()
     db.commit()
-
-
-@pytest.fixture
-def admin_token(db, make_user):
-    """A bearer token for a real admin user.
-
-    Goes through UserService.create_token rather than signing a JWT by hand,
-    because get_current_user_dependency also checks the token has a live row —
-    a hand-signed token is rejected before the admin check is ever reached.
-    """
-    admin_role = db.query(Role).filter(Role.name == "admin").first()
-    if admin_role is None:
-        pytest.skip("no admin role in this database; run scripts/init_auth_tables.py")
-
-    user = make_user("content-admin@example.invalid")
-    db.add(UserRole(user_id=user.id, role_id=admin_role.id))
-    db.commit()
-
-    return UserService(db).create_token(user.id, TokenType.ACCESS, expires_in_minutes=10)
 
 
 def _auth(token):


### PR DESCRIPTION
Backend half of the blog. The web pages come in a follow-up so this stays reviewable.

## What lands

A `posts` table and the CRUD behind it, in the shape the other three content types already use: slug + `published`, public reads defaulting to published-only, writes behind `require_admin`.

## Decisions

**Markdown, not HTML, in `body`.** The API stores and returns it verbatim and never renders it, so no untrusted HTML sits in the column waiting to be trusted by whatever reads it next. Rendering and sanitisation happen once, server-side, in the web app — the place that knows it is producing HTML. The alternative (HTML in the DB) would mean sanitising on write *and* on render, and would make the admin editor a raw-HTML box.

**Slug derived from the title, override allowed on create.** Same as `ProjectCreate`. The override earns its keep here: a post's URL is permanent and an editorial title makes a bad one.

**`published_at` is a real column, not `created_at`.** `created_at` is when the draft row was made. For a post written over a fortnight that is the wrong date, and it is the one that would end up in the feed and the sitemap. The service stamps it the first time the post goes live and then never moves it — unpublishing to fix a typo does not reshuffle the index or rewrite a date already in someone's feed reader. An explicit value wins, which is how a post gets backdated.

**`tags` filtered in Python.** The column is `json`, not `jsonb`, so Postgres has no containment operator for it, and the cast that would fix that is not something SQLite can run. Tens of rows, not thousands. Noted in the code and the migration header.

## Migration

Hand-checked, per the repo's rule. `published` gets `server_default=false` so an `INSERT` from psql is a draft rather than an error; `published_at` is nullable and unindexed on purpose. `downgrade()` drops the table and every post in it — reversible only while it is empty, which it is on the way in. This runs unattended against production via `fly deploy`, and a `CREATE TABLE` is safe to run that way.

## Verification

Against a scratch Postgres on 55432, not the production database the local `.env` points at.

- `alembic upgrade head` from empty, then `downgrade -1` and back up — clean both ways
- `pytest -q` — 125 passed, including 20 new blog tests
- API running on 8010: posts list newest-first, `?tag=FastAPI` filters correctly, the Markdown body comes back byte-for-byte, a draft 404s anonymously and appears for an admin

The new tests cover the publication stamp specifically: that publishing sets it, that republishing does not move it, that an explicit date is kept, and that drafts sort last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)