### PR TITLE
Land the blog pages and the inbox actions on main

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,9 @@
 # (lib/api.ts appends that). Read on the server only, so it is deliberately not
 # prefixed NEXT_PUBLIC_: the API's location is never shipped to the browser.
 API_URL=http://127.0.0.1:8000
+
+# The site's own public origin, no trailing slash. Only the sitemap, the RSS
+# feed and the Open Graph tags need it — everything else links relatively. Left
+# unset it falls back to the production URL, so a preview deploy emits links
+# that work rather than links to a machine the reader does not have.
+SITE_URL=http://localhost:3000

--- a/apps/web/app/(console)/admin/page.tsx
+++ b/apps/web/app/(console)/admin/page.tsx
@@ -1,13 +1,17 @@
 import type { Metadata } from "next";
 
+import { markContactAsRead, removeContact } from "@/app/actions/contacts";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { ConfirmDelete } from "@/components/ui/confirm-delete";
 import { Container } from "@/components/ui/container";
 import { Eyebrow, eyebrowClasses } from "@/components/ui/eyebrow";
 import { Notice } from "@/components/ui/notice";
 import { cn } from "@/lib/cn";
 import { requireAdmin } from "@/lib/admin-guard";
 import { fetchContacts } from "@/lib/console-api";
+import { inboxProblem } from "@/lib/inbox";
 
 export const metadata: Metadata = {
   title: "Inbox",
@@ -26,8 +30,10 @@ export const metadata: Metadata = {
  * It is also the first time these submissions are readable anywhere but the
  * notification email.
  *
- * Editing — marking read, deleting, and content CRUD — is deliberately not here
- * yet.
+ * Messages can now be marked read and deleted. Both are plain form posts to
+ * Server Actions, so the inbox works with scripting off; see
+ * app/actions/contacts.ts for why the outcome comes back through the URL.
+ * Content CRUD is still to come.
  */
 
 /** "10 Aug 2026, 21:47" in the reader's locale-independent short form. */
@@ -44,12 +50,13 @@ function formatReceived(value: string): string {
   });
 }
 
-export default async function AdminInboxPage() {
+export default async function AdminInboxPage({ searchParams }: PageProps<"/admin">) {
   // Runs in the layout too. Repeated here rather than passed down because a
   // page must not depend on a parent having done the check — and it is a cache
   // hit on the same request, not a second call to the API.
   const { accessToken } = await requireAdmin("/admin");
   const result = await fetchContacts(accessToken);
+  const problem = inboxProblem((await searchParams).problem);
 
   return (
     // "wide" rather than "layout": these cards are a column of prose, and the
@@ -61,6 +68,16 @@ export default async function AdminInboxPage() {
       <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
         Contact messages
       </h1>
+
+      {/*
+        A failed write, reported above the list rather than beside the message
+        it concerns. The action redirects, so by the time this renders the page
+        has been rebuilt from scratch and there is no row to attach it to — and
+        the thing the reader needs is the sentence, not its position.
+      */}
+      {problem ? (
+        <Notice className="mt-8 border-destructive/50">{problem}</Notice>
+      ) : null}
 
       {!result.ok ? (
         /*
@@ -120,6 +137,39 @@ export default async function AdminInboxPage() {
                   <p className="mt-4 max-w-prose whitespace-pre-line text-sm text-foreground">
                     {contact.message}
                   </p>
+
+                  {/*
+                    items-start, not items-center: the delete control is a
+                    <details> that grows downwards when opened, and centring
+                    would drag "Mark as read" halfway down the card with it.
+                  */}
+                  <div className="mt-5 flex flex-wrap items-start gap-2 border-t border-border/60 pt-4">
+                    {/*
+                      Only while it is unread. A button that is already done is
+                      either a no-op the reader has to test, or a lie — and the
+                      API has no route back, so it could not be a toggle.
+                    */}
+                    {!contact.read && (
+                      <form action={markContactAsRead}>
+                        <input type="hidden" name="id" value={contact.id} />
+                        <Button
+                          variant="quiet"
+                          type="submit"
+                          className="min-h-11 px-4 py-2 text-xs"
+                        >
+                          Mark as read
+                        </Button>
+                      </form>
+                    )}
+
+                    <ConfirmDelete
+                      action={removeContact}
+                      id={contact.id}
+                      // Names the sender, so the confirmation is about a
+                      // message rather than about a row number.
+                      warning={`Delete the message from ${contact.name}? This cannot be undone, and it is the only copy outside your email.`}
+                    />
+                  </div>
                 </Card>
               </li>
             ))}

--- a/apps/web/app/(site)/blog/[slug]/page.tsx
+++ b/apps/web/app/(site)/blog/[slug]/page.tsx
@@ -1,0 +1,167 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Container } from "@/components/ui/container";
+import { eyebrowClasses } from "@/components/ui/eyebrow";
+import { getPost, getPosts } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import { formatFullDate, isoDay } from "@/lib/format";
+import { readingMinutes, renderMarkdown, summarise } from "@/lib/markdown";
+import { absoluteUrl } from "@/lib/site";
+
+/**
+ * Pre-render the published posts at build time. Anything published after the
+ * last deploy still renders on demand and is then cached, so writing a post
+ * does not need a redeploy — same arrangement as the project pages.
+ */
+export async function generateStaticParams() {
+  const posts = await getPosts();
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/blog/[slug]">): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getPost(slug);
+
+  if (!post) return { title: "Post not found" };
+
+  const description = post.excerpt ?? summarise(post.body);
+
+  return {
+    title: post.title,
+    description,
+    alternates: { canonical: absoluteUrl(`/blog/${post.slug}`) },
+    openGraph: {
+      type: "article",
+      title: post.title,
+      description,
+      url: absoluteUrl(`/blog/${post.slug}`),
+      // The instant, not the day: Open Graph wants ISO 8601 and consumers use
+      // it for ordering, where a date alone puts everything at midnight.
+      publishedTime: post.published_at ?? undefined,
+      tags: post.tags,
+      images: post.cover_image ? [post.cover_image] : undefined,
+    },
+  };
+}
+
+function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <>
+      <dt className={eyebrowClasses}>{label}</dt>
+      <dd className="text-sm text-foreground">{children}</dd>
+    </>
+  );
+}
+
+export default async function PostPage({ params }: PageProps<"/blog/[slug]">) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+
+  // Null covers both a genuine 404 and an API outage. A reader can act on
+  // neither, and 404 is the honest answer for "this page has no content" — the
+  // outage is distinguishable on the server log.
+  if (!post) notFound();
+
+  const html = await renderMarkdown(post.body);
+  const day = isoDay(post.published_at);
+
+  return (
+    <>
+      {/*
+        How far through the post you are. Fixed to the top of the viewport
+        rather than pinned under the header, so it does not depend on the
+        header's height; z-50 puts it over the nav's own z-40.
+
+        The fill is scroll-driven CSS — no client component, no scroll
+        listener. See `.reading-progress` in globals.css for why it is behind
+        a `@supports` and a reduced-motion guard, and what it does without
+        them: nothing, which is the correct amount for a decoration.
+      */}
+      <div aria-hidden="true" className="fixed inset-x-0 top-0 z-50 h-0.5">
+        <div className="reading-progress h-full w-full bg-primary" />
+      </div>
+
+      <article className="py-14 sm:py-20">
+        <Container width="reading">
+          <Link
+            href="/blog"
+            className={cn(eyebrowClasses, "transition-colors hover:text-primary")}
+          >
+            ← All posts
+          </Link>
+
+          <header className="mt-8">
+            <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              {post.title}
+            </h1>
+
+            {/*
+              The post's fields, as fields. A description list is the honest
+              markup for label/value pairs, and the two-column grid is the same
+              device the footer uses for its contact channels — a label column
+              sized to the longest label, so adding a row cannot break the
+              alignment.
+            */}
+            <dl className="mt-6 grid grid-cols-[auto_1fr] items-baseline gap-x-6 gap-y-2 border-y border-border py-4">
+              {day ? (
+                <MetaRow label="Published">
+                  <time dateTime={day}>{formatFullDate(post.published_at)}</time>
+                </MetaRow>
+              ) : null}
+
+              <MetaRow label="Reading">{readingMinutes(post.body)} min</MetaRow>
+
+              {post.tags.length > 0 ? (
+                <MetaRow label="Tags">{post.tags.join(" · ")}</MetaRow>
+              ) : null}
+            </dl>
+          </header>
+
+          {post.cover_image ? (
+            /*
+              A plain <img>, not next/image. The URL comes from the API and can
+              point at any host, and next/image refuses anything not listed in
+              `remotePatterns` — so using it here would mean either a redeploy
+              every time a cover is hosted somewhere new, or a wildcard, which
+              turns the site's image optimiser into an open proxy.
+
+              Fixed aspect ratio because the API does not send dimensions and a
+              cover that reflows the article on load is worse than one cropped.
+              Empty alt: there is no alt-text field to fill it from, and an
+              invented description is worse than none.
+            */
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={post.cover_image}
+              alt=""
+              loading="lazy"
+              className="mt-10 aspect-[2/1] w-full rounded-[var(--radius-card)] border border-border object-cover"
+            />
+          ) : null}
+
+          {/*
+            Sanitised in lib/markdown.ts, which is the only reason this is safe.
+            The API stores Markdown verbatim and never escapes anything.
+          */}
+          <div
+            className="article-prose mt-10"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+
+          <footer className="mt-14 border-t border-border pt-6">
+            <Link
+              href="/blog"
+              className={cn(eyebrowClasses, "transition-colors hover:text-primary")}
+            >
+              ← All posts
+            </Link>
+          </footer>
+        </Container>
+      </article>
+    </>
+  );
+}

