### PR TITLE
Inbox: mark read and delete, without JavaScript

### DIFF
--- a/apps/web/app/(console)/admin/page.tsx
+++ b/apps/web/app/(console)/admin/page.tsx
@@ -1,13 +1,17 @@
 import type { Metadata } from "next";
 
+import { markContactAsRead, removeContact } from "@/app/actions/contacts";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { ConfirmDelete } from "@/components/ui/confirm-delete";
 import { Container } from "@/components/ui/container";
 import { Eyebrow, eyebrowClasses } from "@/components/ui/eyebrow";
 import { Notice } from "@/components/ui/notice";
 import { cn } from "@/lib/cn";
 import { requireAdmin } from "@/lib/admin-guard";
 import { fetchContacts } from "@/lib/console-api";
+import { inboxProblem } from "@/lib/inbox";
 
 export const metadata: Metadata = {
   title: "Inbox",
@@ -26,8 +30,10 @@ export const metadata: Metadata = {
  * It is also the first time these submissions are readable anywhere but the
  * notification email.
  *
- * Editing — marking read, deleting, and content CRUD — is deliberately not here
- * yet.
+ * Messages can now be marked read and deleted. Both are plain form posts to
+ * Server Actions, so the inbox works with scripting off; see
+ * app/actions/contacts.ts for why the outcome comes back through the URL.
+ * Content CRUD is still to come.
  */
 
 /** "10 Aug 2026, 21:47" in the reader's locale-independent short form. */
@@ -44,12 +50,13 @@ function formatReceived(value: string): string {
   });
 }
 
