### PR TITLE
A dark console, and a home page that introduces itself as you scroll

### DIFF
--- a/apps/web/app/(console)/admin/[entity]/page.tsx
+++ b/apps/web/app/(console)/admin/[entity]/page.tsx
@@ -1,14 +1,12 @@
+import type { CSSProperties } from "react";
+
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { removeContent, togglePublished } from "@/app/actions/content";
-import { Badge } from "@/components/ui/badge";
 import { Button, buttonClasses } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { ConfirmDelete } from "@/components/ui/confirm-delete";
-import { Container } from "@/components/ui/container";
-import { Eyebrow, eyebrowClasses } from "@/components/ui/eyebrow";
 import { Notice } from "@/components/ui/notice";
 import { requireAdmin } from "@/lib/admin-guard";
 import { cn } from "@/lib/cn";
@@ -49,135 +47,155 @@ export default async function EntityListPage({
   const problem = listProblem((await searchParams).problem);
 
   const rows = result.ok ? result.data : [];
-  const drafts = spec.publishable
-    ? rows.filter((row) => row.published !== true).length
-    : 0;
+  const drafts = spec.publishable ? rows.filter((row) => row.published !== true).length : 0;
 
   return (
-    <Container width="wide" className="py-12 sm:py-16">
-      <div className="flex flex-wrap items-end justify-between gap-4">
+    <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-8 sm:py-10">
+      <header className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <Eyebrow>{spec.plural}</Eyebrow>
-          <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground">
+          {/* No eyebrow above it: the sidebar already says which section this
+              is, and repeating it is the kind of chrome that made the old
+              screens feel padded out. */}
+          <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">
             {spec.plural}
           </h1>
           {result.ok && (
-            <p className={cn(eyebrowClasses, "mt-3")}>
-              {rows.length} {rows.length === 1 ? "row" : "rows"}
-              {spec.publishable ? ` · ${drafts} draft${drafts === 1 ? "" : "s"}` : ""}
+            <p className="mt-1 text-sm text-muted-foreground">
+              {rows.length} {rows.length === 1 ? "item" : "items"}
+              {spec.publishable && drafts > 0 ? ` · ${drafts} draft${drafts === 1 ? "" : "s"}` : ""}
             </p>
           )}
         </div>
 
-        <Link href={`/admin/${spec.key}/new`} className={buttonClasses()}>
+        <Link href={`/admin/${spec.key}/new`} className={buttonClasses("primary")}>
           New {spec.singular}
         </Link>
-      </div>
+      </header>
 
-      {problem && <Notice className="mt-8 border-destructive/50">{problem}</Notice>}
+      {problem && <Notice className="mt-6 border-destructive/50">{problem}</Notice>}
 
       {!result.ok ? (
         /*
-          Surfaced, not swallowed — as in the inbox. The public site hides a
-          failed read behind an empty fallback so a sleeping backend cannot take
-          it down; here that would draw "the API is unreachable" and "you have
-          not written anything yet" as the same picture.
+          Surfaced, not swallowed. The public site hides a failed read behind an
+          empty fallback so a sleeping backend cannot take it down; here that
+          would draw "the API is unreachable" and "you have not written anything
+          yet" as the same picture, and the second reads as working.
         */
-        <Notice className="mt-8">
+        <Notice className="mt-6">
           These {spec.plural.toLowerCase()} could not be loaded — the API did not
           answer. Nothing has been lost; reload once it is back.
         </Notice>
       ) : rows.length === 0 ? (
-        <p className="mt-8 text-muted-foreground">
-          No {spec.plural.toLowerCase()} yet. Create the first one.
-        </p>
+        <div className="c-panel mt-6 px-6 py-14 text-center">
+          <p className="text-sm text-muted-foreground">
+            No {spec.plural.toLowerCase()} yet.
+          </p>
+          <Link
+            href={`/admin/${spec.key}/new`}
+            className={buttonClasses("quiet", "mt-4")}
+          >
+            Create the first one
+          </Link>
+        </div>
       ) : (
-        <ul className="mt-8 flex flex-col gap-3">
-          {rows.map((row) => {
+        <ul className="mt-6 flex flex-col gap-2">
+          {rows.map((row, index) => {
             const id = Number(row.id);
             const title = String(row[spec.titleField] ?? "Untitled");
             const subtitle = spec.subtitleField ? row[spec.subtitleField] : null;
             const published = row.published === true;
 
             return (
-              <li key={id}>
-                <Card className="gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                      <h2 className="font-display font-semibold text-foreground">
-                        {title}
-                      </h2>
-                      {/*
-                        Only drafts are badged. A "Published" badge on every row
-                        is a badge that says nothing — the state worth spotting
-                        at a glance is the one that is invisible to the public.
-                      */}
-                      {spec.publishable && !published && (
-                        <Badge variant="outline">Draft</Badge>
-                      )}
-                    </div>
-
-                    {typeof subtitle === "string" && subtitle && (
-                      // line-clamp so a long description cannot turn one row
-                      // into half a screen.
-                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                        {subtitle}
-                      </p>
-                    )}
-
-                    {typeof row.slug === "string" && (
-                      /*
-                        normal-case, unlike every other eyebrow: this is a URL,
-                        and URLs are case-significant. Rendered in the eyebrow's
-                        uppercase it read as /CENEMATIC, which is not the
-                        address and is not what anyone should copy.
-                      */
-                      <p className={cn(eyebrowClasses, "mt-2 normal-case tracking-normal")}>
-                        /{row.slug}
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="flex shrink-0 flex-wrap items-start gap-2">
-                    <Link
-                      href={`/admin/${spec.key}/${id}`}
-                      className={buttonClasses("quiet", "min-h-11 px-4 py-2 text-xs")}
-                    >
-                      Edit
-                    </Link>
-
+              <li
+                key={id}
+                className="c-panel c-row c-enter relative flex flex-wrap items-start justify-between gap-x-6 gap-y-3 px-4 py-3.5"
+                // Capped at eight: past that the stagger is a wait, not a flourish.
+                style={{ "--i": Math.min(index, 8) } as CSSProperties}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                     {spec.publishable && (
-                      <form action={togglePublished.bind(null, spec.key)}>
-                        <input type="hidden" name="id" value={id} />
-                        {/* The state being moved *to*, so the button's label and
-                            what it sends cannot drift apart. */}
-                        <input
-                          type="hidden"
-                          name="published"
-                          value={published ? "false" : "true"}
+                      // Dot plus word. The dot is what you scan a column for;
+                      // the word is what makes it mean anything to a screen
+                      // reader, and to anyone who does not read this colour.
+                      <span className="inline-flex shrink-0 items-center gap-1.5 font-mono text-[0.6875rem] uppercase tracking-[0.14em] text-muted-foreground">
+                        <span
+                          aria-hidden="true"
+                          className={cn("c-dot", published ? "c-dot-live" : "c-dot-draft")}
                         />
-                        <Button
-                          variant="quiet"
-                          type="submit"
-                          className="min-h-11 px-4 py-2 text-xs"
-                        >
-                          {published ? "Unpublish" : "Publish"}
-                        </Button>
-                      </form>
+                        {published ? "Live" : "Draft"}
+                      </span>
                     )}
 
-                    <ConfirmDelete
-                      action={removeContent.bind(null, spec.key)}
-                      id={id}
-                      warning={`Delete “${title}”? This cannot be undone.`}
-                    />
+                    <h2 className="min-w-0 font-medium text-foreground">
+                      {/*
+                        The title is the way in to the editor, so the row needs
+                        no Edit button — three equal-weight buttons per row was
+                        fifteen buttons on a five-row screen. The label names
+                        the action for anyone who cannot see that convention.
+                      */}
+                      <Link
+                        href={`/admin/${spec.key}/${id}`}
+                        aria-label={`Edit ${title}`}
+                        // Stretched over the row, as on a project card: the
+                        // title alone was a 21px-tall target, and the whole row
+                        // is what looks clickable anyway.
+                        className="truncate transition-colors after:absolute after:inset-0 hover:text-primary"
+                      >
+                        {title}
+                      </Link>
+                    </h2>
                   </div>
-                </Card>
+
+                  <p className="mt-1 truncate text-sm text-muted-foreground">
+                    {typeof row.slug === "string" && (
+                      // normal case, unlike the site's eyebrows: this is a URL,
+                      // and URLs are case-significant.
+                      <span className="font-mono text-xs text-muted-foreground/80">
+                        /{row.slug}
+                      </span>
+                    )}
+                    {typeof row.slug === "string" && typeof subtitle === "string" && subtitle
+                      ? " · "
+                      : ""}
+                    {typeof subtitle === "string" ? subtitle : ""}
+                  </p>
+                </div>
+
+                {/* items-start: the delete control grows downwards when opened. */}
+                {/* Above the stretched link, so these stay independently clickable. */}
+                <div className="relative z-10 flex shrink-0 items-start gap-2">
+                  {spec.publishable && (
+                    <form action={togglePublished.bind(null, spec.key)}>
+                      <input type="hidden" name="id" value={id} />
+                      {/* The state being moved *to*, so the label and what it
+                          sends cannot drift apart. */}
+                      <input
+                        type="hidden"
+                        name="published"
+                        value={published ? "false" : "true"}
+                      />
+                      <Button
+                        variant="quiet"
+                        type="submit"
+                        className="min-h-11 px-3 py-2 text-xs"
+                      >
+                        {published ? "Unpublish" : "Publish"}
+                      </Button>
+                    </form>
+                  )}
+
+                  <ConfirmDelete
+                    action={removeContent.bind(null, spec.key)}
+                    id={id}
+                    warning={`Delete “${title}”? This cannot be undone.`}
+                  />
+                </div>
               </li>
             );
           })}
         </ul>
       )}
-    </Container>
+    </div>
   );
 }

--- a/apps/web/app/(console)/admin/layout.tsx
+++ b/apps/web/app/(console)/admin/layout.tsx
@@ -3,92 +3,103 @@ import Link from "next/link";
 import { signOut } from "@/app/actions/auth";
 import { ConsoleNav } from "@/components/console/console-nav";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Container } from "@/components/ui/container";
 import { requireAdmin } from "@/lib/admin-guard";
 import { accessTokenExpiry } from "@/lib/session";
 
 /**
- * The admin shell: one status strip, then the page.
+ * The admin shell: a sidebar on the left, content on the right.
  *
- * A left sidebar is the reflex for an admin area and would be the wrong
- * furniture here — it is the one shape that says "generic dashboard", and this
- * site's established vocabulary is horizontal mono status strips, the same as
- * the hero's health line and the career timeline's meta rows.
+ * This replaces two stacked horizontal strips — a status bar and a nav bar —
+ * which is what was here before. That arrangement was argued for in a comment
+ * that said a sidebar was "the reflex" and the wrong furniture. Built and
+ * looked at, it was worse: two full-width bands of chrome above every screen,
+ * content centred in a narrow column with the page's graph paper showing down
+ * both sides, and no room for identity and navigation to be different things.
+ * The reflex was right. A tool with six sections wants a column it can grow
+ * into, and the width belongs to the content.
  *
- * This layout is also the gate. `requireAdmin` runs before any page under
- * /admin renders and redirects a signed-out or expired caller, so pages below
- * can assume a session. It is not what protects the data — every read carries
- * the token to the API and `require_admin` there decides — it is what turns an
- * expired session into a sign-in screen rather than a page of error states.
+ * The gate lives here too. `requireAdmin` runs before any page under /admin
+ * renders. It is not what protects the data — every read carries the token to
+ * the API, and `require_admin` there decides — it is what turns an expired
+ * session into a sign-in screen rather than a page of error states.
  */
 export default async function AdminLayout({ children }: LayoutProps<"/admin">) {
   const { user, accessToken } = await requireAdmin("/admin");
   const expiresAt = accessTokenExpiry(accessToken);
 
   return (
-    <>
-      <header className="border-b border-border bg-card/60">
-        <Container
-          width="layout"
-          className="flex flex-wrap items-center gap-x-6 gap-y-3 py-4 font-mono text-xs"
-        >
+    <div className="flex flex-1 flex-col lg:flex-row">
+      {/*
+        Sticky and full-height above `lg`, so the sections stay reachable
+        however long a list runs. Below it the column becomes a band at the top
+        of the page — a drawer would need a client component and a state hook
+        for six links that fit on one scrollable line.
+      */}
+      <aside className="c-sidebar shrink-0 border-b border-border bg-card lg:sticky lg:top-0 lg:h-dvh lg:w-60 lg:border-b-0 lg:border-r">
+        <div className="flex h-full flex-wrap items-center gap-x-4 gap-y-3 px-4 py-3 lg:flex-col lg:flex-nowrap lg:items-stretch lg:gap-0 lg:px-3 lg:py-5">
           <Link
             href="/admin"
-            // min-h-11: as bare inline text this was a 66×16 target, which is
-            // under the 44px floor every other control on the site meets. It
-            // became worth fixing once there was a nav under it to go back from.
-            className="inline-flex min-h-11 items-center uppercase tracking-[0.18em] text-foreground hover:text-primary"
+            className="order-1 inline-flex min-h-11 items-center gap-2 px-1 font-display text-sm font-semibold tracking-tight text-foreground lg:mb-6"
           >
+            {/* The mark: the accent as a shape rather than as more text. */}
+            <span
+              aria-hidden="true"
+              className="h-2 w-2 rotate-45 rounded-[2px] bg-primary"
+            />
             Console
           </Link>
 
-          <span className="text-muted-foreground">{user.email}</span>
+          <div className="order-3 w-full lg:order-2 lg:w-auto lg:flex-1">
+            <ConsoleNav />
+          </div>
 
-          <Badge variant="outline">admin</Badge>
-
-          {expiresAt && (
-            /*
-              A fixed timestamp, not a ticking countdown. A counter would need a
-              client component and an interval for something this sentence says
-              just as well — and the number it would count towards is only
-              approximate anyway, since any page load may renew the session.
-            */
-            <span className="text-muted-foreground">
-              session until{" "}
-              <time dateTime={expiresAt.toISOString()}>
-                {expiresAt.toLocaleTimeString("en-GB", {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </time>
-            </span>
-          )}
+          {/*
+            Identity at the foot of the column, where an app puts it. Hidden on
+            the narrow layout: it is reference, not navigation, and it would
+            cost three rows of a phone screen before any content.
+          */}
+          <div className="order-4 hidden w-full border-t border-border/70 pt-4 lg:block">
+            <p className="truncate px-1 text-xs text-muted-foreground" title={user.email}>
+              {user.email}
+            </p>
+            {expiresAt && (
+              /*
+                A fixed time, not a countdown. A ticking clock needs a client
+                component and an interval to say what this sentence says, and
+                the number is approximate anyway — any page load may renew it.
+              */
+              <p className="mt-1 px-1 font-mono text-[0.6875rem] text-muted-foreground/80">
+                session until{" "}
+                <time dateTime={expiresAt.toISOString()}>
+                  {expiresAt.toLocaleTimeString("en-GB", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </time>
+              </p>
+            )}
+          </div>
 
           {/*
             A real form posting a Server Action, so signing out works without
             JavaScript and is a POST rather than a link — a GET that destroys a
-            session gets fired by every prefetcher and link scanner that meets
-            it.
+            session gets fired by every prefetcher that meets it.
           */}
-          <form action={signOut} className="ms-auto">
-            {/* min-h-11 keeps the 44px tap target the base Button gets from
-                py-3; the compact padding here would otherwise leave it at 33px. */}
-            <Button variant="quiet" type="submit" className="min-h-11 px-4 py-2 text-xs">
+          <form action={signOut} className="order-2 ms-auto lg:order-5 lg:ms-0 lg:mt-3 lg:w-full">
+            <Button
+              variant="quiet"
+              type="submit"
+              className="min-h-11 w-full px-4 py-2 text-xs"
+            >
               Sign out
             </Button>
           </form>
-        </Container>
-      </header>
+        </div>
+      </aside>
 
-      {/*
-        The way between sections, under the status strip rather than beside it:
-        one row says who you are, the next says where you can go, and neither
-        has to compete with the other for width.
-      */}
-      <ConsoleNav />
-
-      {children}
-    </>
+      <main id="main" className="min-w-0 flex-1">
+        {children}
+      </main>
+    </div>
   );
 }

--- a/apps/web/app/(console)/layout.tsx
+++ b/apps/web/app/(console)/layout.tsx
@@ -19,13 +19,22 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+/**
+ * `console-theme` is applied here so both screens behind the door share it — a
+ * light sign-in leading to a dark console is a seam in the one place a person
+ * sees both in the same second.
+ *
+ * There is no `<main>` here any more. It used to wrap `children`, which was
+ * fine while the console was a single column; the admin area now has a sidebar,
+ * and a nav rendered inside `<main>` is both the wrong landmark and a broken
+ * skip link — "skip to content" would land *before* the navigation and skip
+ * nothing. Each area owns its own `<main>` and puts it where content starts.
+ */
 export default function ConsoleLayout({ children }: LayoutProps<"/">) {
   return (
-    <>
+    <div className="console-theme flex flex-1 flex-col">
       <SkipLink />
-      <main id="main" className="flex flex-1 flex-col">
-        {children}
-      </main>
-    </>
+      {children}
+    </div>
   );
 }

--- a/apps/web/app/(console)/login/page.tsx
+++ b/apps/web/app/(console)/login/page.tsx
@@ -47,7 +47,9 @@ export default async function LoginPage({ searchParams }: PageProps<"/login">) {
   const next = safeNextPath(typeof raw === "string" ? raw : null);
 
   return (
-    <section className="hero-atmosphere flex flex-1 items-center py-16 sm:py-24">
+    // The console group no longer supplies a <main>; each screen places its
+    // own, so the skip link lands on content rather than on chrome.
+    <main id="main" className="hero-atmosphere flex flex-1 items-center py-16 sm:py-24">
       <Container width="layout">
         {/*
           Left-aligned on the same rail the hero uses, and capped at a readable
@@ -78,6 +80,6 @@ export default async function LoginPage({ searchParams }: PageProps<"/login">) {
           </p>
         </div>
       </Container>
-    </section>
+    </main>
   );
 }

--- a/apps/web/app/(site)/page.tsx
+++ b/apps/web/app/(site)/page.tsx
@@ -79,7 +79,7 @@ export default async function HomePage() {
             layout container. In the two-column range a dangling odd card spans
             the row — half-filled last rows read as missing data, not layout.
           */
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 sm:max-lg:[&>*:nth-child(odd):last-child]:col-span-2">
+          <div className="reveal-row grid gap-6 sm:grid-cols-2 lg:grid-cols-3 sm:max-lg:[&>*:nth-child(odd):last-child]:col-span-2">
             {projects.map((project) => (
               <ProjectCard key={project.id} project={project} />
             ))}
@@ -97,7 +97,7 @@ export default async function HomePage() {
         {skills.length === 0 ? (
           <EmptyState>No skills published yet.</EmptyState>
         ) : (
-          <div className="grid gap-x-12 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="reveal-row grid gap-x-12 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
             {groupByCategory(skills).map(([category, entries]) => (
               <div key={category}>
                 <Eyebrow>{category}</Eyebrow>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -568,3 +568,211 @@
     }
   }
 }
+
+/* ==========================================================================
+ * The console.
+ *
+ * A different product from the site in front of it, and deliberately so. The
+ * public pages are a portfolio: graph paper, a green tint, generous measure,
+ * hairlines. Wearing that costume, the admin area read as a page of the
+ * portfolio rather than a tool — sparse, centred, unfinished. Nobody but the
+ * owner ever sees these screens and they are already `noindex`, so there is
+ * nothing to be gained by making them match.
+ *
+ * ## How this works, and why it is short
+ *
+ * The console does not fork Button, Card, Notice or Field. It remaps the
+ * variables those primitives already read, inside `.console-theme` only. A
+ * `bg-card` inside the console resolves to a dark panel; a
+ * `rounded-[var(--radius-card)]` picks up the larger radius below. So the whole
+ * component set changes surface without a single component knowing about it,
+ * and the two themes cannot drift apart because there is only one set of
+ * components.
+ *
+ * Always dark, and not wired to the site's theme toggle. The toggle lives in
+ * the public header, which the console does not render; a console that followed
+ * a preference set somewhere it cannot be changed from would just be a console
+ * that is sometimes wrong.
+ * ========================================================================== */
+
+.console-theme {
+  /* Slightly blue-black rather than neutral: a pure grey app surface reads as
+     unfinished next to any saturated accent, and the cast gives the violet
+     something to sit on. */
+  --console-bg: 225 18% 7%;
+  --console-panel: 225 15% 10%;
+  --console-raised: 225 14% 14%;
+  --console-line: 225 12% 19%;
+  --console-accent: 255 88% 72%;
+  --console-text: 225 22% 96%;
+  --console-muted: 225 12% 68%;
+
+  /*
+   * Both halves are needed, and the reason is the whole trick.
+   *
+   * The bare `--card`/`--foreground` channels are what this file's own
+   * `hsl(var(--x) / alpha)` rules read. The `--color-*` names are what Tailwind
+   * utilities read. Setting only the first looked correct in the source and did
+   * nothing on screen: `@theme` declares `--color-card: hsl(var(--card))` *on
+   * :root*, so the substitution happens there, and overriding `--card` further
+   * down the tree never recomputes it. The site's own dark mode gets away with
+   * the short version only because `.dark` sits on <html> — the same element as
+   * :root. A nested scope has to name the variables the utilities actually use.
+   */
+  --background: var(--console-bg);
+  --foreground: var(--console-text);
+  --card: var(--console-panel);
+  --border: var(--console-line);
+  --muted: var(--console-raised);
+  --muted-foreground: var(--console-muted);
+  --accent: var(--console-raised);
+  --accent-foreground: var(--console-text);
+  --primary: var(--console-accent);
+  /* Dark on the accent: the violet is mid-lightness, so near-white on it is
+     light-on-light — the same trap the site's dark palette documents. */
+  --primary-foreground: 225 18% 9%;
+  --ring: var(--console-accent);
+  --destructive: 0 72% 58%;
+  --destructive-text: 0 90% 78%;
+
+  --color-background: hsl(var(--console-bg));
+  --color-foreground: hsl(var(--console-text));
+  --color-card: hsl(var(--console-panel));
+  --color-border: hsl(var(--console-line));
+  --color-muted: hsl(var(--console-raised));
+  --color-muted-foreground: hsl(var(--console-muted));
+  --color-accent: hsl(var(--console-raised));
+  --color-accent-foreground: hsl(var(--console-text));
+  --color-primary: hsl(var(--console-accent));
+  --color-primary-foreground: hsl(225 18% 9%);
+  --color-ring: hsl(var(--console-accent));
+  --color-destructive: hsl(0 72% 58%);
+  --color-destructive-text: hsl(0 90% 78%);
+
+  /* Rounder than the site. The larger radius is most of what separates a 2026
+     app surface from a 2016 one, and these are read at the point of use, so
+     overriding them here does work. */
+  --radius-card: 0.875rem;
+  --radius-control: 0.625rem;
+
+  color-scheme: dark;
+  background-color: hsl(var(--console-bg));
+  /* The body paints graph paper. This is the layer that stops it. */
+  background-image: none;
+  color: hsl(var(--console-text));
+}
+
+@layer components {
+  /*
+   * A panel. Border plus a one-pixel inner highlight along the top edge — the
+   * cheapest way to make a flat dark rectangle read as a raised surface rather
+   * than a hole, and what almost every dark app interface is doing when it
+   * looks "lit".
+   */
+  .console-theme .c-panel {
+    background-color: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius-card);
+    box-shadow:
+      inset 0 1px 0 hsl(0 0% 100% / 0.04),
+      0 1px 2px hsl(0 0% 0% / 0.4);
+  }
+
+  .console-theme .c-row {
+    transition:
+      border-color 160ms,
+      background-color 160ms,
+      transform 160ms;
+  }
+
+  .console-theme .c-row:hover,
+  .console-theme .c-row:focus-within {
+    border-color: hsl(var(--primary) / 0.45);
+    background-color: hsl(var(--muted) / 0.6);
+  }
+
+  /*
+   * The current section. A filled pill rather than an underline, because a
+   * vertical list has no baseline to underline against — and the accent stays
+   * out of the *text*: violet on a violet tint measures badly, so the fill
+   * carries the colour and the label stays plain.
+   */
+  .console-theme .c-nav-item {
+    border-radius: var(--radius-control);
+    transition:
+      background-color 140ms,
+      color 140ms;
+  }
+
+  .console-theme .c-nav-item[aria-current] {
+    background-color: hsl(var(--primary) / 0.16);
+    color: hsl(var(--foreground));
+  }
+
+  .console-theme .c-nav-item:not([aria-current]):hover {
+    background-color: hsl(var(--muted) / 0.7);
+    color: hsl(var(--foreground));
+  }
+
+  /*
+   * A state dot with a halo. Two pixels of colour say "live" faster than a word
+   * does, and the halo is what stops it reading as dust on the screen.
+   */
+  .console-theme .c-dot {
+    width: 0.4375rem;
+    height: 0.4375rem;
+    border-radius: 9999px;
+    flex: none;
+  }
+
+  .console-theme .c-dot-live {
+    background-color: hsl(152 65% 55%);
+    box-shadow: 0 0 0 3px hsl(152 65% 55% / 0.16);
+  }
+
+  .console-theme .c-dot-draft {
+    background-color: hsl(38 95% 62%);
+    box-shadow: 0 0 0 3px hsl(38 95% 62% / 0.16);
+  }
+
+  /*
+   * A wash of accent behind the top of the sidebar. One soft light source, so
+   * the shell has a direction rather than being uniformly flat — the single
+   * decorative move in here, and the reason the column does not look like a
+   * grey box.
+   */
+  .console-theme .c-sidebar {
+    background-image: radial-gradient(
+      22rem 18rem at 0% 0%,
+      hsl(var(--primary) / 0.1),
+      transparent 70%
+    );
+  }
+}
+
+/*
+ * Motion in the console.
+ *
+ * Rows arrive rather than appear, and the stagger is small and finite — 40ms
+ * apart, capped so a list of forty does not take two seconds to finish landing.
+ * The whole thing is one keyframe and a delay; there is no library, no canvas
+ * and nothing on the main thread after the first frame, because a tool is a
+ * place where you are trying to get something done and motion that costs
+ * responsiveness is motion that is in the way.
+ *
+ * Behind `no-preference`, and `both` so the resting state is what a reduced
+ * motion visitor gets immediately rather than a row stuck invisible.
+ */
+@keyframes console-enter {
+  from {
+    opacity: 0;
+    translate: 0 8px;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .console-theme .c-enter {
+    animation: console-enter 300ms var(--ease-enter) both;
+    animation-delay: calc(var(--i, 0) * 40ms);
+  }
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -776,3 +776,104 @@
     animation-delay: calc(var(--i, 0) * 40ms);
   }
 }
+
+/* ==========================================================================
+ * Scroll as the narrator.
+ *
+ * The page introduces itself in order: a section's rule draws in, its label
+ * and heading arrive, then its contents follow row by row as they reach the
+ * viewport. Read top to bottom it plays as a sequence rather than as one flat
+ * document that was always there.
+ *
+ * Every element is driven by its own `view()` timeline, which is why there is
+ * no orchestration code and no library. An element animates on where *it* is
+ * relative to the viewport, so a grid staggers itself as it scrolls in, the
+ * sequence survives someone landing halfway down the page from a link, and
+ * scrubbing backwards plays it backwards. A JavaScript version of this is an
+ * IntersectionObserver, a class toggle and a list of timeouts that all have to
+ * agree; this is a keyframe and a range.
+ *
+ * The two guards are the ones the skill gauges already use, for the reasons
+ * recorded there. `@supports` because a browser without scroll-driven
+ * animations must get the finished state rather than a permanently hidden one —
+ * the base rules below leave everything visible, so the animation only ever
+ * takes things away and puts them back. And `prefers-reduced-motion` because
+ * the block at the top of this file forces `animation-duration` to 0.01ms on
+ * everything, which a scroll-driven animation reads as "already finished".
+ * ========================================================================== */
+
+@keyframes reveal-in {
+  from {
+    opacity: 0;
+    translate: 0 14px;
+  }
+}
+
+@keyframes rule-draw {
+  from {
+    scale: 0 1;
+  }
+}
+
+@layer base {
+  /*
+   * The hairline at the top of a section, as an element rather than a border,
+   * so it can be drawn. Full width by default: if nothing below animates it,
+   * it is exactly the border it replaced.
+   */
+  .section-rule {
+    position: relative;
+  }
+
+  .section-rule::before {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    top: 0;
+    height: 1px;
+    background-color: hsl(var(--border) / 0.6);
+    transform-origin: left;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    @supports (animation-timeline: view()) {
+      .section-rule::before {
+        animation: rule-draw linear both;
+        animation-timeline: view();
+        /* Finished well before the heading lands, so the rule reads as the
+           thing that introduces the section rather than as a late arrival. */
+        animation-range: entry 0% entry 70%;
+      }
+
+      .reveal {
+        animation: reveal-in linear both;
+        animation-timeline: view();
+        animation-range: entry 5% cover 26%;
+      }
+
+      /*
+       * The row animates its children rather than itself: a parent fading
+       * while its children fade multiplies the opacity and drags the block
+       * along with the child's translate. This also means a grid needs one
+       * class, not one per card.
+       *
+       * Members of a row share a scroll position, so they would otherwise
+       * arrive together. Nudging the range per column walks them in from the
+       * left — the same reading direction as the text above them.
+       */
+      .reveal-row > * {
+        animation: reveal-in linear both;
+        animation-timeline: view();
+        animation-range: entry 5% cover 26%;
+      }
+
+      .reveal-row > *:nth-child(2n) {
+        animation-range: entry 9% cover 30%;
+      }
+
+      .reveal-row > *:nth-child(3n) {
+        animation-range: entry 13% cover 34%;
+      }
+    }
+  }
+}

--- a/apps/web/components/console/console-nav.tsx
+++ b/apps/web/components/console/console-nav.tsx
@@ -5,7 +5,7 @@
  *
  * Same as the public nav — there is no server equivalent, a layout is not
  * re-rendered per segment with the path in hand, and nothing in CSS knows which
- * page it is on. Without it this is a row of links that never says where you
+ * page it is on. Without it this is a list of links that never says where you
  * are, which is the one thing a nav is for. No state, no effects.
  */
 
@@ -28,18 +28,15 @@ export function ConsoleNav() {
   const pathname = usePathname();
 
   return (
-    // A horizontal strip, not a sidebar. A left rail is the reflex for an admin
-    // area and is the one shape that says "generic dashboard"; this site's
-    // vocabulary is mono status rows, and the layout above is already one.
-    // overflow-x-auto rather than wrapping: at 375px six sections wrap to three
-    // ragged lines, and a scrolling row keeps the strip one row tall everywhere.
+    // A scrolling row on a phone, a column on a desktop. Wrapping instead would
+    // put six items on three ragged lines and push the page down with them.
     <nav
       aria-label="Console sections"
-      className="flex gap-1 overflow-x-auto border-b border-border bg-card/30"
+      className="-mx-1 flex gap-1 overflow-x-auto px-1 lg:mx-0 lg:flex-col lg:gap-0.5 lg:overflow-visible lg:px-0"
     >
       {SECTIONS.map((section) => {
-        // Exact for the inbox, which is /admin and a prefix of everything else;
-        // prefix for the rest, so an edit form keeps its section marked.
+        // Exact for the inbox, which is /admin and a prefix of every other
+        // section; prefix for the rest, so an edit form keeps its section lit.
         const current =
           section.href === "/admin"
             ? pathname === "/admin"
@@ -49,12 +46,13 @@ export function ConsoleNav() {
           <Link
             key={section.href}
             href={section.href}
+            // Announced, not only coloured — this is the only piece of state in
+            // the sidebar, and the stylesheet keys the pill off this attribute
+            // so the two cannot disagree.
             aria-current={current ? "page" : undefined}
             className={cn(
-              "relative inline-flex min-h-11 shrink-0 items-center px-4 font-mono text-xs uppercase tracking-[0.18em] transition-colors",
-              current
-                ? "text-primary after:absolute after:inset-x-3 after:bottom-0 after:h-px after:bg-primary"
-                : "text-muted-foreground hover:text-primary",
+              "c-nav-item inline-flex min-h-11 shrink-0 items-center px-3 text-sm lg:w-full",
+              current ? "font-medium" : "text-muted-foreground",
             )}
           >
             {section.label}

--- a/apps/web/components/section.tsx
+++ b/apps/web/components/section.tsx
@@ -47,17 +47,20 @@ export function Section({
     <section
       id={id}
       className={cn(
-        "border-t border-border/60 py-16 sm:py-20 lg:py-24",
+        // section-rule replaces the top border with a line that can be drawn
+        // as the section arrives; see globals.css. Without scroll-driven
+        // animation support it renders as exactly the border it replaced.
+        "section-rule py-16 sm:py-20 lg:py-24",
         tinted && "bg-muted",
       )}
     >
       <Container width={width}>
-        {eyebrow ? <Eyebrow className="mb-3">{eyebrow}</Eyebrow> : null}
-        <Heading className="font-display text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+        {eyebrow ? <Eyebrow className="reveal mb-3">{eyebrow}</Eyebrow> : null}
+        <Heading className="reveal font-display text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
           {title}
         </Heading>
         {description ? (
-          <p className="mt-3 max-w-2xl text-muted-foreground">{description}</p>
+          <p className="reveal mt-3 max-w-2xl text-muted-foreground">{description}</p>
         ) : null}
         <div className="mt-10">{children}</div>
       </Container>


### PR DESCRIPTION
Two commits, in response to "xấu quá" and to wanting motion.

## 1. The console is a different product now

The admin area wore the public site's costume — graph paper, green tint, centred column, hairlines — and read as a page of the portfolio rather than a tool: two stacked bands of chrome above every screen, content in a narrow column with paper showing down both sides, and five rows carrying fifteen equal-weight buttons.

Now: a left sidebar, a dark app surface, violet accent, panels with a one-pixel inner highlight, and a status dot per row. Rows lost their Edit button — the title is stretched over the whole row instead, which is both the convention and a target larger than 21px.

The comment that used to sit in `admin/layout.tsx` argued a sidebar was "the reflex" and the wrong furniture. Built and looked at, the alternative was worse. That comment is now the record of having tried it.

**The theme is a scoped remap, not a fork.** `.console-theme` redefines the variables the existing primitives already read, so `Button`, `Card`, `Notice` and `Field` render dark without any component knowing about it — one component set, so the two surfaces cannot drift.

That took two attempts, and the first was exactly the trap CLAUDE.md rule 5 describes. Overriding `--card` and `--foreground` on a nested element did nothing: `@theme` declares `--color-card: hsl(var(--card))` **on `:root`**, so the substitution happens there and never recomputes further down the tree. The site's own dark mode only works because `.dark` sits on `<html>` — the same element as `:root`. The fix is to redefine the `--color-*` names the utilities actually reference. The class names read correctly the whole time; the sidebar rendered white with invisible text.

## 2. The home page introduces itself

Everything below the fold used to be finished before you arrived, so scrolling was retrieval rather than sequence. Each section now arrives in order: the rule draws in, the label and heading follow, then the contents walk in row by row.

This is `animation-timeline: view()` — no library, no WebGL, no JavaScript at all. Each element animates on where *it* sits relative to the viewport, which buys three things a scripted version has to be written to do: a grid staggers itself with no per-card index, someone landing halfway down from a link sees the correct state instead of a blank page, and scrubbing back up plays it backwards.

I chose this over three.js deliberately. A WebGL hero is ~150KB gzipped, needs `"use client"`, and runs in front of LCP — and the hero is the one thing a recruiter judges in five seconds, where slow costs more than the effect gains. The same technique is already proven in this codebase twice (the skill gauges, the blog's reading-progress bar).

Fail-closed by construction, not by a fallback: no base rule sets `opacity: 0`, only the keyframe does. A browser without scroll-driven animations, or a visitor who asked for reduced motion, gets the finished page immediately.

## Verification

- console at 1440px: contrast measured from rendered pixels via canvas — title 17.3:1, row title 16.2:1, status chip 7.6:1, current nav item 13.1:1, no failures; every control ≥44px after the two the first pass caught
- scroll reveal: a card below the fold reads opacity 0 / translate 14px and resolves to 1 / 0 in view; the three grid columns hold three different ranges; a section rule below the fold reports `scale: "0 1"` against a live `ViewTimeline`
- `pnpm lint`, 106 unit tests, 58 e2e

## Note on the 3D ask

Not done, and I'd argue against it in `/admin` specifically: those screens are behind a login and `noindex`, so nobody but the owner ever sees them, and 3D in a tool is charming once and in the way thereafter. If real WebGL is still wanted, the hero is the place and it should be its own PR — lazy-loaded behind the first paint, with a static fallback, and with LCP measured before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)