--- a/apps/web/app/(site)/blog/feed.xml/route.ts
+++ b/apps/web/app/(site)/blog/feed.xml/route.ts
@@ -1,0 +1,95 @@
+import { getPosts } from "@/lib/api";
+import { summarise } from "@/lib/markdown";
+import { absoluteUrl } from "@/lib/site";
+
+/**
+ * RSS for the blog.
+ *
+ * Descriptions only, not full post bodies. A feed carrying the whole article
+ * has to embed sanitised HTML inside XML, and that nesting is where feeds break
+ * — one unescaped ampersand and the document stops parsing for every reader at
+ * once. The excerpt is what a reader needs to decide to click.
+ */
+
+const ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+/**
+ * `&` first is not an accident of ordering — it is why this is a single pass.
+ * Replacing `<` before `&` would leave `&lt;` and then escape its own
+ * ampersand on the next pass, producing `&amp;lt;`.
+ */
+function escapeXml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ESCAPES[character]);
+}
+
+/** RFC 822, which is what RSS specifies. UTC, so no reader sees a shifted date. */
+function rfc822(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toUTCString();
+}
+
+export async function GET() {
+  const posts = await getPosts();
+
+  const items = posts
+    .map((post) => {
+      const url = absoluteUrl(`/blog/${post.slug}`);
+      const published = rfc822(post.published_at);
+
+      return [
+        "    <item>",
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${escapeXml(url)}</link>`,
+        // A guid that is not a URL still has to be stable; the permalink is
+        // both, and `isPermaLink` says so explicitly rather than by default.
+        `      <guid isPermaLink="true">${escapeXml(url)}</guid>`,
+        `      <description>${escapeXml(post.excerpt ?? summarise(post.body))}</description>`,
+        published ? `      <pubDate>${published}</pubDate>` : null,
+        ...post.tags.map((tag) => `      <category>${escapeXml(tag)}</category>`),
+        "    </item>",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n");
+
+  // The newest post's date, not the time this ran. A build timestamp would
+  // change the body of every response and defeat conditional requests, for a
+  // field no reader looks at.
+  const lastBuild = rfc822(posts[0]?.published_at ?? null);
+
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    "  <channel>",
+    "    <title>Phạm Đăng Khôi — Writing</title>",
+    `    <link>${absoluteUrl("/blog")}</link>`,
+    "    <description>Notes on what I built, what broke, and what the fix turned out to be.</description>",
+    "    <language>en</language>",
+    `    <atom:link href="${absoluteUrl("/blog/feed.xml")}" rel="self" type="application/rss+xml" />`,
+    lastBuild ? `    <lastBuildDate>${lastBuild}</lastBuildDate>` : null,
+    items,
+    "  </channel>",
+    "</rss>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return new Response(xml, {
+    headers: {
+      // `charset` spelled out: the titles carry Vietnamese diacritics, and a
+      // reader that guesses latin-1 renders the author's own name as mojibake.
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}
+
+/** Matches the content cache in lib/api.ts; a feed does not need to be fresher. */
+export const revalidate = 300;

--- a/apps/web/app/(site)/blog/page.tsx
+++ b/apps/web/app/(site)/blog/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+
+import { PostRow } from "@/components/post-row";
+import { EmptyState, Section } from "@/components/section";
+import { TagFilter } from "@/components/tag-filter";
+import { getPosts } from "@/lib/api";
+
+export const metadata: Metadata = {
+  title: "Writing",
+  description:
+    "Notes on what I built, what broke, and what the fix turned out to be.",
+  alternates: {
+    types: { "application/rss+xml": "/blog/feed.xml" },
+  },
+};
+
+/** Every tag in use, most-used first, so the facets lead with the real subjects. */
+function facetsOf(posts: { tags: string[] }[]): string[] {
+  const counts = new Map<string, number>();
+
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([tag]) => tag);
+}
+
+export default async function BlogPage({ searchParams }: PageProps<"/blog">) {
+  const { tag } = await searchParams;
+  // An array means the query string had `?tag=` twice. Take the first rather
+  // than rendering "a,b" as though it were a tag anyone could have.
+  const active = Array.isArray(tag) ? tag[0] : tag;
+
+  const posts = await getPosts();
+  const shown = active ? posts.filter((post) => post.tags.includes(active)) : posts;
+
+  return (
+    <Section
+      level="h1"
+      width="wide"
+      eyebrow={`Writing · ${posts.length}`}
+      title="Notes from building this"
+      description="What I built, what broke, and what the fix turned out to be. Mostly backend, occasionally CSS."
+    >
+      <TagFilter tags={facetsOf(posts)} active={active} />
+
+      {shown.length === 0 ? (
+        <div className="mt-8">
+          <EmptyState>
+            {active
+              ? `Nothing tagged ${active} yet.`
+              : "No posts published yet."}
+          </EmptyState>
+        </div>
+      ) : (
+        // border-t so the first row has a rule above it and the list reads as
+        // a set of entries rather than as text that happens to have lines under
+        // it. Each row supplies its own border-b.
+        <ul className="mt-8 border-t border-border/60">
+          {shown.map((post) => (
+            <PostRow key={post.id} post={post} />
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}

--- a/apps/web/app/actions/contacts.ts
+++ b/apps/web/app/actions/contacts.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { requireAdmin } from "@/lib/admin-guard";
+import { deleteContact, markContactRead } from "@/lib/console-api";
+import { INBOX_PATH, type InboxProblem } from "@/lib/inbox";
+
+/**
+ * The inbox's two writes.
+ *
+ * ## Why there is no `revalidatePath`
+ *
+ * There is nothing to revalidate. lib/console-api.ts reads `no-store`
+ * throughout — a response that depends on an Authorization header must not sit
+ * in a shared cache — so the next render of /admin already fetches fresh. The
+ * public site's readers are the ones behind a five-minute ISR window, and none
+ * of them read contacts. A `revalidatePath` here would be a no-op that looked
+ * load-bearing, which is worse than not having it; the CRUD screens for
+ * published content will need one, and it will mean something there.
+ *
+ * ## Why the outcome travels in the URL
+ *
+ * These are plain `<form action={...}>` posts, so they work with scripting off,
+ * and a bare Server Action has no way to hand anything back to a page rendered
+ * that way. `useActionState` would, at the cost of making both controls client
+ * components that do nothing until hydration. Redirecting with a `problem` code
+ * keeps the whole path server-side, and the success case redirects too — to the
+ * clean URL, so a failure notice cannot outlive the failure that caused it.
+ *
+ * ## Why each one re-checks the session
+ *
+ * `requireAdmin` runs in the layout, but a layout does not guard a Server
+ * Action: the action is a POST endpoint the browser can reach directly, and it
+ * has to establish for itself who is calling. The API would refuse an
+ * unauthenticated write anyway — this is what turns that refusal into a sign-in
+ * screen rather than an error.
+ */
+
+/** Reject anything that is not a plain positive integer before it reaches a URL. */
+function readId(formData: FormData): number | null {
+  const id = Number(formData.get("id"));
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+function fail(problem: InboxProblem): never {
+  redirect(`${INBOX_PATH}?problem=${problem}`);
+}
+
+/**
+ * Which sentence a failed write earns.
+ *
+ * `missing` is the interesting one: a 404 here almost always means the message
+ * was deleted from another tab, which is not a fault and must not be reported
+ * as one. `whenFailed` is what is left — the API was reachable but refused, or
+ * was not reachable at all.
+ */
+function problemFor(
+  reason: "unauthorized" | "rate_limited" | "missing" | "error",
+  whenFailed: InboxProblem,
+): InboxProblem {
+  if (reason === "unauthorized") return "session-ended";
+  if (reason === "missing") return "already-gone";
+  return whenFailed;
+}
+
+export async function markContactAsRead(formData: FormData): Promise<void> {
+  const { accessToken } = await requireAdmin(INBOX_PATH);
+
+  const id = readId(formData);
+  if (id === null) fail("unknown-message");
+
+  const result = await markContactRead(accessToken, id);
+  if (!result.ok) fail(problemFor(result.reason, "not-marked"));
+
+  redirect(INBOX_PATH);
+}
+
+export async function removeContact(formData: FormData): Promise<void> {
+  const { accessToken } = await requireAdmin(INBOX_PATH);
+
+  const id = readId(formData);
+  if (id === null) fail("unknown-message");
+
+  const result = await deleteContact(accessToken, id);
+  if (!result.ok) fail(problemFor(result.reason, "not-deleted"));
+
+  redirect(INBOX_PATH);
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -342,6 +342,207 @@
   }
 
   /*
+   * A post body, which is the only HTML on this site the app does not write
+   * itself — it comes out of lib/markdown.ts as a string.
+   *
+   * Hand-written rather than @tailwindcss/typography. That plugin ships a
+   * complete type system of its own: its own scale, its own greys, its own
+   * spacing rhythm, none of which are these tokens. Adopting it would mean
+   * overriding nearly all of it to get back to the site's own values, and the
+   * bits that were missed would be the places the blog stopped looking like
+   * the rest of the site. Everything below is expressed in tokens.
+   */
+  .article-prose {
+    color: hsl(var(--foreground));
+  }
+
+  .article-prose > * + * {
+    margin-top: 1.25em;
+  }
+
+  .article-prose h2,
+  .article-prose h3 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    /* A heading belongs to what follows it, so it sits closer to that. */
+    margin-top: 2.5em;
+    margin-bottom: -0.5em;
+  }
+
+  .article-prose h2 {
+    font-size: 1.375rem;
+  }
+
+  .article-prose h3 {
+    font-size: 1.125rem;
+  }
+
+  .article-prose a {
+    color: hsl(var(--primary));
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .article-prose strong {
+    font-weight: 600;
+  }
+
+  .article-prose ul,
+  .article-prose ol {
+    padding-left: 1.5rem;
+  }
+
+  .article-prose ul {
+    list-style: disc;
+  }
+
+  .article-prose ol {
+    list-style: decimal;
+  }
+
+  .article-prose li::marker {
+    color: hsl(var(--primary));
+  }
+
+  .article-prose li + li {
+    margin-top: 0.5em;
+  }
+
+  .article-prose blockquote {
+    border-left: 2px solid hsl(var(--primary));
+    padding-left: 1.25rem;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .article-prose hr {
+    border: 0;
+    border-top: 1px solid hsl(var(--border));
+    margin-block: 2.5em;
+  }
+
+  /* Inline code, distinguished from the prose by face and surface, not colour. */
+  .article-prose :not(pre) > code {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    background-color: hsl(var(--muted));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius-control);
+    padding: 0.1em 0.35em;
+  }
+
+  /*
+   * Code blocks carry no syntax highlighting, and that is a decision rather
+   * than a gap. A highlighter introduces eight or so colours that answer to
+   * nothing in this palette, in a page whose whole scheme is one accent on one
+   * neutral, and it needs a second theme to survive dark mode. What a reader
+   * actually needs from a block — where it starts, where it ends, and what
+   * language it is — the surface and the label below give them.
+   */
+  .article-prose pre {
+    position: relative;
+    overflow-x: auto;
+    background-color: hsl(var(--muted));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius-card);
+    padding: 1.25rem;
+    font-size: 0.8125rem;
+    line-height: 1.7;
+  }
+
+  /* Room for the label, and only where there is a label to make room for. */
+  .article-prose pre[data-lang] {
+    padding-top: 2.25rem;
+  }
+
+  .article-prose pre code {
+    font-family: var(--font-mono);
+  }
+
+  /*
+   * The fence's language, in the same mono-uppercase treatment as every other
+   * field name on the site. `data-lang` is written by lib/markdown.ts from a
+   * className the sanitiser has already vetted.
+   */
+  .article-prose pre[data-lang]::before {
+    content: attr(data-lang);
+    position: absolute;
+    top: 0.625rem;
+    right: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .article-prose img {
+    border-radius: var(--radius-card);
+    border: 1px solid hsl(var(--border));
+  }
+
+  .article-prose table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  .article-prose th,
+  .article-prose td {
+    border: 1px solid hsl(var(--border));
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  .article-prose th {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: hsl(var(--muted-foreground));
+    font-weight: 500;
+  }
+
+  /*
+   * How far through the post you are, as a line across the top of the window.
+   *
+   * Scroll-driven, so it costs no JavaScript — the same technique the skill
+   * gauges use, and the reason neither of them is a client component. The
+   * guards are the same too, and for the same reason: the base rule leaves it
+   * at zero width, so a browser without scroll timelines shows an empty track
+   * rather than a bar stuck at the wrong value.
+   *
+   * Behind `prefers-reduced-motion: no-preference` to match the gauges. The
+   * bar only moves when the reader moves the page, so it is arguably not the
+   * kind of motion that preference is about — but the reduced-motion block
+   * below forces `animation-duration` to 0.01ms on everything, and a
+   * scroll-driven animation with a fixed duration completes immediately and
+   * pins itself full. Opting out is what keeps that from happening.
+   */
+  @keyframes reading-progress {
+    from {
+      scale: 0 1;
+    }
+    to {
+      scale: 1 1;
+    }
+  }
+
+  .reading-progress {
+    transform-origin: left;
+    scale: 0 1;
+  }
+
+  @supports (animation-timeline: scroll()) {
+    @media (prefers-reduced-motion: no-preference) {
+      .reading-progress {
+        animation: reading-progress linear both;
+        animation-timeline: scroll(root block);
+      }
+    }
+  }
+
+  /*
    * Respect a reduced-motion preference for everything, including the smooth
    * scrolling above — vestibular triggers are not a per-component concern.
    */

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+import { absoluteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      // The console is behind a session guard already; this only keeps its
+      // URLs out of results, where they are noise rather than a risk.
+      disallow: ["/admin", "/login"],
+    },
+    sitemap: absoluteUrl("/sitemap.xml"),
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,39 @@
+import type { MetadataRoute } from "next";
+
+import { getPosts, getProjects } from "@/lib/api";
+import { absoluteUrl } from "@/lib/site";
+
+/**
+ * The sitemap, built from the same API the pages read.
+ *
+ * Both readers fall back to an empty list if the API is unreachable, so an
+ * outage during a build produces a sitemap of the static pages rather than a
+ * failed build — the same trade the rest of the site makes.
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [posts, projects] = await Promise.all([getPosts(), getProjects()]);
+
+  const staticPages = ["/", "/blog", "/career-journey", "/certificates"].map((path) => ({
+    url: absoluteUrl(path),
+    changeFrequency: "monthly" as const,
+    priority: path === "/" ? 1 : 0.8,
+  }));
+
+  return [
+    ...staticPages,
+    ...posts.map((post) => ({
+      url: absoluteUrl(`/blog/${post.slug}`),
+      // `updated_at` is null until a row is edited, so a post that has never
+      // been touched since publication reports the date it went live.
+      lastModified: post.updated_at ?? post.published_at ?? post.created_at,
+      changeFrequency: "yearly" as const,
+      priority: 0.7,
+    })),
+    ...projects.map((project) => ({
+      url: absoluteUrl(`/projects/${project.slug}`),
+      lastModified: project.updated_at ?? project.created_at,
+      changeFrequency: "yearly" as const,
+      priority: 0.6,
+    })),
+  ];
+}

--- a/apps/web/components/nav-links.tsx
+++ b/apps/web/components/nav-links.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/cn";
 // thumb no way to tell the two apart.
 const LINKS = [
   { href: "/#projects", label: "Projects", short: "Pr" },
+  { href: "/blog", label: "Blog", short: "Bl" },
   { href: "/career-journey", label: "Career", short: "Ca" },
   { href: "/certificates", label: "Certificates", short: "Ce" },
 ];
@@ -28,15 +29,29 @@ function pathOf(href: string): string {
   return href.split("#")[0] || "/";
 }
 
+/**
+ * Whether `pathname` is this entry's page, or a page underneath it.
+ *
+ * Exact match stopped being enough when one entry got children: a reader on
+ * `/blog/some-post` is still in Blog, and a nav that drops its marker the
+ * moment you click through tells you less than one that keeps it.
+ *
+ * `/` is excluded from the prefix half. It is a prefix of every path, and a nav
+ * that highlights Projects on every page says nothing — which is what the exact
+ * match was guarding against in the first place.
+ */
+function isCurrent(pathname: string, href: string): boolean {
+  const path = pathOf(href);
+  return pathname === path || (path !== "/" && pathname.startsWith(`${path}/`));
+}
+
 export function NavLinks() {
   const pathname = usePathname();
 
   return (
     <>
       {LINKS.map((link) => {
-        // Exact match rather than prefix: `/` is a prefix of everything, and a
-        // nav that highlights Projects on every page tells you nothing.
-        const current = pathname === pathOf(link.href);
+        const current = isCurrent(pathname, link.href);
 
         return (
           <Link

--- a/apps/web/components/post-row.tsx
+++ b/apps/web/components/post-row.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+
+import { eyebrowClasses } from "@/components/ui/eyebrow";
+import { cn } from "@/lib/cn";
+import { isoDay } from "@/lib/format";
+import { readingMinutes, summarise } from "@/lib/markdown";
+import type { Post } from "@/lib/types";
+
+/**
+ * One entry in the blog index.
+ *
+ * Not a Card, deliberately. Projects and certificates are already card grids,
+ * and a third would make the writing read as "projects, but text". A post list
+ * is a different kind of object: append-only, reverse-chronological, timestamped
+ * and tagged — which is to say a log, the vocabulary this site already speaks
+ * in its mono labels. So the index is rows on hairlines with a column of
+ * timestamps down the left, and the fixed-width date is what makes that column
+ * line up into an edge.
+ */
+export function PostRow({ post }: { post: Post }) {
+  const day = isoDay(post.published_at);
+  const minutes = readingMinutes(post.body);
+  const blurb = post.excerpt ?? summarise(post.body);
+
+  return (
+    <li className="group relative border-b border-border/60">
+      <div className="grid gap-x-8 gap-y-2.5 py-7 sm:grid-cols-[6.5rem_1fr]">
+        {/*
+          The meta column. Side by side above `sm`, where it is a gutter; a
+          single inline row below it, where a 6.5rem column would leave the
+          title about twenty characters of width.
+        */}
+        {/*
+          The hierarchy inside this column is made by promoting the date, not
+          by dimming what sits under it. Dimming was the first attempt — the
+          read time and the tags carried `opacity-70` — and it measured 4.26:1
+          on 12px text in dark mode, under the 4.5:1 it needs. There was no
+          headroom to spend: `--muted-foreground` is already tuned to sit just
+          over the line (7.81:1 here), so any opacity on top of it fails.
+        */}
+        <div className="flex items-baseline gap-3 sm:flex-col sm:gap-1.5">
+          {day ? (
+            <time
+              dateTime={day}
+              className={cn(
+                eyebrowClasses,
+                // Tracking off, unlike every other eyebrow on the site: this
+                // one is a fixed-width figure whose job is to line up with the
+                // dates above and below it, and letter-spacing on digits works
+                // against that.
+                "tracking-normal text-foreground transition-colors group-hover:text-primary group-focus-within:text-primary",
+              )}
+            >
+              {day}
+            </time>
+          ) : null}
+          <span className={cn(eyebrowClasses, "tracking-normal")}>{minutes} min</span>
+        </div>
+
+        <div>
+          {/* h2: the page heading is h1, so h3 here would skip a level. */}
+          <h2 className="font-display text-lg font-semibold text-foreground sm:text-xl">
+            {/*
+              Stretched over the whole row, as on a project card — the row is
+              the target, not the seven words of the title.
+            */}
+            <Link
+              href={`/blog/${post.slug}`}
+              className="after:absolute after:inset-0 transition-colors group-hover:text-primary"
+            >
+              {post.title}
+            </Link>
+          </h2>
+
+          {/* Capped well inside the row: the blurb is prose and wants a measure. */}
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{blurb}</p>
+
+          {post.tags.length > 0 ? (
+            /*
+              Plain text, not Badge chips. The chips at the top of the page are
+              controls you can press; these are data. Giving the two the same
+              treatment would promise a filter the row does not offer.
+            */
+            <p className={cn(eyebrowClasses, "mt-3")}>{post.tags.join(" · ")}</p>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/components/tag-filter.tsx
+++ b/apps/web/components/tag-filter.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+
+/**
+ * The blog index's tag facets.
+ *
+ * Links, not buttons, and no client component: each facet is a URL that can be
+ * shared, linked and opened in a new tab, and the page it leads to is rendered
+ * on the server. A `useState` filter would have thrown all of that away to
+ * avoid a navigation nobody minds.
+ */
+export function TagFilter({ tags, active }: { tags: string[]; active?: string }) {
+  if (tags.length === 0) return null;
+
+  return (
+    <nav aria-label="Filter posts by tag" className="flex flex-wrap items-center gap-x-2">
+      <Facet href="/blog" label="All" active={!active} />
+      {tags.map((tag) => (
+        <Facet
+          key={tag}
+          href={`/blog?tag=${encodeURIComponent(tag)}`}
+          label={tag}
+          active={tag === active}
+        />
+      ))}
+    </nav>
+  );
+}
+
+function Facet({
+  href,
+  label,
+  active,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      // aria-current, not colour alone: which facet is applied is the only
+      // state on this page, and it has to survive being read out loud.
+      aria-current={active ? "true" : undefined}
+      // The link carries the tap target and the badge carries the look. A
+      // Badge on its own is about 20px tall and, for a short label like "All",
+      // 36px wide — neither of which is something a thumb can reliably hit.
+      // Both minimums are needed: height alone left "All" at 36×44.
+      className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-[var(--radius-pill)]"
+    >
+      {/*
+        The applied facet is a filled chip, not a tinted one. Tinted was the
+        first attempt — `text-primary` on `bg-primary/12` — and it measured
+        4.25:1 in light mode, under the 4.5:1 that 12px text needs. Filling it
+        uses the primary/primary-foreground pairing the palette already tunes
+        for both themes, and "selected" is what a filled chip means anyway.
+      */}
+      <Badge
+        variant={active ? "neutral" : "outline"}
+        className={
+          active
+            ? "bg-primary text-primary-foreground"
+            : "transition-colors hover:border-primary/50 hover:text-primary"
+        }
+      >
+        {label}
+      </Badge>
+    </Link>
+  );
+}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -20,6 +20,18 @@ const VARIANTS = {
   primary: "bg-primary text-primary-foreground hover:opacity-90",
   /** Secondary actions that should not compete: "send another", "cancel". */
   quiet: "border border-border text-foreground hover:border-primary/40 hover:text-primary",
+  /**
+   * Destructive actions. Outlined rather than filled, and set in
+   * --destructive-text rather than --destructive.
+   *
+   * Both halves matter. A filled red button is the loudest thing on a screen,
+   * and these sit in a row of ordinary controls — the weight should come from
+   * the confirmation step, not the colour. And --destructive is tuned to be
+   * seen as a fill or a border: as *text* it measures 3.76:1 on a card in light
+   * mode and 1.88:1 in dark, which is why the palette carries a second red.
+   */
+  danger:
+    "border border-destructive/50 text-destructive-text hover:border-destructive hover:bg-destructive/10",
 } as const;
 
 export function buttonClasses(

--- a/apps/web/components/ui/confirm-delete.tsx
+++ b/apps/web/components/ui/confirm-delete.tsx
@@ -1,0 +1,62 @@
+import { Button, buttonClasses } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+/**
+ * A delete that takes two deliberate actions, and no JavaScript to enforce it.
+ *
+ * The reflex here is `onClick={() => confirm(...)}`, which fails in the wrong
+ * direction: with scripting off the handler never runs and the single click
+ * deletes immediately — a guard that disappears exactly when it is not being
+ * watched. A `<dialog>` has the same problem, since it needs `showModal()` to
+ * open at all.
+ *
+ * `<details>` is the version that works with nothing running. The summary is
+ * keyboard-operable and screen-reader-announced natively, the panel is real
+ * markup either way, and the destructive control genuinely does not exist on
+ * the page until it has been opened. The summary relabels itself to "Cancel"
+ * when open, because a control that still says "Delete" while a Delete button
+ * sits underneath it is asking to be clicked twice.
+ *
+ * Consumed by the inbox now; every content list that grows a delete wants the
+ * same thing, which is why it is here rather than in that page.
+ */
+export function ConfirmDelete({
+  action,
+  id,
+  warning,
+  confirmLabel = "Delete permanently",
+}: {
+  /** A Server Action. It receives the `id` below as a form field. */
+  action: (formData: FormData) => Promise<void>;
+  id: number;
+  /** What is about to be lost. Specific — "this message", not "this item". */
+  warning: string;
+  confirmLabel?: string;
+}) {
+  return (
+    <details className="group/confirm">
+      <summary
+        className={cn(
+          buttonClasses("quiet", "min-h-11 cursor-pointer px-4 py-2 text-xs"),
+          // The default triangle is removed in both engines — Blink and modern
+          // Safari use ::marker, older WebKit its own pseudo-element.
+          "list-none [&::-webkit-details-marker]:hidden",
+        )}
+      >
+        <span className="group-open/confirm:hidden">Delete</span>
+        <span className="hidden group-open/confirm:inline">Cancel</span>
+      </summary>
+
+      <div className="mt-2 rounded-[var(--radius-control)] border border-destructive/40 bg-card p-3">
+        <p className="text-sm text-foreground">{warning}</p>
+
+        <form action={action} className="mt-3">
+          <input type="hidden" name="id" value={id} />
+          <Button variant="danger" type="submit" className="min-h-11 px-4 py-2 text-xs">
+            {confirmLabel}
+          </Button>
+        </form>
+      </div>
+    </details>
+  );
+}

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getCareerEntries,
   getCertificates,
+  getPost,
+  getPosts,
   getProject,
   getProjects,
   getSkills,
@@ -31,6 +33,7 @@ const LIST_READERS = [
   ["getSkills", getSkills],
   ["getCertificates", getCertificates],
   ["getCareerEntries", getCareerEntries],
+  ["getPosts", getPosts],
 ] as const;
 
 let fetchMock: ReturnType<typeof vi.fn>;
@@ -63,6 +66,12 @@ describe("when the API is unreachable", () => {
     fetchMock.mockRejectedValue(new TypeError("fetch failed"));
 
     await expect(getProject("portfolio")).resolves.toBeNull();
+  });
+
+  it("getPost returns null", async () => {
+    fetchMock.mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(getPost("square-corners")).resolves.toBeNull();
   });
 
   it("says so on the server log", async () => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import type { CareerEntry, Certificate, Project, Skill } from "./types";
+import type { CareerEntry, Certificate, Post, Project, Skill } from "./types";
 
 /**
  * Server-side reader for the content API.
@@ -94,4 +94,21 @@ export async function getCertificates(): Promise<Certificate[]> {
 
 export async function getCareerEntries(): Promise<CareerEntry[]> {
   return getJson<CareerEntry[]>("/career/", [], isList);
+}
+
+/**
+ * Published posts, newest first — the API decides the order, not the caller.
+ *
+ * No tag parameter, though the API takes one. The index has to know every tag
+ * that exists in order to draw the facets, and a response already filtered to
+ * one tag cannot tell it about the others; so the page fetches the whole list
+ * once and narrows it itself. One request, complete facets, and the filtered
+ * view costs no second round trip.
+ */
+export async function getPosts(): Promise<Post[]> {
+  return getJson<Post[]>("/posts/", [], isList);
+}
+
+export async function getPost(slug: string): Promise<Post | null> {
+  return getJson<Post | null>(`/posts/slug/${encodeURIComponent(slug)}`, null, isRecord);
 }

--- a/apps/web/lib/console-api.ts
+++ b/apps/web/lib/console-api.ts
@@ -29,6 +29,13 @@ export type ApiResult<T> =
   | { ok: true; data: T }
   | { ok: false; reason: "unauthorized" }
   | { ok: false; reason: "rate_limited"; response: Response }
+  /**
+   * The row is not there. Distinguished from `error` because it is the one
+   * failure with a specific, common and completely benign cause — the thing was
+   * deleted since the page rendered — and collapsing it into "the API did not
+   * answer" makes the console report an outage that did not happen.
+   */
+  | { ok: false; reason: "missing" }
   | { ok: false; reason: "error" };
 
 async function call(
@@ -68,6 +75,10 @@ async function toResult<T>(response: Response | null, url: string): Promise<ApiR
   }
 
   if (response.status === 429) return { ok: false, reason: "rate_limited", response };
+
+  // Not logged: a 404 on a write means the row went away, which is an ordinary
+  // race between two tabs rather than something wrong with the system.
+  if (response.status === 404) return { ok: false, reason: "missing" };
 
   if (!response.ok) {
     console.error(`[console] ${response.status} ${response.statusText} from ${url}`);
@@ -158,4 +169,28 @@ export async function fetchContacts(token: string): Promise<ApiResult<Contact[]>
   }
 
   return result;
+}
+
+/**
+ * Mark a message read.
+ *
+ * One-way, because the API is: it exposes `PUT /contacts/{id}/read` and nothing
+ * that clears the flag. That is the right shape — the flag records having seen
+ * a message, and there is no version of "I have not seen this" that becomes
+ * true again afterwards.
+ */
+export async function markContactRead(
+  token: string,
+  id: number,
+): Promise<ApiResult<Contact>> {
+  const path = `/contacts/${id}/read`;
+  const response = await call(path, { method: "PUT", token });
+  return toResult<Contact>(response, path);
+}
+
+/** Delete a message. There is no soft delete on the API; the row goes. */
+export async function deleteContact(token: string, id: number): Promise<ApiResult<unknown>> {
+  const path = `/contacts/${id}`;
+  const response = await call(path, { method: "DELETE", token });
+  return toResult<unknown>(response, path);
 }

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -24,6 +24,33 @@ export function formatMonthYear(value: string | null): string | null {
   return `${monthName} ${year}`;
 }
 
+/**
+ * The date part of an API timestamp, as `2026-08-09`.
+ *
+ * Sliced, not parsed, for the same reason as above and then some:
+ * `published_at` is a full instant with an offset, so `new Date()` would move
+ * the day for any reader whose timezone crosses midnight relative to it — a
+ * post published on the 9th would be dated the 8th in Los Angeles. The stored
+ * UTC day is the day it was published, and it reads the same for everyone.
+ *
+ * Also the format `<time datetime>` wants.
+ */
+export function isoDay(value: string | null): string | null {
+  return value ? value.slice(0, 10) : null;
+}
+
+/** "9 August 2026" — a post is dated to the day, unlike a role or a project. */
+export function formatFullDate(value: string | null): string | null {
+  const day = isoDay(value);
+  if (!day) return null;
+
+  const [year, month, date] = day.split("-");
+  const monthName = MONTHS[Number(month) - 1];
+  if (!monthName || !year || !date) return day;
+
+  return `${Number(date)} ${monthName} ${year}`;
+}
+
 /** "December 2024 — March 2025", or "… — Present" while it is still running. */
 export function formatPeriod(startedOn: string | null, endedOn: string | null): string {
   const start = formatMonthYear(startedOn);

--- a/apps/web/lib/inbox.ts
+++ b/apps/web/lib/inbox.ts
@@ -1,0 +1,54 @@
+/**
+ * What the inbox's actions can report back, and how it is worded.
+ *
+ * Lives here rather than beside the Server Actions that produce it, for the
+ * reason lib/contact.ts records: a `"use server"` module may only export async
+ * functions, and a lookup table exported from one type-checks and builds
+ * cleanly, then throws the first time the action is invoked.
+ */
+
+/** The inbox is the console's index; the actions redirect back to it. */
+export const INBOX_PATH = "/admin";
+
+export type InboxProblem =
+  | "unknown-message"
+  | "already-gone"
+  | "not-marked"
+  | "not-deleted"
+  | "session-ended";
+
+/**
+ * Each line says what happened, what state the message is now in, and what to
+ * do. The middle part is the one that matters: after a failed write the only
+ * question is whether it half-happened, and "it is unchanged" answers it.
+ *
+ * `already-gone` is separate from the two below it because it is the likeliest
+ * failure by far — a message deleted in another tab, or on a page left open —
+ * and it is not a fault. Reporting it as "the API did not answer" would be both
+ * alarming and untrue: the API answered, promptly, with a 404.
+ */
+const MESSAGES: Record<InboxProblem, string> = {
+  "unknown-message":
+    "That request did not name a message, so nothing changed. Reload and try again.",
+  "already-gone":
+    "That message had already been deleted, so nothing changed. The list below is current.",
+  "not-marked":
+    "That message was not marked as read — the API did not answer. It is unchanged; try again.",
+  "not-deleted":
+    "That message was not deleted — the API did not answer. It is still here; try again.",
+  "session-ended":
+    "Your session ended before that went through, so nothing changed. Sign in again to repeat it.",
+};
+
+/**
+ * Turn a `?problem=` value into something to show, or null.
+ *
+ * Anything unrecognised returns null rather than being echoed: the value
+ * arrives from the URL, so a visitor can put whatever they like in it, and a
+ * page that renders it is a page that renders text chosen by whoever wrote the
+ * link.
+ */
+export function inboxProblem(value: string | string[] | undefined): string | null {
+  const key = Array.isArray(value) ? value[0] : value;
+  return key && key in MESSAGES ? MESSAGES[key as InboxProblem] : null;
+}

--- a/apps/web/lib/markdown.test.ts
+++ b/apps/web/lib/markdown.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import { plainText, readingMinutes, renderMarkdown, summarise } from "./markdown";
+
+/**
+ * The output of `renderMarkdown` goes straight into `dangerouslySetInnerHTML`.
+ *
+ * Everywhere else on this site, React escapes what it renders. Here it is
+ * explicitly told not to, which makes this module the one place a post body can
+ * reach the DOM as markup — and post bodies are the only HTML on the site the
+ * app does not write itself. The sanitiser is what makes that safe, so the
+ * first block below is not a nice-to-have: it is the reason the rest of the
+ * feature is allowed to exist in this shape.
+ */
+
+describe("sanitisation", () => {
+  it("drops a script tag", async () => {
+    const html = await renderMarkdown("Hello <script>alert(1)</script> world");
+
+    // The tag is what matters. What was between the tags survives as prose —
+    // the reader sees the literal text "alert(1)", which is inert. Asserting
+    // the body were gone too would be asserting the wrong thing: a post *about*
+    // XSS should be able to quote one.
+    expect(html).not.toContain("<script");
+  });
+
+  it("drops an inline event handler", async () => {
+    const html = await renderMarkdown('<img src="x" onerror="alert(1)">');
+
+    expect(html).not.toContain("onerror");
+  });
+
+  it("drops a javascript: URL", async () => {
+    const html = await renderMarkdown("[click me](javascript:alert(1))");
+
+    expect(html).not.toContain("javascript:");
+  });
+
+  it("drops an iframe", async () => {
+    const html = await renderMarkdown('<iframe src="https://example.com"></iframe>');
+
+    expect(html).not.toContain("<iframe");
+  });
+
+  it("escapes markup that arrives as text rather than rendering it", async () => {
+    const html = await renderMarkdown("A tag looks like <b>this</b> in prose");
+
+    // remark-rehype drops the raw HTML node entirely rather than passing it
+    // through; either way the one thing that must not happen is a live <b>.
+    expect(html).not.toContain("<b>");
+  });
+});
+
+describe("rendering", () => {
+  it("renders headings, emphasis and links", async () => {
+    const html = await renderMarkdown("## Heading\n\nSome *emphasis* and [a link](/blog).");
+
+    expect(html).toContain("<h2>Heading</h2>");
+    expect(html).toContain("<em>emphasis</em>");
+    expect(html).toContain('<a href="/blog">a link</a>');
+  });
+
+  it("renders GitHub tables, which plain CommonMark does not", async () => {
+    const html = await renderMarkdown("| a | b |\n| - | - |\n| 1 | 2 |");
+
+    expect(html).toContain("<table>");
+  });
+
+  it("labels a fenced block with its language", async () => {
+    const html = await renderMarkdown("```css\na { color: red }\n```");
+
+    // The stylesheet renders this as the corner label; without it every block
+    // is unlabelled, which is the state this attribute exists to fix.
+    expect(html).toContain('data-lang="css"');
+  });
+
+  it("leaves an unlabelled fence unlabelled rather than guessing", async () => {
+    const html = await renderMarkdown("```\nplain\n```");
+
+    expect(html).not.toContain("data-lang");
+  });
+
+  it("does not invent a language from an attacker-shaped class", async () => {
+    // The attribute is written by this module, so the pattern it matches is
+    // the boundary. Anything that is not a plain language name is ignored.
+    const html = await renderMarkdown('```" onmouseover="alert(1)\ncode\n```');
+
+    expect(html).not.toContain("onmouseover");
+  });
+});
+
+describe("plainText", () => {
+  it("takes code fences out whole", () => {
+    // A description opening with three backticks and a language name
+    // describes nothing.
+    expect(plainText("Intro.\n\n```js\nconst x = 1\n```\n\nOutro.")).toBe("Intro. Outro.");
+  });
+
+  it("keeps a link's text and drops its target", () => {
+    expect(plainText("See [the docs](https://example.com/very/long).")).toBe("See the docs.");
+  });
+
+  it("strips heading markers and emphasis", () => {
+    expect(plainText("# Title\n\nSome **bold** text.")).toBe("Title Some bold text.");
+  });
+});
+
+describe("summarise", () => {
+  it("leaves a short body alone", () => {
+    expect(summarise("Short enough.")).toBe("Short enough.");
+  });
+
+  it("cuts on a word boundary and marks the cut", () => {
+    const summary = summarise("alpha bravo charlie delta echo foxtrot", 20);
+
+    expect(summary.endsWith("…")).toBe(true);
+    // Not mid-word: "charl…" reads as a truncation bug rather than a choice.
+    expect(summary).toBe("alpha bravo charlie…");
+  });
+});
+
+describe("readingMinutes", () => {
+  it("never reports less than a minute", () => {
+    expect(readingMinutes("One sentence.")).toBe(1);
+  });
+
+  it("rounds up rather than to nearest", () => {
+    // 274 words is 1.37 minutes. To nearest that is "1 min", which reads as a
+    // stub; and under-promising is the wrong direction for this figure.
+    expect(readingMinutes("word ".repeat(274))).toBe(2);
+  });
+
+  it("counts prose rather than code", () => {
+    const prose = `${"word ".repeat(400)}`;
+    const withCode = `${prose}\n\n\`\`\`js\n${"token ".repeat(2000)}\n\`\`\``;
+
+    // The code fence would triple the figure if it counted, and nobody reads a
+    // code block at prose speed.
+    expect(readingMinutes(withCode)).toBe(readingMinutes(prose));
+  });
+});