-export default async function AdminInboxPage() {
+export default async function AdminInboxPage({ searchParams }: PageProps<"/admin">) {
   // Runs in the layout too. Repeated here rather than passed down because a
   // page must not depend on a parent having done the check — and it is a cache
   // hit on the same request, not a second call to the API.
   const { accessToken } = await requireAdmin("/admin");
   const result = await fetchContacts(accessToken);
+  const problem = inboxProblem((await searchParams).problem);
 
   return (
     // "wide" rather than "layout": these cards are a column of prose, and the
@@ -61,6 +68,16 @@ export default async function AdminInboxPage() {
       <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
         Contact messages
       </h1>
+
+      {/*
+        A failed write, reported above the list rather than beside the message
+        it concerns. The action redirects, so by the time this renders the page
+        has been rebuilt from scratch and there is no row to attach it to — and
+        the thing the reader needs is the sentence, not its position.
+      */}
+      {problem ? (
+        <Notice className="mt-8 border-destructive/50">{problem}</Notice>
+      ) : null}
 
       {!result.ok ? (
         /*
@@ -120,6 +137,39 @@ export default async function AdminInboxPage() {
                   <p className="mt-4 max-w-prose whitespace-pre-line text-sm text-foreground">
                     {contact.message}
                   </p>
+
+                  {/*
+                    items-start, not items-center: the delete control is a
+                    <details> that grows downwards when opened, and centring
+                    would drag "Mark as read" halfway down the card with it.
+                  */}
+                  <div className="mt-5 flex flex-wrap items-start gap-2 border-t border-border/60 pt-4">
+                    {/*
+                      Only while it is unread. A button that is already done is
+                      either a no-op the reader has to test, or a lie — and the
+                      API has no route back, so it could not be a toggle.
+                    */}
+                    {!contact.read && (
+                      <form action={markContactAsRead}>
+                        <input type="hidden" name="id" value={contact.id} />
+                        <Button
+                          variant="quiet"
+                          type="submit"
+                          className="min-h-11 px-4 py-2 text-xs"
+                        >
+                          Mark as read
+                        </Button>
+                      </form>
+                    )}
+
+                    <ConfirmDelete
+                      action={removeContact}
+                      id={contact.id}
+                      // Names the sender, so the confirmation is about a
+                      // message rather than about a row number.
+                      warning={`Delete the message from ${contact.name}? This cannot be undone, and it is the only copy outside your email.`}
+                    />
+                  </div>
                 </Card>
               </li>
             ))}

--- a/apps/web/app/actions/contacts.ts
+++ b/apps/web/app/actions/contacts.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { requireAdmin } from "@/lib/admin-guard";
+import { deleteContact, markContactRead } from "@/lib/console-api";
+import { INBOX_PATH, type InboxProblem } from "@/lib/inbox";
+
+/**
+ * The inbox's two writes.
+ *
+ * ## Why there is no `revalidatePath`
+ *
+ * There is nothing to revalidate. lib/console-api.ts reads `no-store`
+ * throughout — a response that depends on an Authorization header must not sit
+ * in a shared cache — so the next render of /admin already fetches fresh. The
+ * public site's readers are the ones behind a five-minute ISR window, and none
+ * of them read contacts. A `revalidatePath` here would be a no-op that looked
+ * load-bearing, which is worse than not having it; the CRUD screens for
+ * published content will need one, and it will mean something there.
+ *
+ * ## Why the outcome travels in the URL
+ *
+ * These are plain `<form action={...}>` posts, so they work with scripting off,
+ * and a bare Server Action has no way to hand anything back to a page rendered
+ * that way. `useActionState` would, at the cost of making both controls client
+ * components that do nothing until hydration. Redirecting with a `problem` code
+ * keeps the whole path server-side, and the success case redirects too — to the
+ * clean URL, so a failure notice cannot outlive the failure that caused it.
+ *
+ * ## Why each one re-checks the session
+ *
+ * `requireAdmin` runs in the layout, but a layout does not guard a Server
+ * Action: the action is a POST endpoint the browser can reach directly, and it
+ * has to establish for itself who is calling. The API would refuse an
+ * unauthenticated write anyway — this is what turns that refusal into a sign-in
+ * screen rather than an error.
+ */
+
+/** Reject anything that is not a plain positive integer before it reaches a URL. */
+function readId(formData: FormData): number | null {
+  const id = Number(formData.get("id"));
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+function fail(problem: InboxProblem): never {
+  redirect(`${INBOX_PATH}?problem=${problem}`);
+}
+
+/**
+ * Which sentence a failed write earns.
+ *
+ * `missing` is the interesting one: a 404 here almost always means the message
+ * was deleted from another tab, which is not a fault and must not be reported
+ * as one. `whenFailed` is what is left — the API was reachable but refused, or
+ * was not reachable at all.
+ */
+function problemFor(
+  reason: "unauthorized" | "rate_limited" | "missing" | "error",
+  whenFailed: InboxProblem,
+): InboxProblem {
+  if (reason === "unauthorized") return "session-ended";
+  if (reason === "missing") return "already-gone";
+  return whenFailed;
+}
+
+export async function markContactAsRead(formData: FormData): Promise<void> {
+  const { accessToken } = await requireAdmin(INBOX_PATH);
+
+  const id = readId(formData);
+  if (id === null) fail("unknown-message");
+
+  const result = await markContactRead(accessToken, id);
+  if (!result.ok) fail(problemFor(result.reason, "not-marked"));
+
+  redirect(INBOX_PATH);
+}
+
+export async function removeContact(formData: FormData): Promise<void> {
+  const { accessToken } = await requireAdmin(INBOX_PATH);
+
+  const id = readId(formData);
+  if (id === null) fail("unknown-message");
+
+  const result = await deleteContact(accessToken, id);
+  if (!result.ok) fail(problemFor(result.reason, "not-deleted"));
+
+  redirect(INBOX_PATH);
+}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -20,6 +20,18 @@ const VARIANTS = {
   primary: "bg-primary text-primary-foreground hover:opacity-90",
   /** Secondary actions that should not compete: "send another", "cancel". */
   quiet: "border border-border text-foreground hover:border-primary/40 hover:text-primary",
+  /**
+   * Destructive actions. Outlined rather than filled, and set in
+   * --destructive-text rather than --destructive.
+   *
+   * Both halves matter. A filled red button is the loudest thing on a screen,
+   * and these sit in a row of ordinary controls — the weight should come from
+   * the confirmation step, not the colour. And --destructive is tuned to be
+   * seen as a fill or a border: as *text* it measures 3.76:1 on a card in light
+   * mode and 1.88:1 in dark, which is why the palette carries a second red.
+   */
+  danger:
+    "border border-destructive/50 text-destructive-text hover:border-destructive hover:bg-destructive/10",
 } as const;
 
 export function buttonClasses(

--- a/apps/web/components/ui/confirm-delete.tsx
+++ b/apps/web/components/ui/confirm-delete.tsx
@@ -1,0 +1,62 @@
+import { Button, buttonClasses } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+/**
+ * A delete that takes two deliberate actions, and no JavaScript to enforce it.
+ *
+ * The reflex here is `onClick={() => confirm(...)}`, which fails in the wrong
+ * direction: with scripting off the handler never runs and the single click
+ * deletes immediately — a guard that disappears exactly when it is not being
+ * watched. A `<dialog>` has the same problem, since it needs `showModal()` to
+ * open at all.
+ *
+ * `<details>` is the version that works with nothing running. The summary is
+ * keyboard-operable and screen-reader-announced natively, the panel is real
+ * markup either way, and the destructive control genuinely does not exist on
+ * the page until it has been opened. The summary relabels itself to "Cancel"
+ * when open, because a control that still says "Delete" while a Delete button
+ * sits underneath it is asking to be clicked twice.
+ *
+ * Consumed by the inbox now; every content list that grows a delete wants the
+ * same thing, which is why it is here rather than in that page.
+ */
+export function ConfirmDelete({
+  action,
+  id,
+  warning,
+  confirmLabel = "Delete permanently",
+}: {
+  /** A Server Action. It receives the `id` below as a form field. */
+  action: (formData: FormData) => Promise<void>;
+  id: number;
+  /** What is about to be lost. Specific — "this message", not "this item". */
+  warning: string;
+  confirmLabel?: string;
+}) {
+  return (
+    <details className="group/confirm">
+      <summary
+        className={cn(
+          buttonClasses("quiet", "min-h-11 cursor-pointer px-4 py-2 text-xs"),
+          // The default triangle is removed in both engines — Blink and modern
+          // Safari use ::marker, older WebKit its own pseudo-element.
+          "list-none [&::-webkit-details-marker]:hidden",
+        )}
+      >
+        <span className="group-open/confirm:hidden">Delete</span>
+        <span className="hidden group-open/confirm:inline">Cancel</span>
+      </summary>
+
+      <div className="mt-2 rounded-[var(--radius-control)] border border-destructive/40 bg-card p-3">
+        <p className="text-sm text-foreground">{warning}</p>
+
+        <form action={action} className="mt-3">
+          <input type="hidden" name="id" value={id} />
+          <Button variant="danger" type="submit" className="min-h-11 px-4 py-2 text-xs">
+            {confirmLabel}
+          </Button>
+        </form>
+      </div>
+    </details>
+  );
+}

--- a/apps/web/lib/console-api.ts
+++ b/apps/web/lib/console-api.ts
@@ -29,6 +29,13 @@ export type ApiResult<T> =
   | { ok: true; data: T }
   | { ok: false; reason: "unauthorized" }
   | { ok: false; reason: "rate_limited"; response: Response }
+  /**
+   * The row is not there. Distinguished from `error` because it is the one
+   * failure with a specific, common and completely benign cause — the thing was
+   * deleted since the page rendered — and collapsing it into "the API did not
+   * answer" makes the console report an outage that did not happen.
+   */
+  | { ok: false; reason: "missing" }
   | { ok: false; reason: "error" };
 
 async function call(
@@ -68,6 +75,10 @@ async function toResult<T>(response: Response | null, url: string): Promise<ApiR
   }
 
   if (response.status === 429) return { ok: false, reason: "rate_limited", response };
+
+  // Not logged: a 404 on a write means the row went away, which is an ordinary
+  // race between two tabs rather than something wrong with the system.
+  if (response.status === 404) return { ok: false, reason: "missing" };
 
   if (!response.ok) {
     console.error(`[console] ${response.status} ${response.statusText} from ${url}`);
@@ -158,4 +169,28 @@ export async function fetchContacts(token: string): Promise<ApiResult<Contact[]>
   }
 
   return result;
+}
+
+/**
+ * Mark a message read.
+ *
+ * One-way, because the API is: it exposes `PUT /contacts/{id}/read` and nothing
+ * that clears the flag. That is the right shape — the flag records having seen
+ * a message, and there is no version of "I have not seen this" that becomes
+ * true again afterwards.
+ */
+export async function markContactRead(
+  token: string,
+  id: number,
+): Promise<ApiResult<Contact>> {
+  const path = `/contacts/${id}/read`;
+  const response = await call(path, { method: "PUT", token });
+  return toResult<Contact>(response, path);
+}
+
+/** Delete a message. There is no soft delete on the API; the row goes. */
+export async function deleteContact(token: string, id: number): Promise<ApiResult<unknown>> {
+  const path = `/contacts/${id}`;
+  const response = await call(path, { method: "DELETE", token });
+  return toResult<unknown>(response, path);
 }

--- a/apps/web/lib/inbox.ts
+++ b/apps/web/lib/inbox.ts
@@ -1,0 +1,54 @@
+/**
+ * What the inbox's actions can report back, and how it is worded.
+ *
+ * Lives here rather than beside the Server Actions that produce it, for the
+ * reason lib/contact.ts records: a `"use server"` module may only export async
+ * functions, and a lookup table exported from one type-checks and builds
+ * cleanly, then throws the first time the action is invoked.
+ */
+
+/** The inbox is the console's index; the actions redirect back to it. */
+export const INBOX_PATH = "/admin";
+
+export type InboxProblem =
+  | "unknown-message"
+  | "already-gone"
+  | "not-marked"
+  | "not-deleted"
+  | "session-ended";
+
+/**
+ * Each line says what happened, what state the message is now in, and what to
+ * do. The middle part is the one that matters: after a failed write the only
+ * question is whether it half-happened, and "it is unchanged" answers it.
+ *
+ * `already-gone` is separate from the two below it because it is the likeliest
+ * failure by far — a message deleted in another tab, or on a page left open —
+ * and it is not a fault. Reporting it as "the API did not answer" would be both
+ * alarming and untrue: the API answered, promptly, with a 404.
+ */
+const MESSAGES: Record<InboxProblem, string> = {
+  "unknown-message":
+    "That request did not name a message, so nothing changed. Reload and try again.",
+  "already-gone":
+    "That message had already been deleted, so nothing changed. The list below is current.",
+  "not-marked":
+    "That message was not marked as read — the API did not answer. It is unchanged; try again.",
+  "not-deleted":
+    "That message was not deleted — the API did not answer. It is still here; try again.",
+  "session-ended":
+    "Your session ended before that went through, so nothing changed. Sign in again to repeat it.",
+};
+
+/**
+ * Turn a `?problem=` value into something to show, or null.
+ *
+ * Anything unrecognised returns null rather than being echoed: the value
+ * arrives from the URL, so a visitor can put whatever they like in it, and a
+ * page that renders it is a page that renders text chosen by whoever wrote the
+ * link.
+ */
+export function inboxProblem(value: string | string[] | undefined): string | null {
+  const key = Array.isArray(value) ? value[0] : value;
+  return key && key in MESSAGES ? MESSAGES[key as InboxProblem] : null;
+}


### PR DESCRIPTION
Item 2 of the admin brief. **Stacked on #36**, which is stacked on #35 — the base here is `feat/blog-web`, so this diff is just the console.

No backend change: `PUT /contacts/{id}/read` and `DELETE /contacts/{id}` already exist behind `require_admin`.

## The confirmation is a `<details>`

Both actions are plain `<form action={serverAction}>` posts so the inbox works with scripting off, and that constraint decided how delete is confirmed.

`onClick={() => confirm(...)}` fails in the wrong direction: with no JavaScript the handler never runs, the single click deletes, and the guard is missing exactly when nothing is watching. `<dialog>` has the same problem — it needs `showModal()` to open at all.

A `<details>` needs nothing running. The summary is keyboard-operable and screen-reader-announced natively, and the destructive button does not exist on the page until it has been opened. It relabels itself to "Cancel" while open, because a control still reading "Delete" directly above a Delete button is asking to be clicked twice.

## Marking read is one-way

Matching the API, which has no route back. That is the right shape: the flag records having *seen* a message, and there is no version of "I have not seen this" that becomes true again. So the button renders only while a message is unread, rather than being a toggle that lies about what it does.

## What driving it changed

A 404 was being reported as "the API did not answer" — but the API had answered, promptly, and the message had simply been deleted from another tab. That is the likeliest failure on this screen and it is not a fault. `ApiResult` gained a `missing` reason, and the inbox now says:

> That message had already been deleted, so nothing changed. The list below is current.

Which is also true — the redirect means the list is re-fetched.

## Smaller notes

- The outcome travels in the URL rather than through `useActionState`, which would make both controls client components that do nothing until hydration. Success redirects to the clean path, so a stale failure notice cannot outlive its failure.
- No `revalidatePath`: `console-api.ts` reads `no-store` throughout, so there is no cache to bust. The CRUD screens for published content will need one, and it will mean something there.
- Each action re-checks the session. A layout does not guard a Server Action — it is a POST endpoint the browser can reach directly.
- `Button` gained a `danger` variant: outlined not filled, and set in `--destructive-text` rather than `--destructive`, which is tuned for fills and measures 1.88:1 as text in dark mode. Measured 7.93:1 as used here.
- `ConfirmDelete` is in `components/ui/` because every content list that grows a delete wants exactly this.

## Verification

Against a real session and a real API on 8010, not a stub:

- marking read clears the badge and the button, and the count updates
- deleting removes the row; the two-step confirm behaves and the summary relabels
- a message deleted behind the page's back reports "already deleted" and renders a current list
- 1440px and 375px, both themes: no overflow, every control ≥44px, no contrast failure

`pnpm lint`, 106 unit tests, 58 e2e.

## Known, not addressed here

When the API is unreachable, `requireAdmin` sends the admin to `/login` rather than saying the API is down — so the "try again" notices are only reachable when the API answers and refuses. That is existing behaviour in `lib/admin-guard.ts`, and a signed-in admin meeting an outage arguably deserves a better answer than a sign-in form that also cannot work. Changing that function's contract touches the login and refresh flows and their e2e specs, so it belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)