### PR TITLE
Manage every content type from /admin

### DIFF
--- a/apps/web/app/(console)/admin/[entity]/[id]/page.tsx
+++ b/apps/web/app/(console)/admin/[entity]/[id]/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { saveContent } from "@/app/actions/content";
+import { EntityForm } from "@/components/console/entity-form";
+import { Container } from "@/components/ui/container";
+import { Eyebrow, eyebrowClasses } from "@/components/ui/eyebrow";
+import { Notice } from "@/components/ui/notice";
+import { requireAdmin } from "@/lib/admin-guard";
+import { cn } from "@/lib/cn";
+import { fetchContentItem } from "@/lib/console-api";
+import { entityFor, toValues } from "@/lib/content-schema";
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/admin/[entity]/[id]">): Promise<Metadata> {
+  const spec = entityFor((await params).entity);
+  return { title: spec ? `Edit ${spec.singular}` : "Not found" };
+}
+
+export default async function EditEntityPage({ params }: PageProps<"/admin/[entity]/[id]">) {
+  const { entity, id } = await params;
+  const spec = entityFor(entity);
+  if (!spec) notFound();
+
+  const numericId = Number(id);
+  if (!Number.isInteger(numericId) || numericId <= 0) notFound();
+
+  const { accessToken } = await requireAdmin(`/admin/${spec.key}/${id}`);
+  const result = await fetchContentItem(accessToken, spec.apiPath, numericId);
+
+  // A row that is not there is a 404, the same as a bad id. An outage is not:
+  // telling the admin their post no longer exists because the backend is asleep
+  // would be a lie, and one they might act on.
+  if (!result.ok && result.reason === "missing") notFound();
+
+  const title = result.ok ? String(result.data[spec.titleField] ?? "") : "";
+
+  return (
+    <Container width="wide" className="py-12 sm:py-16">
+      <Link
+        href={`/admin/${spec.key}`}
+        className={cn(eyebrowClasses, "transition-colors hover:text-primary")}
+      >
+        ← {spec.plural}
+      </Link>
+
+      <Eyebrow className="mt-8">Edit {spec.singular}</Eyebrow>
+      <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
+        {title || `Edit ${spec.singular}`}
+      </h1>
+
+      {!result.ok ? (
+        <Notice className="mt-8">
+          This {spec.singular} could not be loaded — the API did not answer.
+          Nothing has been lost; reload once it is back.
+        </Notice>
+      ) : (
+        <>
+          {typeof result.data.slug === "string" && (
+            /*
+              Shown, not editable. The API's update schemas carry no `slug`
+              on purpose: regenerating one on a title edit silently breaks
+              every link already published to it.
+            */
+            <p className={cn(eyebrowClasses, "mt-3 normal-case tracking-normal")}>
+              /{result.data.slug} · fixed at creation
+            </p>
+          )}
+
+          <EntityForm
+            spec={spec}
+            mode="edit"
+            initial={toValues(spec, result.data)}
+            action={saveContent.bind(null, spec.key, numericId)}
+            cancelHref={`/admin/${spec.key}`}
+          />
+        </>
+      )}
+    </Container>
+  );
+}

--- a/apps/web/app/(console)/admin/[entity]/new/page.tsx
+++ b/apps/web/app/(console)/admin/[entity]/new/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { saveContent } from "@/app/actions/content";
+import { EntityForm } from "@/components/console/entity-form";
+import { Container } from "@/components/ui/container";
+import { Eyebrow, eyebrowClasses } from "@/components/ui/eyebrow";
+import { requireAdmin } from "@/lib/admin-guard";
+import { cn } from "@/lib/cn";
+import { entityFor, fieldsFor } from "@/lib/content-schema";
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/admin/[entity]/new">): Promise<Metadata> {
+  const spec = entityFor((await params).entity);
+  return { title: spec ? `New ${spec.singular}` : "Not found" };
+}
+
+export default async function NewEntityPage({ params }: PageProps<"/admin/[entity]/new">) {
+  const { entity } = await params;
+  const spec = entityFor(entity);
+  if (!spec) notFound();
+
+  await requireAdmin(`/admin/${spec.key}/new`);
+
+  // Every field starts empty rather than at the API's defaults. A checkbox
+  // pre-ticked as published would mean a slip of the mouse puts an unfinished
+  // row on the public site; unpublished is the safe direction, and it is also
+  // what the API's own default is.
+  const initial = Object.fromEntries(
+    fieldsFor(spec, "create").map((field) => [field.name, ""]),
+  );
+
+  return (
+    <Container width="wide" className="py-12 sm:py-16">
+      <Link
+        href={`/admin/${spec.key}`}
+        className={cn(eyebrowClasses, "transition-colors hover:text-primary")}
+      >
+        ← {spec.plural}
+      </Link>
+
+      <Eyebrow className="mt-8">New</Eyebrow>
+      <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
+        New {spec.singular}
+      </h1>
+
+      <EntityForm
+        spec={spec}
+        mode="create"
+        initial={initial}
+        // Bound here, on the server: the form posts no field that decides what
+        // gets written or where.
+        action={saveContent.bind(null, spec.key, null)}
+        cancelHref={`/admin/${spec.key}`}
+      />
+    </Container>
+  );
+}