--- a/apps/web/lib/markdown.ts
+++ b/apps/web/lib/markdown.ts
@@ -1,0 +1,144 @@
+import "server-only";
+
+import type { Element, Root } from "hast";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import { visit } from "unist-util-visit";
+
+/**
+ * Turns a post's Markdown into HTML, on the server.
+ *
+ * `server-only` for the same reason as lib/api.ts: this pulls in the whole
+ * unified stack, and an accidental client import would ship a Markdown parser
+ * to the browser to render text that was already HTML by the time it left the
+ * server.
+ *
+ * The API stores Markdown and returns it verbatim — it never renders and never
+ * sanitises. That choice puts the entire escaping problem in one place: here,
+ * the only code that produces HTML from it. `rehype-sanitize` runs against
+ * GitHub's schema, so a post body containing `<script>` or an `onerror=`
+ * attribute is stripped rather than trusted.
+ *
+ * The output is handed to `dangerouslySetInnerHTML`. That is safe *because* of
+ * the sanitiser, not in spite of it — if this pipeline ever loses that step,
+ * the blog becomes a stored-XSS hole. There is a test that says so.
+ */
+
+/**
+ * A conservative pattern for a fence's language. Only ever used to fill an
+ * attribute this module writes, so nothing from a post body reaches the DOM
+ * unescaped through it.
+ */
+const LANGUAGE_CLASS = /^language-([a-z0-9+#.-]{1,16})$/i;
+
+/**
+ * Copies a fence's language onto its `<pre>` as `data-lang`, so the stylesheet
+ * can label the block without a client component.
+ *
+ * Runs *after* the sanitiser rather than before it. The default schema does not
+ * allow `data-lang`, so a sanitiser running last would strip the attribute
+ * again; and putting this last means the value is derived from a className the
+ * sanitiser has already vetted, then matched against the pattern above.
+ */
+function labelCodeBlocks() {
+  return (tree: Root) => {
+    visit(tree, "element", (node: Element) => {
+      if (node.tagName !== "pre") return;
+
+      const code = node.children.find(
+        (child): child is Element => child.type === "element" && child.tagName === "code",
+      );
+      if (!code) return;
+
+      const classes = code.properties?.className;
+      if (!Array.isArray(classes)) return;
+
+      for (const entry of classes) {
+        const match = LANGUAGE_CLASS.exec(String(entry));
+        if (match) {
+          node.properties = { ...node.properties, "data-lang": match[1].toLowerCase() };
+          return;
+        }
+      }
+    });
+  };
+}
+
+const processor = unified()
+  .use(remarkParse)
+  // Tables, strikethrough, task lists and bare-URL autolinks. Plain CommonMark
+  // has none of those, and a post that uses a table would render its pipes.
+  .use(remarkGfm)
+  // `allowDangerousHtml` is deliberately absent: raw HTML in a post body is
+  // dropped at this step, before the sanitiser is even asked about it.
+  .use(remarkRehype)
+  .use(rehypeSanitize, {
+    ...defaultSchema,
+    attributes: {
+      ...defaultSchema.attributes,
+      // Every link out of a post body is untrusted by definition.
+      a: [...(defaultSchema.attributes?.a ?? []), "target", "rel"],
+    },
+  })
+  .use(labelCodeBlocks)
+  .use(rehypeStringify);
+
+export async function renderMarkdown(markdown: string): Promise<string> {
+  const file = await processor.process(markdown);
+  return String(file);
+}
+
+/**
+ * Roughly what the post says, with the Markdown taken off.
+ *
+ * Only ever used for the meta description and the index blurb when a post has
+ * no `excerpt`, so approximate is fine — it does not have to survive a
+ * round trip. Code fences go first and whole: a description opening with three
+ * backticks and a language name describes nothing.
+ */
+export function plainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/^[#>\s-]+/gm, "")
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** The blurb a post falls back to when it has no `excerpt` of its own. */
+export function summarise(markdown: string, limit = 180): string {
+  const text = plainText(markdown);
+  if (text.length <= limit) return text;
+
+  // Cut on a word boundary; a description ending mid-word looks truncated by
+  // accident rather than on purpose.
+  const clipped = text.slice(0, limit);
+  const lastSpace = clipped.lastIndexOf(" ");
+  return `${clipped.slice(0, lastSpace > 0 ? lastSpace : limit)}…`;
+}
+
+/** Words per minute for silent reading of technical prose. */
+const READING_SPEED = 200;
+
+/**
+ * How long the post takes to read, in whole minutes, never less than one.
+ *
+ * Counts the prose rather than the raw source, so a post that is half code
+ * fences is not credited with the minutes it would take to read them aloud.
+ *
+ * Rounds up, not to nearest. A 274-word post is 1.37 minutes, and rounding to
+ * nearest called that "1 min" — which reads as a stub rather than an estimate,
+ * and is the one direction this number should not err in. Rounding up is also
+ * what every other site's figure means, so it compares.
+ */
+export function readingMinutes(markdown: string): number {
+  const words = plainText(markdown).split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words / READING_SPEED));
+}

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -1,0 +1,21 @@
+/**
+ * The site's own absolute URL.
+ *
+ * Needed by the three things that cannot use a relative path: the sitemap, the
+ * RSS feed, and Open Graph tags. Everything else on the site links relatively
+ * and should keep doing so.
+ *
+ * Not prefixed `NEXT_PUBLIC_`, because only server-rendered output uses it —
+ * same reasoning as `API_URL`. The default is the production URL rather than
+ * localhost: a missing variable in a preview deploy should produce links that
+ * work, not links to a machine the reader does not have.
+ */
+export const SITE_URL = (process.env.SITE_URL ?? "https://khoipham.vercel.app").replace(
+  /\/$/,
+  "",
+);
+
+/** An absolute URL for `path`, which must start with a slash. */
+export function absoluteUrl(path: string): string {
+  return `${SITE_URL}${path}`;
+}

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -84,6 +84,26 @@ export interface Contact {
   updated_at: string | null;
 }
 
+export interface Post {
+  id: number;
+  slug: string;
+  title: string;
+  /** Card blurb and meta description. Null falls back to the body's opening. */
+  excerpt: string | null;
+  /** Markdown. The API never renders it; lib/markdown.ts does, server-side. */
+  body: string;
+  tags: string[];
+  cover_image: string | null;
+  published: boolean;
+  /**
+   * When the post went live — not `created_at`, which is when the draft row was
+   * made. Null only on a draft, which the public API never returns.
+   */
+  published_at: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
 /** What POST /auth/login and POST /auth/refresh return. */
 export interface TokenPair {
   access_token: string;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,12 +17,20 @@
     "next": "16.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
+    "rehype-sanitize": "^6.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
     "server-only": "^0.0.1",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
+    "@types/hast": "^3.0.5",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
+++ b/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
@@ -31,6 +31,13 @@ const PAGES = [
     heading: "Courses and certifications",
     empty: ["No certificates published yet."],
   },
+  {
+    // Stronger than the three above: /blog reads searchParams, so it renders
+    // per request rather than at build time — this failure happens live.
+    path: "/blog",
+    heading: "Notes from building this",
+    empty: ["No posts published yet."],
+  },
 ];
 
 test.describe("pages built with no API behind them", () => {
@@ -114,5 +121,42 @@ test.describe("a project detail page when the read fails", () => {
     expect(response?.status()).toBe(200);
     await expect(page.getByRole("heading", { level: 1 })).toHaveText("Stubbed Project");
     await expect(page.getByText("A project served by the e2e stub.")).toBeVisible();
+  });
+});
+
+/**
+ * The same five failures for a post. Worth repeating rather than trusting the
+ * project route to stand for both, because this one does something no other
+ * page does: it renders API-supplied Markdown into the DOM through
+ * `dangerouslySetInnerHTML`. A malformed read must stop at the 404 page, well
+ * before anything reaches that renderer.
+ */
+test.describe("a post page when the read fails", () => {
+  const FAILURES = [
+    { slug: "stub-missing", why: "the API says 404" },
+    { slug: "stub-500", why: "the API 500s" },
+    { slug: "stub-hangup", why: "the connection drops mid-request" },
+    { slug: "stub-not-json", why: "the body is not JSON" },
+    { slug: "stub-wrong-shape", why: "the body is JSON of the wrong shape" },
+  ];
+
+  for (const { slug, why } of FAILURES) {
+    test(`404s, not 500s, when ${why}`, async ({ page }) => {
+      const response = await page.goto(`/blog/${slug}`);
+
+      expect(response?.status(), `${why} must not surface as a server error`).toBe(404);
+    });
+  }
+
+  test("renders the post, and its Markdown, when the read works", async ({ page }) => {
+    const response = await page.goto("/blog/a-real-slug");
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("Stubbed Post");
+
+    // The body arrived as Markdown and left as HTML: this heading and this
+    // <code> only exist if the pipeline ran.
+    await expect(page.getByRole("heading", { name: "Stubbed heading", level: 2 })).toBeVisible();
+    await expect(page.locator(".article-prose code")).toHaveText("code");
   });
 });

--- a/apps/web/tests/e2e/stub-api.mjs
+++ b/apps/web/tests/e2e/stub-api.mjs
@@ -46,6 +46,23 @@ function project(slug) {
   };
 }
 
+/** A post whose body is real Markdown, so the render pipeline is exercised too. */
+function post(slug) {
+  return {
+    id: 1,
+    slug,
+    title: "Stubbed Post",
+    excerpt: "A post served by the e2e stub.",
+    body: "## Stubbed heading\n\nA paragraph with `code` in it.\n",
+    tags: ["FastAPI", "Next.js"],
+    cover_image: null,
+    published: true,
+    published_at: "2026-08-09T00:00:00Z",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: null,
+  };
+}
+
 /**
  * Tokens shaped like the real ones, so the console's own parsing is exercised.
  *
@@ -277,6 +294,25 @@ const server = createServer(async (request, response) => {
     if (slug === "stub-wrong-shape") return send(response, 200, []);
 
     return send(response, 200, project(slug));
+  }
+
+  // The same five failures as the project route above. A post detail page has
+  // one thing a project page does not — it renders Markdown into the DOM — so
+  // "the API answered, but not with a post" has to land on the 404 page rather
+  // than reaching the renderer with something that is not a post.
+  if (pathname.startsWith("/api/v1/posts/slug/")) {
+    const slug = decodeURIComponent(pathname.slice("/api/v1/posts/slug/".length));
+
+    if (slug === "stub-500") return send(response, 500, { detail: "Internal error" });
+    if (slug === "stub-missing") return send(response, 404, { detail: "Not found" });
+    if (slug === "stub-hangup") return hangUp(response);
+    if (slug === "stub-not-json") {
+      response.writeHead(200, { "content-type": "application/json" });
+      return response.end("<html>Service suspended</html>");
+    }
+    if (slug === "stub-wrong-shape") return send(response, 200, []);
+
+    return send(response, 200, post(slug));
   }
 
   // The list routes are only reached during the e2e build, which deliberately

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,12 +22,33 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.2
+        version: 11.1.2
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@playwright/test':
         specifier: ^1.62.1
@@ -35,6 +56,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.3
+      '@types/hast':
+        specifier: ^3.0.5
+        version: 3.0.5
       '@types/node':
         specifier: ^20
         version: 20.19.43
@@ -646,17 +670,29 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
@@ -668,6 +704,9 @@ packages:
 
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.66.0':
     resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
@@ -727,6 +766,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.66.0':
     resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
@@ -946,6 +988,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -993,6 +1038,9 @@ packages:
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1000,6 +1048,15 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -1014,6 +1071,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1060,6 +1120,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1071,9 +1134,16 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1139,6 +1209,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-next@16.3.0:
     resolution: {integrity: sha512-lPrf1kHsMJEZqO0uXkNB400c5MGrhrTk3BNX7P0ol4gt61+iUlQfjy9TyIOEA9eOXrf+5+mYbT/JsY8+zqUByQ==}
@@ -1266,6 +1340,9 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1412,11 +1489,23 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1508,6 +1597,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -1754,6 +1847,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1764,13 +1860,136 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1941,6 +2160,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1967,6 +2189,24 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2071,6 +2311,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -2106,6 +2349,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2165,6 +2411,12 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2216,6 +2468,24 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -2227,6 +2497,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
@@ -2357,6 +2633,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2867,13 +3146,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.43':
     dependencies:
@@ -2886,6 +3179,8 @@ snapshots:
   '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -2977,6 +3272,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     optional: true
@@ -3191,6 +3488,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -3239,12 +3538,20 @@ snapshots:
 
   caniuse-lite@1.0.30001809: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
 
   client-only@0.0.1: {}
 
@@ -3255,6 +3562,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -3296,6 +3605,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -3310,7 +3623,13 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@2.1.0:
     dependencies:
@@ -3447,6 +3766,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-next@16.3.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
@@ -3659,6 +3980,8 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3802,11 +4125,37 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@ungap/structured-clone': 1.3.3
+      unist-util-position: 5.0.0
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-void-elements@3.0.0: {}
 
   ignore@5.3.2: {}
 
@@ -3901,6 +4250,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -4102,6 +4453,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -4114,9 +4467,316 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -4292,6 +4952,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.2.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -4324,6 +4986,51 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-sanitize: 5.0.2
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@4.0.0: {}
 
@@ -4485,6 +5192,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -4547,6 +5256,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -4584,6 +5298,10 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -4657,6 +5375,39 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -4693,6 +5444,16 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.2.1(@types/node@20.19.43)(jiti@2.7.0):
     dependencies:
@@ -4794,3 +5555,5 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
Recovery PR. No new code — it carries the two commits that #36 and #37 were meant to land but did not.

## What went wrong

#36 and #37 were stacked, and their bases were branches rather than `main`:

| PR | head | base | where it actually went |
|----|------|------|------------------------|
| #35 | `feat/blog-api` | `main` | main ✅ |
| #36 | `feat/blog-web` | `feat/blog-api` | into that branch |
| #37 | `feat/admin-contacts` | `feat/blog-web` | into that branch |

Because #35 merged into `main` first, `main` only ever received what `feat/blog-api` held at that moment. GitHub marked #36 and #37 "merged" — truthfully, since each one did merge into the branch it targeted — and their commits stayed there. That is why the site has the blog *API* but no `/blog` page and no Blog link in the header.

My fault for opening a stack without saying that the bases have to be re-pointed at `main` as each one lands.

## What this contains

Exactly the two stranded commits, unchanged:

- `da4678f` feat(web): add the blog — a log, not a card grid
- `7d3dd80` feat(web): let the inbox act on a message, without JavaScript

Merge base is the blog-API commit, which is already on `main`, so nothing is duplicated. `git merge-tree` reports no conflicts.

Review already happened on #36 and #37; this is the same diff arriving at the right place.

## After this merges

`/blog` and `/blog/[slug]` render, Blog appears in the header, `/blog/feed.xml`, `/sitemap.xml` and `/robots.txt` exist, and the inbox can mark read and delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)