--- a/apps/web/app/(console)/admin/[entity]/page.tsx
+++ b/apps/web/app/(console)/admin/[entity]/page.tsx
@@ -1,0 +1,183 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { removeContent, togglePublished } from "@/app/actions/content";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonClasses } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ConfirmDelete } from "@/components/ui/confirm-delete";
+import { Container } from "@/components/ui/container";
+import { Eyebrow, eyebrowClasses } from "@/components/ui/eyebrow";
+import { Notice } from "@/components/ui/notice";
+import { requireAdmin } from "@/lib/admin-guard";
+import { cn } from "@/lib/cn";
+import { fetchContentList } from "@/lib/console-api";
+import { ENTITIES, entityFor, listProblem } from "@/lib/content-schema";
+
+/**
+ * One list screen for all five content types.
+ *
+ * The route is `[entity]` rather than five folders because the screens differ
+ * only in which fields they show, and lib/content-schema.ts already holds that.
+ * An unrecognised segment is a 404 — the entity is looked up in ENTITIES and
+ * never taken from the URL as a path.
+ */
+
+/** Only these five segments exist; anything else 404s rather than rendering. */
+export function generateStaticParams() {
+  return ENTITIES.map((entity) => ({ entity: entity.key }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/admin/[entity]">): Promise<Metadata> {
+  const spec = entityFor((await params).entity);
+  return { title: spec ? spec.plural : "Not found" };
+}
+
+export default async function EntityListPage({
+  params,
+  searchParams,
+}: PageProps<"/admin/[entity]">) {
+  const { entity } = await params;
+  const spec = entityFor(entity);
+  if (!spec) notFound();
+
+  const { accessToken } = await requireAdmin(`/admin/${spec.key}`);
+  const result = await fetchContentList(accessToken, spec.apiPath);
+  const problem = listProblem((await searchParams).problem);
+
+  const rows = result.ok ? result.data : [];
+  const drafts = spec.publishable
+    ? rows.filter((row) => row.published !== true).length
+    : 0;
+
+  return (
+    <Container width="wide" className="py-12 sm:py-16">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <Eyebrow>{spec.plural}</Eyebrow>
+          <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
+            {spec.plural}
+          </h1>
+          {result.ok && (
+            <p className={cn(eyebrowClasses, "mt-3")}>
+              {rows.length} {rows.length === 1 ? "row" : "rows"}
+              {spec.publishable ? ` · ${drafts} draft${drafts === 1 ? "" : "s"}` : ""}
+            </p>
+          )}
+        </div>
+
+        <Link href={`/admin/${spec.key}/new`} className={buttonClasses()}>
+          New {spec.singular}
+        </Link>
+      </div>
+
+      {problem && <Notice className="mt-8 border-destructive/50">{problem}</Notice>}
+
+      {!result.ok ? (
+        /*
+          Surfaced, not swallowed — as in the inbox. The public site hides a
+          failed read behind an empty fallback so a sleeping backend cannot take
+          it down; here that would draw "the API is unreachable" and "you have
+          not written anything yet" as the same picture.
+        */
+        <Notice className="mt-8">
+          These {spec.plural.toLowerCase()} could not be loaded — the API did not
+          answer. Nothing has been lost; reload once it is back.
+        </Notice>
+      ) : rows.length === 0 ? (
+        <p className="mt-8 text-muted-foreground">
+          No {spec.plural.toLowerCase()} yet. Create the first one.
+        </p>
+      ) : (
+        <ul className="mt-8 flex flex-col gap-3">
+          {rows.map((row) => {
+            const id = Number(row.id);
+            const title = String(row[spec.titleField] ?? "Untitled");
+            const subtitle = spec.subtitleField ? row[spec.subtitleField] : null;
+            const published = row.published === true;
+
+            return (
+              <li key={id}>
+                <Card className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                      <h2 className="font-display font-semibold text-foreground">
+                        {title}
+                      </h2>
+                      {/*
+                        Only drafts are badged. A "Published" badge on every row
+                        is a badge that says nothing — the state worth spotting
+                        at a glance is the one that is invisible to the public.
+                      */}
+                      {spec.publishable && !published && (
+                        <Badge variant="outline">Draft</Badge>
+                      )}
+                    </div>
+
+                    {typeof subtitle === "string" && subtitle && (
+                      // line-clamp so a long description cannot turn one row
+                      // into half a screen.
+                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                        {subtitle}
+                      </p>
+                    )}
+
+                    {typeof row.slug === "string" && (
+                      /*
+                        normal-case, unlike every other eyebrow: this is a URL,
+                        and URLs are case-significant. Rendered in the eyebrow's
+                        uppercase it read as /CENEMATIC, which is not the
+                        address and is not what anyone should copy.
+                      */
+                      <p className={cn(eyebrowClasses, "mt-2 normal-case tracking-normal")}>
+                        /{row.slug}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex shrink-0 flex-wrap items-start gap-2">
+                    <Link
+                      href={`/admin/${spec.key}/${id}`}
+                      className={buttonClasses("quiet", "min-h-11 px-4 py-2 text-xs")}
+                    >
+                      Edit
+                    </Link>
+
+                    {spec.publishable && (
+                      <form action={togglePublished.bind(null, spec.key)}>
+                        <input type="hidden" name="id" value={id} />
+                        {/* The state being moved *to*, so the button's label and
+                            what it sends cannot drift apart. */}
+                        <input
+                          type="hidden"
+                          name="published"
+                          value={published ? "false" : "true"}
+                        />
+                        <Button
+                          variant="quiet"
+                          type="submit"
+                          className="min-h-11 px-4 py-2 text-xs"
+                        >
+                          {published ? "Unpublish" : "Publish"}
+                        </Button>
+                      </form>
+                    )}
+
+                    <ConfirmDelete
+                      action={removeContent.bind(null, spec.key)}
+                      id={id}
+                      warning={`Delete “${title}”? This cannot be undone.`}
+                    />
+                  </div>
+                </Card>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Container>
+  );
+}

--- a/apps/web/app/(console)/admin/layout.tsx
+++ b/apps/web/app/(console)/admin/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { signOut } from "@/app/actions/auth";
+import { ConsoleNav } from "@/components/console/console-nav";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Container } from "@/components/ui/container";
@@ -34,7 +35,10 @@ export default async function AdminLayout({ children }: LayoutProps<"/admin">) {
         >
           <Link
             href="/admin"
-            className="uppercase tracking-[0.18em] text-foreground hover:text-primary"
+            // min-h-11: as bare inline text this was a 66×16 target, which is
+            // under the 44px floor every other control on the site meets. It
+            // became worth fixing once there was a nav under it to go back from.
+            className="inline-flex min-h-11 items-center uppercase tracking-[0.18em] text-foreground hover:text-primary"
           >
             Console
           </Link>
@@ -76,6 +80,13 @@ export default async function AdminLayout({ children }: LayoutProps<"/admin">) {
           </form>
         </Container>
       </header>
+
+      {/*
+        The way between sections, under the status strip rather than beside it:
+        one row says who you are, the next says where you can go, and neither
+        has to compete with the other for width.
+      */}
+      <ConsoleNav />
 
       {children}
     </>

--- a/apps/web/app/actions/content.ts
+++ b/apps/web/app/actions/content.ts
@@ -1,0 +1,193 @@
+"use server";
+
+import { updateTag } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { requireAdmin } from "@/lib/admin-guard";
+import { CONTENT_TAGS, type ContentTag } from "@/lib/api";
+import {
+  type ContentState,
+  type EntitySpec,
+  entityFor,
+  readForm,
+  toPayload,
+  validate,
+} from "@/lib/content-schema";
+import { createContent, deleteContent, updateContent } from "@/lib/console-api";
+
+/**
+ * Writes for every content type, driven by lib/content-schema.ts.
+ *
+ * ## The entity comes from the description, never from the request
+ *
+ * Each action is given an entity key and looks it up in `ENTITIES`. An
+ * unrecognised key is a 404, not a request forwarded to a path someone typed —
+ * without that, `apiPath` would be attacker-controlled and these functions
+ * would proxy arbitrary calls to the API using the admin's own token.
+ *
+ * ## Why the public site is revalidated and the console is not
+ *
+ * lib/api.ts holds public reads for five minutes, so a project edited here
+ * would keep showing its old text on the home page for that long — the one
+ * place where "it saved but the site disagrees" is visible to a stranger.
+ * Every write busts the pages its type appears on. The console itself needs
+ * nothing: lib/console-api.ts reads `no-store` throughout.
+ *
+ * ## Why each action re-checks the session
+ *
+ * `requireAdmin` runs in the layout, but a layout does not guard a Server
+ * Action — the action is a POST endpoint the browser can reach directly.
+ */
+
+function specOrNotFound(entityKey: string): EntitySpec {
+  const spec = entityFor(entityKey);
+  if (!spec) {
+    // Reached only if a caller invents a key; the screens pass one from ENTITIES.
+    throw new Error(`Unknown content type: ${entityKey}`);
+  }
+  return spec;
+}
+
+/**
+ * Drop every public page that read this type.
+ *
+ * By tag, not by path, and that is a correctness point rather than a tidy one.
+ * `revalidatePath` was the first attempt: it cleared `/blog`, and did *not*
+ * clear the prerendered `/blog/[slug]` pages even when called with the route
+ * pattern and `"page"`. Unpublishing a post therefore removed it from the index
+ * while leaving the post itself readable at its own URL, body and all, with the
+ * API correctly 404ing underneath. Found by opening the URL after clicking
+ * Unpublish; nothing in the type system or the test suite was ever going to say
+ * so.
+ *
+ * A tag also survives the thing paths cannot: this action knows a row's id and
+ * nothing else, so it could not have named the slug even if paths had worked.
+ *
+ * `updateTag`, not `revalidateTag`. In Next 16 the latter takes a cache-life
+ * profile and marks the entry stale; the former is the Server Action form and
+ * expires it immediately, which is what "I pressed Publish and then looked at
+ * the site" requires. Getting this from memory would have produced the wrong
+ * one — the signature is in node_modules/next/dist/server/web/spec-extension.
+ */
+function revalidatePublic(spec: EntitySpec): void {
+  updateTag(tagFor(spec));
+}
+
+/** The spec's tag, checked against the ones lib/api.ts actually applies. */
+function tagFor(spec: EntitySpec): ContentTag {
+  const tag = CONTENT_TAGS[spec.cacheTag as keyof typeof CONTENT_TAGS];
+  if (!tag) {
+    // A spec whose tag matches nothing would revalidate nothing, silently —
+    // the public site would just keep serving stale content after every edit.
+    throw new Error(`No cache tag in lib/api.ts matches "${spec.cacheTag}"`);
+  }
+  return tag;
+}
+
+function listPath(spec: EntitySpec): string {
+  return `/admin/${spec.key}`;
+}
+
+/**
+ * Create or update, depending on `id`.
+ *
+ * Bound to its entity and row by the page that renders the form
+ * (`saveContent.bind(null, key, id)`), so the form itself posts nothing that
+ * decides what gets written.
+ */
+export async function saveContent(
+  entityKey: string,
+  id: number | null,
+  _previous: ContentState,
+  formData: FormData,
+): Promise<ContentState> {
+  const spec = specOrNotFound(entityKey);
+  const { accessToken } = await requireAdmin(listPath(spec));
+  const mode = id === null ? "create" : "edit";
+
+  const values = readForm(spec, formData, mode);
+
+  // The browser ran this too. It runs again because the browser's copy is a
+  // convenience, not a control — this form posts fine with scripting off.
+  const errors = validate(spec, values, mode);
+  if (Object.keys(errors).length > 0) {
+    return { status: "invalid", errors, values };
+  }
+
+  const payload = toPayload(spec, values, mode);
+
+  const result =
+    id === null
+      ? await createContent(accessToken, spec.apiPath, payload)
+      : await updateContent(accessToken, spec.apiPath, id, payload);
+
+  if (!result.ok) {
+    // A 404 on an edit means the row was deleted while this form sat open —
+    // worth saying, because "the API did not answer" would send the admin
+    // looking for an outage that is not there.
+    if (result.reason === "missing") return { status: "missing", values };
+    return { status: "unavailable", values };
+  }
+
+  revalidatePublic(spec);
+  redirect(listPath(spec));
+}
+
+/** Flip `published`. Sends only that field; the rest of the row is not touched. */
+export async function togglePublished(entityKey: string, formData: FormData): Promise<void> {
+  const spec = specOrNotFound(entityKey);
+  const { accessToken } = await requireAdmin(listPath(spec));
+
+  const id = readId(formData);
+  if (id === null) redirect(`${listPath(spec)}?problem=unknown-row`);
+
+  const published = formData.get("published") === "true";
+  const result = await updateContent(accessToken, spec.apiPath, id, { published });
+
+  if (!result.ok) {
+    redirect(`${listPath(spec)}?problem=${problemFor(result.reason, "not-published")}`);
+  }
+
+  revalidatePublic(spec);
+  redirect(listPath(spec));
+}
+
+export async function removeContent(entityKey: string, formData: FormData): Promise<void> {
+  const spec = specOrNotFound(entityKey);
+  const { accessToken } = await requireAdmin(listPath(spec));
+
+  const id = readId(formData);
+  if (id === null) redirect(`${listPath(spec)}?problem=unknown-row`);
+
+  const result = await deleteContent(accessToken, spec.apiPath, id);
+
+  if (!result.ok) {
+    redirect(`${listPath(spec)}?problem=${problemFor(result.reason, "not-deleted")}`);
+  }
+
+  revalidatePublic(spec);
+  redirect(listPath(spec));
+}
+
+/*
+ * There is deliberately no `loadContent` action. Reading a row for the edit
+ * form is something the page does on the server anyway, and exporting it from
+ * here would turn a plain function call into a POST endpoint the browser can
+ * reach — admin-guarded, so not a hole, but surface with nothing to gain.
+ */
+
+/** Reject anything that is not a plain positive integer before it reaches a URL. */
+function readId(formData: FormData): number | null {
+  const id = Number(formData.get("id"));
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+function problemFor(
+  reason: "unauthorized" | "rate_limited" | "missing" | "error",
+  whenFailed: string,
+): string {
+  if (reason === "unauthorized") return "session-ended";
+  // Not a fault: the row was deleted from another tab, which is ordinary.
+  if (reason === "missing") return "already-gone";
+  return whenFailed;
+}

--- a/apps/web/components/console/console-nav.tsx
+++ b/apps/web/components/console/console-nav.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+/*
+ * A client component for one reason: `usePathname`.
+ *
+ * Same as the public nav — there is no server equivalent, a layout is not
+ * re-rendered per segment with the path in hand, and nothing in CSS knows which
+ * page it is on. Without it this is a row of links that never says where you
+ * are, which is the one thing a nav is for. No state, no effects.
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/cn";
+import { ENTITIES } from "@/lib/content-schema";
+
+/**
+ * The inbox first, because it is the only section that receives things rather
+ * than holding things — it is the one with something new in it.
+ */
+const SECTIONS = [
+  { href: "/admin", label: "Inbox" },
+  ...ENTITIES.map((entity) => ({ href: `/admin/${entity.key}`, label: entity.plural })),
+];
+
+export function ConsoleNav() {
+  const pathname = usePathname();
+
+  return (
+    // A horizontal strip, not a sidebar. A left rail is the reflex for an admin
+    // area and is the one shape that says "generic dashboard"; this site's
+    // vocabulary is mono status rows, and the layout above is already one.
+    // overflow-x-auto rather than wrapping: at 375px six sections wrap to three
+    // ragged lines, and a scrolling row keeps the strip one row tall everywhere.
+    <nav
+      aria-label="Console sections"
+      className="flex gap-1 overflow-x-auto border-b border-border bg-card/30"
+    >
+      {SECTIONS.map((section) => {
+        // Exact for the inbox, which is /admin and a prefix of everything else;
+        // prefix for the rest, so an edit form keeps its section marked.
+        const current =
+          section.href === "/admin"
+            ? pathname === "/admin"
+            : pathname === section.href || pathname.startsWith(`${section.href}/`);
+
+        return (
+          <Link
+            key={section.href}
+            href={section.href}
+            aria-current={current ? "page" : undefined}
+            className={cn(
+              "relative inline-flex min-h-11 shrink-0 items-center px-4 font-mono text-xs uppercase tracking-[0.18em] transition-colors",
+              current
+                ? "text-primary after:absolute after:inset-x-3 after:bottom-0 after:h-px after:bg-primary"
+                : "text-muted-foreground hover:text-primary",
+            )}
+          >
+            {section.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/components/console/entity-form.tsx
+++ b/apps/web/components/console/entity-form.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+/*
+ * A client component for one reason: `useActionState`.
+ *
+ * A create or edit form has to come back with per-field errors *and* what was
+ * typed, and there is no server-only way to do that — the URL cannot carry a
+ * two-thousand-word Markdown body, and re-rendering from scratch would empty
+ * the form. This is the same hook, for the same reason, as the contact form.
+ *
+ * It still works with scripting off: `useActionState` is progressively
+ * enhanced, so with no JavaScript the form does a plain POST and Next
+ * re-renders the page with the returned state. That is why every control is
+ * filled from `defaultValue` on the state's values rather than from the row —
+ * on that path the fields would otherwise reset to their saved text and throw
+ * away the edit that was just rejected.
+ */
+
+import Link from "next/link";
+import { useActionState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { CheckboxField, SelectField, TextAreaField, TextField } from "@/components/ui/field";
+import { Notice } from "@/components/ui/notice";
+import {
+  INITIAL_CONTENT_STATE,
+  type ContentState,
+  type EntitySpec,
+  type FieldSpec,
+  type Values,
+  fieldsFor,
+} from "@/lib/content-schema";
+
+export function EntityForm({
+  spec,
+  mode,
+  initial,
+  action,
+  cancelHref,
+}: {
+  spec: EntitySpec;
+  mode: "create" | "edit";
+  /** The row as strings, or empty strings for a new one. */
+  initial: Values;
+  action: (previous: ContentState, formData: FormData) => Promise<ContentState>;
+  cancelHref: string;
+}) {
+  const [state, formAction, pending] = useActionState(action, INITIAL_CONTENT_STATE);
+
+  const values = state.status === "idle" ? initial : state.values;
+  const errors = state.status === "invalid" ? state.errors : {};
+
+  return (
+    <form action={formAction} className="mt-8">
+      {state.status === "unavailable" && (
+        <Notice className="mb-6 border-destructive/50">
+          Nothing was saved — the API did not answer. Your changes are still in
+          the form below; try again.
+        </Notice>
+      )}
+
+      {state.status === "missing" && (
+        <Notice className="mb-6 border-destructive/50">
+          This {spec.singular} has been deleted, so there was nothing to save
+          into. Copy anything you want to keep before leaving this page.
+        </Notice>
+      )}
+
+      {state.status === "invalid" && (
+        <Notice className="mb-6 border-destructive/50">
+          Nothing was saved. Check the fields marked below.
+        </Notice>
+      )}
+
+      {/* max-w so a text input does not stretch to a 1200px line on a big screen. */}
+      <div className="flex max-w-2xl flex-col gap-6">
+        {fieldsFor(spec, mode).map((field) => (
+          <Control
+            key={field.name}
+            field={field}
+            value={values[field.name] ?? ""}
+            error={errors[field.name]}
+          />
+        ))}
+      </div>
+
+      <div className="mt-8 flex flex-wrap items-center gap-3 border-t border-border pt-6">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : mode === "create" ? `Create ${spec.singular}` : "Save changes"}
+        </Button>
+
+        {/* A link, not a button: cancelling is going somewhere, not submitting. */}
+        <Link href={cancelHref} className="min-h-11 px-2 py-3 text-sm text-muted-foreground hover:text-primary">
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+function Control({
+  field,
+  value,
+  error,
+}: {
+  field: FieldSpec;
+  value: string;
+  error?: string;
+}) {
+  const hint = field.hint ? (
+    <span className="text-xs font-normal normal-case tracking-normal text-muted-foreground">
+      {field.hint}
+    </span>
+  ) : undefined;
+
+  switch (field.kind) {
+    case "boolean":
+      return (
+        <CheckboxField
+          name={field.name}
+          label={field.label}
+          hint={field.hint}
+          defaultChecked={value === "true"}
+        />
+      );
+
+    case "select":
+      return (
+        <SelectField
+          name={field.name}
+          label={field.label}
+          meta={hint}
+          error={error}
+          options={field.options ?? []}
+          defaultValue={value}
+        />
+      );
+
+    case "list":
+      return (
+        <TextAreaField
+          name={field.name}
+          label={field.label}
+          meta={
+            <span className="text-xs font-normal normal-case tracking-normal text-muted-foreground">
+              One per line
+            </span>
+          }
+          error={error}
+          rows={field.rows ?? 4}
+          defaultValue={value}
+        />
+      );
+
+    case "textarea":
+    case "markdown":
+      return (
+        <TextAreaField
+          name={field.name}
+          label={field.label}
+          meta={hint}
+          error={error}
+          rows={field.rows ?? 4}
+          defaultValue={value}
+          // Markdown is written in the same face it is read in; the body of a
+          // post is largely code fences and indentation, and a proportional
+          // font makes both unreadable while editing.
+          className={field.kind === "markdown" ? "font-mono text-[0.8125rem]" : undefined}
+        />
+      );
+
+    default:
+      return (
+        <TextField
+          name={field.name}
+          label={field.label}
+          meta={hint}
+          error={error}
+          defaultValue={value}
+          type={inputType(field.kind)}
+          maxLength={field.maxLength}
+        />
+      );
+  }
+}
+
+function inputType(kind: FieldSpec["kind"]): string {
+  if (kind === "date" || kind === "datetime") return "date";
+  if (kind === "number") return "number";
+  // Not type="url": the browser then refuses anything without a scheme, and
+  // rejects it with a tooltip rather than the field error this form uses for
+  // everything else. The API takes a string; a typo is the admin's own.
+  return "text";
+}

--- a/apps/web/components/ui/field.tsx
+++ b/apps/web/components/ui/field.tsx
@@ -1,4 +1,9 @@
-import type { InputHTMLAttributes, ReactNode, TextareaHTMLAttributes } from "react";
+import type {
+  InputHTMLAttributes,
+  ReactNode,
+  SelectHTMLAttributes,
+  TextareaHTMLAttributes,
+} from "react";
 
 import { eyebrowClasses } from "@/components/ui/eyebrow";
 import { cn } from "@/lib/cn";
@@ -78,11 +83,25 @@ type SharedProps = {
   error?: string;
 };
 
+/*
+ * Every control below pulls `className` out of the rest of its props and merges
+ * it, rather than letting the spread carry it.
+ *
+ * Spreading it is the bug it looks like it is not. `<input className={base}
+ * {...props} />` lets a caller's `className` replace the base outright — and
+ * because a spread applies whatever the key holds, passing `className={
+ * undefined}` from a conditional replaces it with nothing at all. The controls
+ * then render with no border, no background and no padding, which on a light
+ * page means an input you cannot see. That shipped through type-check and lint
+ * and was caught by opening the form.
+ */
+
 export function TextField({
   name,
   label,
   meta,
   error,
+  className,
   ...props
 }: SharedProps & Omit<InputHTMLAttributes<HTMLInputElement>, "name" | "id">) {
   return (
@@ -90,12 +109,86 @@ export function TextField({
       <input
         id={name}
         name={name}
-        className={controlClasses}
         aria-invalid={error ? true : undefined}
         aria-describedby={error ? `${name}-error` : undefined}
         {...props}
+        className={cn(controlClasses, className)}
       />
     </FieldShell>
+  );
+}
+
+export function SelectField({
+  name,
+  label,
+  meta,
+  error,
+  options,
+  className,
+  ...props
+}: SharedProps & { options: { value: string; label: string }[] } & Omit<
+    SelectHTMLAttributes<HTMLSelectElement>,
+    "name" | "id"
+  >) {
+  return (
+    <FieldShell htmlFor={name} label={label} meta={meta} error={error}>
+      <select
+        id={name}
+        name={name}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${name}-error` : undefined}
+        {...props}
+        className={cn(controlClasses, className)}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </FieldShell>
+  );
+}
+
+/**
+ * A checkbox, which does not use FieldShell.
+ *
+ * The shell puts its label above the control, which is right for something you
+ * type into and wrong for a checkbox — a tickbox belongs beside its label, and
+ * the label has to be part of the target rather than sitting above it. So this
+ * is a `<label>` wrapping both, giving a 44px row that is entirely clickable.
+ */
+export function CheckboxField({
+  name,
+  label,
+  hint,
+  defaultChecked,
+}: {
+  name: string;
+  label: string;
+  hint?: string;
+  defaultChecked?: boolean;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={name}
+        className="inline-flex min-h-11 cursor-pointer items-center gap-3"
+      >
+        <input
+          id={name}
+          name={name}
+          type="checkbox"
+          defaultChecked={defaultChecked}
+          // h-5 w-5: the browser default is 13px, which is both hard to hit and
+          // visually lost next to 14px text. accent-primary tints the tick with
+          // the site's own colour instead of the OS blue.
+          className="h-5 w-5 shrink-0 accent-primary"
+        />
+        <span className={eyebrowClasses}>{label}</span>
+      </label>
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
   );
 }
 
@@ -104,6 +197,7 @@ export function TextAreaField({
   label,
   meta,
   error,
+  className,
   ...props
 }: SharedProps & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "name" | "id">) {
   return (
@@ -111,12 +205,12 @@ export function TextAreaField({
       <textarea
         id={name}
         name={name}
-        // Vertical resize only: a horizontally resizable textarea can be
-        // dragged out past its container and break the column.
-        className={cn(controlClasses, "resize-y")}
         aria-invalid={error ? true : undefined}
         aria-describedby={error ? `${name}-error` : undefined}
         {...props}
+        // Vertical resize only: a horizontally resizable textarea can be
+        // dragged out past its container and break the column.
+        className={cn(controlClasses, "resize-y", className)}
       />
     </FieldShell>
   );

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -44,12 +44,40 @@ const isList: ShapeCheck = (data) => Array.isArray(data);
 const isRecord: ShapeCheck = (data) =>
   typeof data === "object" && data !== null && !Array.isArray(data);
 
-async function getJson<T>(path: string, fallback: T, isExpectedShape: ShapeCheck): Promise<T> {
+/**
+ * Cache tags, one per content type.
+ *
+ * These are what the console's writes invalidate. Tagging rather than listing
+ * paths is not a tidiness preference — it is the only version that works. A
+ * publish toggle knows a row's id and nothing else, so it cannot name
+ * `/blog/the-slug`; and `revalidatePath("/blog/[slug]", "page")` did not clear
+ * the prerendered detail pages, which left an unpublished post still readable
+ * at its URL, body and all, while the API was correctly 404ing it. A tag
+ * invalidates every page that read the tagged response, whatever its path.
+ */
+export const CONTENT_TAGS = {
+  projects: "projects",
+  skills: "skills",
+  certificates: "certificates",
+  career: "career",
+  posts: "posts",
+} as const;
+
+export type ContentTag = (typeof CONTENT_TAGS)[keyof typeof CONTENT_TAGS];
+
+async function getJson<T>(
+  path: string,
+  fallback: T,
+  isExpectedShape: ShapeCheck,
+  tag: ContentTag,
+): Promise<T> {
   const url = `${API_URL}/api/v1${path}`;
 
   try {
     const response = await fetch(url, {
-      next: { revalidate: REVALIDATE_SECONDS },
+      // `revalidate` is still the backstop for a change made anywhere but the
+      // console — the seed script, or psql.
+      next: { revalidate: REVALIDATE_SECONDS, tags: [tag] },
       signal: AbortSignal.timeout(TIMEOUT_MS),
       headers: { Accept: "application/json" },
     });
@@ -77,23 +105,28 @@ async function getJson<T>(path: string, fallback: T, isExpectedShape: ShapeCheck
 }
 
 export async function getProjects(): Promise<Project[]> {
-  return getJson<Project[]>("/projects/", [], isList);
+  return getJson<Project[]>("/projects/", [], isList, CONTENT_TAGS.projects);
 }
 
 export async function getProject(slug: string): Promise<Project | null> {
-  return getJson<Project | null>(`/projects/slug/${encodeURIComponent(slug)}`, null, isRecord);
+  return getJson<Project | null>(
+    `/projects/slug/${encodeURIComponent(slug)}`,
+    null,
+    isRecord,
+    CONTENT_TAGS.projects,
+  );
 }
 
 export async function getSkills(): Promise<Skill[]> {
-  return getJson<Skill[]>("/skills/", [], isList);
+  return getJson<Skill[]>("/skills/", [], isList, CONTENT_TAGS.skills);
 }
 
 export async function getCertificates(): Promise<Certificate[]> {
-  return getJson<Certificate[]>("/certificates/", [], isList);
+  return getJson<Certificate[]>("/certificates/", [], isList, CONTENT_TAGS.certificates);
 }
 
 export async function getCareerEntries(): Promise<CareerEntry[]> {
-  return getJson<CareerEntry[]>("/career/", [], isList);
+  return getJson<CareerEntry[]>("/career/", [], isList, CONTENT_TAGS.career);
 }
 
 /**
@@ -106,9 +139,14 @@ export async function getCareerEntries(): Promise<CareerEntry[]> {
  * view costs no second round trip.
  */
 export async function getPosts(): Promise<Post[]> {
-  return getJson<Post[]>("/posts/", [], isList);
+  return getJson<Post[]>("/posts/", [], isList, CONTENT_TAGS.posts);
 }
 
 export async function getPost(slug: string): Promise<Post | null> {
-  return getJson<Post | null>(`/posts/slug/${encodeURIComponent(slug)}`, null, isRecord);
+  return getJson<Post | null>(
+    `/posts/slug/${encodeURIComponent(slug)}`,
+    null,
+    isRecord,
+    CONTENT_TAGS.posts,
+  );
 }

--- a/apps/web/lib/console-api.ts
+++ b/apps/web/lib/console-api.ts
@@ -194,3 +194,89 @@ export async function deleteContact(token: string, id: number): Promise<ApiResul
   const response = await call(path, { method: "DELETE", token });
   return toResult<unknown>(response, path);
 }
+
+/**
+ * Content CRUD, for whichever type the caller names.
+ *
+ * One set of functions rather than five, because the API is one shape for all
+ * of them — see lib/content-schema.ts, which holds the differences. `apiPath`
+ * comes from that description and never from a URL, so a request cannot be
+ * aimed somewhere else by editing the address bar.
+ *
+ * These return rows untyped. The admin screens render from the field
+ * description rather than from a TypeScript interface, and the reader that does
+ * care about shape — the public site's lib/api.ts — has its own.
+ */
+export type ContentRecord = Record<string, unknown>;
+
+/**
+ * Every row, drafts included.
+ *
+ * The token is what does that: `get_optional_admin` on the API widens the same
+ * public list route to unpublished rows when the caller is an admin — which is
+ * also why an admin list must never be cached. See the note at the top.
+ */
+export async function fetchContentList(
+  token: string,
+  apiPath: string,
+): Promise<ApiResult<ContentRecord[]>> {
+  const response = await call(apiPath, { token });
+  const result = await toResult<ContentRecord[]>(response, apiPath);
+
+  // Same reasoning as fetchContacts: an object where a list belongs throws on
+  // .map() during render, which is a 500 produced by a successful request.
+  if (result.ok && !Array.isArray(result.data)) {
+    console.error(`[console] ${apiPath} returned 200 with a non-list body`);
+    return { ok: false, reason: "error" };
+  }
+
+  return result;
+}
+
+export async function fetchContentItem(
+  token: string,
+  apiPath: string,
+  id: number,
+): Promise<ApiResult<ContentRecord>> {
+  const path = `${apiPath}${id}`;
+  const response = await call(path, { token });
+  return toResult<ContentRecord>(response, path);
+}
+
+export async function createContent(
+  token: string,
+  apiPath: string,
+  payload: ContentRecord,
+): Promise<ApiResult<ContentRecord>> {
+  const response = await call(apiPath, {
+    method: "POST",
+    token,
+    body: JSON.stringify(payload),
+  });
+  return toResult<ContentRecord>(response, apiPath);
+}
+
+export async function updateContent(
+  token: string,
+  apiPath: string,
+  id: number,
+  payload: ContentRecord,
+): Promise<ApiResult<ContentRecord>> {
+  const path = `${apiPath}${id}`;
+  const response = await call(path, {
+    method: "PUT",
+    token,
+    body: JSON.stringify(payload),
+  });
+  return toResult<ContentRecord>(response, path);
+}
+
+export async function deleteContent(
+  token: string,
+  apiPath: string,
+  id: number,
+): Promise<ApiResult<unknown>> {
+  const path = `${apiPath}${id}`;
+  const response = await call(path, { method: "DELETE", token });
+  return toResult<unknown>(response, path);
+}

--- a/apps/web/lib/content-schema.ts
+++ b/apps/web/lib/content-schema.ts
@@ -1,0 +1,492 @@
+/**
+ * What each content type is made of, in one place.
+ *
+ * ## Why a description rather than five sets of pages
+ *
+ * Projects, skills, certificates, career entries and posts are the same shape
+ * on the API — `GET /`, `GET /{id}`, `POST /`, `PUT /{id}`, `DELETE /{id}` —
+ * and differ only in their fields. Written out longhand that is five list
+ * pages, five create pages and five edit forms, all near-identical, which is
+ * the exact thing the repo's "if the same class string appears twice" rule
+ * exists to stop. It is also how a field ends up validated on one screen and
+ * not on another.
+ *
+ * So each type is described here and the screens are rendered from the
+ * description. The cost is one indirection; the benefit is that adding a
+ * column to a table is one entry in this file rather than an edit in four
+ * places, and every screen gets it at once.
+ *
+ * ## Why this file has no imports
+ *
+ * Same reason as lib/contact.ts: it is used by the browser (the form) and by
+ * the server (the action that receives the form), so the two cannot disagree
+ * about what a valid value is. Anything the browser enforces can be skipped by
+ * posting the form directly, so the server runs the identical function.
+ *
+ * The maximums mirror the column widths in apps/api/app/models/portfolio.py.
+ * Being stricter here than the API rejects values the API would accept; being
+ * looser hands the admin a 500 that could have been a sentence under the field.
+ */
+
+export type FieldKind =
+  | "text"
+  | "textarea"
+  /** Markdown, edited as plain text. Rendered server-side; see lib/markdown.ts. */
+  | "markdown"
+  | "url"
+  /** An API `date` column: sent as `YYYY-MM-DD`. */
+  | "date"
+  /** An API `datetime` column, but only the day is meaningful. See toPayload. */
+  | "datetime"
+  | "number"
+  | "boolean"
+  | "select"
+  /** A JSON list of strings, edited one per line. */
+  | "list";
+
+export type FieldSpec = {
+  name: string;
+  label: string;
+  kind: FieldKind;
+  required?: boolean;
+  /** Mirrors the column width. Absent on TEXT columns, which have none. */
+  maxLength?: number;
+  options?: { value: string; label: string }[];
+  /** Shown under the label. For saying what a field means, not what it is. */
+  hint?: string;
+  rows?: number;
+  /**
+   * Settable on create and fixed afterwards — which is the API's rule, not a
+   * choice made here: the `*Update` schemas have no `slug`, because
+   * regenerating one on a title edit silently breaks every link already
+   * published to it.
+   */
+  createOnly?: boolean;
+};
+
+export type EntitySpec = {
+  /** The URL segment under /admin, and the key everything else is looked up by. */
+  key: string;
+  /** Path on the API, with its trailing slash. */
+  apiPath: string;
+  singular: string;
+  plural: string;
+  /** Which field to show as a row's name in the list. */
+  titleField: string;
+  /** A second line under the title in the list, when there is one worth having. */
+  subtitleField?: string;
+  /** Whether rows have a `published` flag, and so a publish toggle. */
+  publishable: boolean;
+  fields: FieldSpec[];
+  /**
+   * The cache tag every public read of this type carries, so a write can
+   * invalidate them all without knowing which URLs exist. Must match a value in
+   * CONTENT_TAGS in lib/api.ts — that file cannot be imported here, because this
+   * module is loaded by the browser and that one is `server-only`.
+   */
+  cacheTag: string;
+};
+
+const SLUG: FieldSpec = {
+  name: "slug",
+  label: "Slug",
+  kind: "text",
+  maxLength: 255,
+  createOnly: true,
+  hint: "The URL segment. Leave empty to derive it from the title — it cannot be changed later.",
+};
+
+const PUBLISHED: FieldSpec = {
+  name: "published",
+  label: "Published",
+  kind: "boolean",
+  hint: "Unpublished rows are invisible to the public site and its API.",
+};
+
+const PROJECT_STATUS: FieldSpec = {
+  name: "status",
+  label: "Status",
+  kind: "select",
+  required: true,
+  options: [
+    { value: "completed", label: "Completed" },
+    { value: "in_progress", label: "In progress" },
+    { value: "on_hold", label: "On hold" },
+    { value: "dropped", label: "Dropped" },
+  ],
+};
+
+export const ENTITIES: EntitySpec[] = [
+  {
+    key: "projects",
+    cacheTag: "projects",
+    apiPath: "/projects/",
+    singular: "project",
+    plural: "Projects",
+    titleField: "title",
+    subtitleField: "description",
+    publishable: true,
+    fields: [
+      { name: "title", label: "Title", kind: "text", required: true, maxLength: 255 },
+      {
+        name: "description",
+        label: "Description",
+        kind: "textarea",
+        required: true,
+        rows: 3,
+        hint: "The card blurb on the home page.",
+      },
+      {
+        name: "long_description",
+        label: "Long description",
+        kind: "textarea",
+        rows: 6,
+        hint: "The body of the detail page.",
+      },
+      SLUG,
+      { name: "image_url", label: "Image URL", kind: "url", maxLength: 500 },
+      { name: "github_url", label: "Source URL", kind: "url", maxLength: 500 },
+      { name: "live_url", label: "Live URL", kind: "url", maxLength: 500 },
+      { name: "technologies", label: "Technologies", kind: "list" },
+      { name: "features", label: "Features", kind: "list" },
+      { name: "challenges", label: "Challenges", kind: "list" },
+      { name: "started_on", label: "Started on", kind: "date" },
+      {
+        name: "ended_on",
+        label: "Ended on",
+        kind: "date",
+        hint: "Leave empty while the work is still running.",
+      },
+      PROJECT_STATUS,
+      { name: "featured", label: "Featured", kind: "boolean" },
+      PUBLISHED,
+      {
+        name: "order",
+        label: "Order",
+        kind: "number",
+        hint: "Lowest first, within the published set.",
+      },
+    ],
+  },
+  {
+    key: "posts",
+    cacheTag: "posts",
+    apiPath: "/posts/",
+    singular: "post",
+    plural: "Posts",
+    titleField: "title",
+    subtitleField: "excerpt",
+    publishable: true,
+    fields: [
+      { name: "title", label: "Title", kind: "text", required: true, maxLength: 255 },
+      {
+        name: "excerpt",
+        label: "Excerpt",
+        kind: "textarea",
+        rows: 3,
+        hint: "The blurb on the index and the meta description. Left empty, the opening of the body is used.",
+      },
+      {
+        name: "body",
+        label: "Body",
+        kind: "markdown",
+        required: true,
+        rows: 20,
+        hint: "Markdown. Rendered and sanitised on the server; raw HTML is dropped.",
+      },
+      SLUG,
+      { name: "tags", label: "Tags", kind: "list" },
+      { name: "cover_image", label: "Cover image URL", kind: "url", maxLength: 500 },
+      PUBLISHED,
+      {
+        name: "published_at",
+        label: "Published on",
+        kind: "datetime",
+        hint: "Left empty, it is stamped the first time the post is published. Set it to backdate.",
+      },
+    ],
+  },
+  {
+    key: "certificates",
+    cacheTag: "certificates",
+    apiPath: "/certificates/",
+    singular: "certificate",
+    plural: "Certificates",
+    titleField: "title",
+    subtitleField: "issuer",
+    publishable: true,
+    fields: [
+      { name: "title", label: "Title", kind: "text", required: true, maxLength: 255 },
+      { name: "issuer", label: "Issuer", kind: "text", required: true, maxLength: 255 },
+      { name: "issue_date", label: "Issued on", kind: "datetime", required: true },
+      SLUG,
+      { name: "category", label: "Category", kind: "text", maxLength: 50 },
+      { name: "description", label: "Description", kind: "textarea", rows: 3 },
+      { name: "skills", label: "Skills", kind: "list" },
+      { name: "credential_id", label: "Credential ID", kind: "text", maxLength: 100 },
+      { name: "credential_url", label: "Credential URL", kind: "url", maxLength: 500 },
+      { name: "image_url", label: "Image URL", kind: "url", maxLength: 500 },
+      PUBLISHED,
+    ],
+  },
+  {
+    key: "career",
+    cacheTag: "career",
+    apiPath: "/career/",
+    singular: "career entry",
+    plural: "Career",
+    titleField: "title",
+    subtitleField: "company",
+    publishable: true,
+    fields: [
+      { name: "title", label: "Role", kind: "text", required: true, maxLength: 255 },
+      { name: "company", label: "Company", kind: "text", required: true, maxLength: 255 },
+      { name: "location", label: "Location", kind: "text", maxLength: 255 },
+      { name: "started_on", label: "Started on", kind: "date", required: true },
+      {
+        name: "ended_on",
+        label: "Ended on",
+        kind: "date",
+        hint: "Leave empty for a role you are still in; the site renders that as Present.",
+      },
+      SLUG,
+      { name: "highlights", label: "Highlights", kind: "list" },
+      PUBLISHED,
+    ],
+  },
+  {
+    key: "skills",
+    cacheTag: "skills",
+    apiPath: "/skills/",
+    singular: "skill",
+    plural: "Skills",
+    titleField: "name",
+    subtitleField: "category",
+    // The only content type with no `published` column: skills are a flat list
+    // on the home page and have never had a draft state.
+    publishable: false,
+    fields: [
+      { name: "name", label: "Name", kind: "text", required: true, maxLength: 100 },
+      {
+        name: "category",
+        label: "Category",
+        kind: "text",
+        required: true,
+        maxLength: 50,
+        hint: "Groups the bars on the home page: Frontend, Backend, Database, Cloud, DevOps, Tools.",
+      },
+      {
+        name: "level",
+        label: "Level",
+        kind: "select",
+        required: true,
+        options: [
+          { value: "beginner", label: "Beginner" },
+          { value: "intermediate", label: "Intermediate" },
+          { value: "advanced", label: "Advanced" },
+          { value: "expert", label: "Expert" },
+        ],
+      },
+      { name: "icon", label: "Icon", kind: "text", maxLength: 100 },
+      { name: "order", label: "Order", kind: "number" },
+    ],
+  },
+];
+
+export function entityFor(key: string | undefined): EntitySpec | undefined {
+  return ENTITIES.find((entity) => entity.key === key);
+}
+
+/** Fields the form shows: everything, minus the create-only ones when editing. */
+export function fieldsFor(spec: EntitySpec, mode: "create" | "edit"): FieldSpec[] {
+  return mode === "create" ? spec.fields : spec.fields.filter((field) => !field.createOnly);
+}
+
+export type Values = Record<string, string>;
+export type Errors = Record<string, string>;
+
+/**
+ * Every value is read as a string, including the booleans.
+ *
+ * FormData has no types — an unchecked checkbox is simply absent — so the
+ * string form is what actually crosses the wire, and converting once at the
+ * edge (`toPayload`) beats each screen guessing. It also means a rejected form
+ * can be re-rendered with exactly what was typed.
+ */
+export function readForm(spec: EntitySpec, formData: FormData, mode: "create" | "edit"): Values {
+  const values: Values = {};
+
+  for (const field of fieldsFor(spec, mode)) {
+    if (field.kind === "boolean") {
+      // A checkbox posts its value only when checked; absence is false.
+      values[field.name] = formData.get(field.name) === "on" ? "true" : "";
+      continue;
+    }
+    const raw = formData.get(field.name);
+    values[field.name] = typeof raw === "string" ? raw : "";
+  }
+
+  return values;
+}
+
+/** Turn an API record into the strings the form edits. */
+export function toValues(spec: EntitySpec, record: Record<string, unknown>): Values {
+  const values: Values = {};
+
+  for (const field of spec.fields) {
+    const raw = record[field.name];
+
+    if (raw === null || raw === undefined) {
+      values[field.name] = "";
+    } else if (field.kind === "boolean") {
+      values[field.name] = raw ? "true" : "";
+    } else if (field.kind === "list") {
+      values[field.name] = Array.isArray(raw) ? raw.join("\n") : "";
+    } else if (field.kind === "datetime") {
+      // Sliced, not parsed: `new Date()` on an instant would shift the day for
+      // anyone west of UTC, the same trap lib/format.ts documents.
+      values[field.name] = String(raw).slice(0, 10);
+    } else {
+      values[field.name] = String(raw);
+    }
+  }
+
+  return values;
+}
+
+/** One item per line, blanks dropped — so a trailing newline is not an entry. */
+function toList(value: string): string[] {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Errors name the field and the fix, in the house style: no "invalid input",
+ * which tells someone their value was rejected without telling them what to
+ * change.
+ */
+export function validate(spec: EntitySpec, values: Values, mode: "create" | "edit"): Errors {
+  const errors: Errors = {};
+
+  for (const field of fieldsFor(spec, mode)) {
+    const value = (values[field.name] ?? "").trim();
+
+    if (!value) {
+      if (field.required) errors[field.name] = `${field.label} is required.`;
+      continue;
+    }
+
+    if (field.maxLength && value.length > field.maxLength) {
+      errors[field.name] =
+        `${field.label} is ${value.length} characters. Trim it to ${field.maxLength}.`;
+      continue;
+    }
+
+    if (field.kind === "number" && !Number.isInteger(Number(value))) {
+      errors[field.name] = `${field.label} has to be a whole number.`;
+      continue;
+    }
+
+    if ((field.kind === "date" || field.kind === "datetime") && !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      errors[field.name] = `${field.label} has to be a date, as YYYY-MM-DD.`;
+      continue;
+    }
+
+    if (field.kind === "select" && !field.options?.some((option) => option.value === value)) {
+      errors[field.name] = `${field.label} is not one of the choices.`;
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Convert the form's strings into what the API's schema expects.
+ *
+ * `datetime` fields are edited as a day and sent at midnight UTC. Only the day
+ * is ever displayed — the certificates page and the blog both slice the first
+ * ten characters — so the time carries no information, and inventing one from
+ * the admin's clock would make the stored value depend on where they were
+ * sitting.
+ */
+export function toPayload(
+  spec: EntitySpec,
+  values: Values,
+  mode: "create" | "edit",
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  for (const field of fieldsFor(spec, mode)) {
+    const value = (values[field.name] ?? "").trim();
+
+    switch (field.kind) {
+      case "boolean":
+        payload[field.name] = value === "true";
+        break;
+      case "number":
+        payload[field.name] = value ? Number(value) : 0;
+        break;
+      case "list":
+        payload[field.name] = toList(values[field.name] ?? "");
+        break;
+      case "datetime":
+        payload[field.name] = value ? `${value}T00:00:00Z` : null;
+        break;
+      default:
+        // Empty means null, not "". The columns are nullable and an empty
+        // string would render as a blank line on the public page rather than
+        // being skipped by the `? :` that guards it.
+        payload[field.name] = value || null;
+    }
+  }
+
+  // A slug the admin left empty must not be sent as null: the API derives it
+  // from the title only when the key is absent.
+  if (mode === "create" && !payload.slug) delete payload.slug;
+
+  return payload;
+}
+
+/**
+ * What a save can come back as.
+ *
+ * Lives here rather than beside the Server Action, for the reason lib/contact.ts
+ * records: a `"use server"` module may only export async functions, and
+ * `INITIAL_CONTENT_STATE` below is a real object — it would type-check, build,
+ * and then throw the first time the form was submitted.
+ */
+export type ContentState =
+  | { status: "idle" }
+  /** Field-level problems, plus what was typed so nothing is lost. */
+  | { status: "invalid"; errors: Errors; values: Values }
+  /** The row was deleted while the form was open. */
+  | { status: "missing"; values: Values }
+  /** The API refused or did not answer. Nothing was saved. */
+  | { status: "unavailable"; values: Values };
+
+export const INITIAL_CONTENT_STATE: ContentState = { status: "idle" };
+
+/** Failures the list screen reports, from its `?problem=` parameter. */
+const LIST_PROBLEMS: Record<string, string> = {
+  "already-gone":
+    "That row had already been deleted, so nothing changed. The list below is current.",
+  "not-deleted":
+    "That row was not deleted — the API did not answer. It is still here; try again.",
+  "not-published":
+    "The publish state was not changed — the API did not answer. It is as it was; try again.",
+  "unknown-row": "That request did not name a row, so nothing changed. Reload and try again.",
+  "session-ended":
+    "Your session ended before that went through, so nothing changed. Sign in again to repeat it.",
+};
+
+/**
+ * Anything unrecognised returns null rather than being echoed. The value comes
+ * from the URL, so a visitor can put whatever they like in it, and a page that
+ * prints it is a page that prints text chosen by whoever wrote the link.
+ */
+export function listProblem(value: string | string[] | undefined): string | null {
+  const key = Array.isArray(value) ? value[0] : value;
+  return key && key in LIST_PROBLEMS ? LIST_PROBLEMS[key] : null;
+}


### PR DESCRIPTION
Items 1 and 3 of the admin brief: CRUD for all five content types, and a nav to move between them.

**Merge #38 first.** This branch is built on it, so until #38 lands the diff here also shows the blog pages and the inbox actions. Once #38 is in, this PR shrinks to just the console work. No re-pointing needed either way — the base is `main`.

No backend change: projects, skills, certificates, career entries and posts already had full CRUD behind `require_admin`.

## One set of screens, not five

All five are the same shape on the API and differ only in their fields, so each is described in `lib/content-schema.ts` and the screens render from that description. Written longhand this is fifteen near-identical pages, which is how a field ends up validated on one screen and not another; now adding a column is one entry in one file and every screen gets it.

The description imports nothing, so the browser and the server share it and cannot disagree about what a valid value is — the same arrangement as `lib/contact.ts`.

## Two bugs the browser found and the type system did not

**A draft leak.** Clicking Unpublish removed a post from `/blog` and left it fully readable at `/blog/its-slug`, body included, while the API was correctly 404ing underneath. `revalidatePath` cleared the index but not the prerendered detail pages, even called with the route pattern and `"page"`.

Public reads now carry a cache tag per content type and every write invalidates the tag. That also solves what paths never could: the publish toggle knows a row's id and nothing else, so it could not have named the slug even if `revalidatePath` had worked.

The fix needed `updateTag`, not `revalidateTag` — in Next 16 the latter takes a cache-life profile and marks an entry stale, while the former is the Server Action form and expires it immediately. From memory I would have written the wrong one; the signature is in `node_modules`, exactly as `apps/web/AGENTS.md` says to check.

**Invisible form controls.** `TextAreaField` set `className` and then spread `{...props}`, so a caller's `className` replaced the base styles — and a spread applies whatever the key holds, so `className={undefined}` from a conditional replaced them with nothing at all. The excerpt and body fields rendered with no border, no background and no padding: on a light page, inputs you cannot see. `pnpm type-check` and `pnpm lint` were both green. Every control now merges the incoming class.

## Smaller decisions

- Delete reuses the no-JavaScript `<details>` confirmation from the inbox, so the destructive button does not exist on the page until it is opened.
- The nav is a horizontal strip, not a sidebar — the admin layout already argues why, and a left rail is the one shape that says "generic dashboard". It scrolls sideways at 375px rather than wrapping to three ragged lines.
- Slugs are settable on create and shown-but-fixed on edit. That is the API's rule, not a preference: the update schemas carry no slug, because regenerating one on a title edit breaks every link already published to it.
- `published` starts unticked on a new row, so a slip of the mouse cannot put an unfinished draft on the public site.
- Only drafts are badged. A "Published" badge on every row is a badge that says nothing.
- The Console link in the status strip was a 66×16 tap target; it is 44px now that there is a nav under it to go back from.

## Verification

Against the real API on 8010 with a scratch database, not a stub:

- created a post from the form and followed it to the database, the blog index, its detail page and the RSS feed — slug derived, tags split per line, `published_at` stamped by the service
- unpublished it and confirmed all four dropped it and the detail page returns 404 on fresh requests
- edited a project and confirmed only the field I touched changed: dates, the status enum, both booleans and three string lists survived the round trip intact, and the slug was untouched
- created a skill — the one type with no publish flag — and confirmed it shows no publish control, no draft count, and reaches the home page
- submitted an empty form and checked the field errors carry `aria-invalid` and `aria-describedby` pointing at real nodes
- 375px and 1440px, both themes: no horizontal overflow, one `<h1>` per page, every control ≥44px, no contrast failure

`pnpm lint`, 106 unit tests, 58 e2e.

One note on measuring: the first contrast pass reported six failures on the nav that turned out to be my measuring script, not the page — the nav's background is an `oklab()` colour and the script only understood `rgb()` and `color(srgb …)`. Re-measured by painting the colour stack onto a canvas and letting the browser resolve it, which is the version worth keeping.

## Still open from the brief

Item 4, the traffic dashboard, using Vercel Web Analytics as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)