### PR TITLE
The home page, made worth looking at

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ blob-report/
 .env
 .env.*
 !.env.example
+.env*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,39 @@ same seriousness as the auth hardening in `apps/api`, not as a wrapper around
    answer. Reading the skill is not the same as escaping the thing it warns
    about; check the finished screen against the list, not just the plan.
 
-2. **Review with the `frontend-reviewer` subagent once per batch, not once per
+2. **Run the Impeccable detector before every commit, and again before opening
+   a PR.** Not once per batch — every time. It is deterministic, runs no model,
+   and costs seconds:
+
+   ```
+   npx impeccable detect --json apps/web/app apps/web/components
+   ```
+
+   `[]` is clean. Treat anything else the way you treat a failing test — fix
+   it, or write down why it is wrong; do not commit past it.
+
+   This tier exists because the expensive tiers kept missing cheap things.
+   `rounded-[--radius-x]` emitted invalid CSS and survived type-check, lint,
+   build *and* a human review for weeks.
+
+   Its published rule list is worth reading on its own. Three entries on it —
+   "AI beige" palettes, pulsing-dot indicators, and status-chip soup — each
+   described something this site was doing and had argued for in a comment.
+   Those were matched by hand against the list, not caught by a run; they were
+   already fixed by the time the detector was first pointed at this repo.
+
+   **A silent pass is not a pass.** In text mode this tool prints nothing at
+   all when it is clean, which is indistinguishable from not having run. Use
+   `--json` — clean is `[]` — and if a run ever reports nothing on a change you
+   expected it to have an opinion about, prove the tool is alive before
+   believing it: point it at a file with a deliberate `bg-clip-text` gradient
+   and check that it complains.
+
+   Do not treat a clean run as permission to skip looking at the page. It
+   checks for known tells; it has no opinion about whether the design is any
+   good.
+
+3. **Review with the `frontend-reviewer` subagent once per batch, not once per
    change — and ask before starting it.** A pass costs roughly 100k tokens and
    twenty minutes, which is out of proportion to a restyled footer. Propose it,
    say what it would cover, and wait; if the answer is no, carry on and offer
@@ -38,7 +70,7 @@ same seriousness as the auth hardening in `apps/api`, not as a wrapper around
    `rounded-[--radius-x]` emits invalid CSS, which meant every corner on the
    site had silently been square. Batch it; do not abandon it.
 
-3. **Look at what you built.** Screenshot it. A change that has only been
+4. **Look at what you built.** Screenshot it. A change that has only been
    type-checked has not been verified — `pnpm type-check` passing tells you
    nothing about whether the page is usable.
 
@@ -51,22 +83,21 @@ same seriousness as the auth hardening in `apps/api`, not as a wrapper around
    ```
 
    And check tokens with `getComputedStyle`, never by reading the class name —
-   see rule 5.
+   see rule 6.
 
-   The three checks belong to three different layers, and none replaces
-   another: `frontend-design` picks the *direction* before any code exists,
-   this rule catches what a screen actually looks like, and `frontend-reviewer`
-   (rule 2) sweeps a whole batch. A deterministic detector such as
-   `npx impeccable detect` fits between the last two — it is the layer that
-   would have caught `rounded-[--radius-x]` in CI for no tokens at all, which
-   type-check, lint, build and a human review all missed for weeks.
+   Rules 1 to 4 are four different layers and none replaces another:
+   `frontend-design` (1) picks the *direction* before any code exists, the
+   detector (2) catches known tells on every commit, `frontend-reviewer` (3)
+   sweeps a whole batch, and this rule is the one that asks whether the screen
+   is actually any good — which is the only question none of the others can
+   answer.
 
-4. **Server components by default.** `"use client"` needs a reason that is
+5. **Server components by default.** `"use client"` needs a reason that is
    stated in a comment: an event handler, browser API, or hook that genuinely
    cannot run on the server. Reaching for it to call `useState` for something
    CSS can do is the most common mistake here.
 
-5. **Tokens, not literals.** Colours, radii and spacing come from
+6. **Tokens, not literals.** Colours, radii and spacing come from
    `app/globals.css`. A raw hex or a one-off `rounded-[13px]` in a component is
    a bug — it is how a component set stops looking like one system.
 
@@ -79,16 +110,16 @@ same seriousness as the auth hardening in `apps/api`, not as a wrapper around
    loudly: check the emitted stylesheet or `getComputedStyle`, not the class
    name.
 
-6. **Primitives, not copy-paste.** If the same class string appears twice, it
+7. **Primitives, not copy-paste.** If the same class string appears twice, it
    belongs in `components/ui/`. Check what is already there before writing a new
    one.
 
-7. **The quality floor is not optional and is not announced.** Responsive to
+8. **The quality floor is not optional and is not announced.** Responsive to
    375px, visible keyboard focus, `prefers-reduced-motion` respected, real
    `<button>`/`<a>` for interactive things, one `<h1>` per page. These are not
    features to mention in a PR; they are the cost of entry.
 
-8. **The API can be down.** Every read in `lib/api.ts` returns a fallback, and
+9. **The API can be down.** Every read in `lib/api.ts` returns a fallback, and
    pages render an empty state rather than a 500. Keep it that way — this
    replaced a static site that could not break.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,13 @@ same seriousness as the auth hardening in `apps/api`, not as a wrapper around
 1. **Use the `frontend-design` skill before designing.** Not after. It exists to
    stop the work converging on the same three AI-default looks.
 
+   It is worth knowing that this site walked straight into one of them anyway.
+   The amber redesign was "near-black ground plus one bright accent" — that
+   skill's own AI-default #2 — and the light mode was a warm cream, its #1. Both
+   were argued for at length in `globals.css` and both were still the default
+   answer. Reading the skill is not the same as escaping the thing it warns
+   about; check the finished screen against the list, not just the plan.
+
 2. **Review with the `frontend-reviewer` subagent once per batch, not once per
    change — and ask before starting it.** A pass costs roughly 100k tokens and
    twenty minutes, which is out of proportion to a restyled footer. Propose it,
@@ -34,6 +41,25 @@ same seriousness as the auth hardening in `apps/api`, not as a wrapper around
 3. **Look at what you built.** Screenshot it. A change that has only been
    type-checked has not been verified — `pnpm type-check` passing tells you
    nothing about whether the page is usable.
+
+   There is no local API on the default port (8000 is taken on this machine).
+   The quickest way to see real content rather than empty states is to point
+   the dev server at the deployed API, which is public and read-only:
+
+   ```
+   API_URL=https://khoi-portfolio-api.fly.dev pnpm exec next dev --port 3100
+   ```
+
+   And check tokens with `getComputedStyle`, never by reading the class name —
+   see rule 5.
+
+   The three checks belong to three different layers, and none replaces
+   another: `frontend-design` picks the *direction* before any code exists,
+   this rule catches what a screen actually looks like, and `frontend-reviewer`
+   (rule 2) sweeps a whole batch. A deterministic detector such as
+   `npx impeccable detect` fits between the last two — it is the layer that
+   would have caught `rounded-[--radius-x]` in CI for no tokens at all, which
+   type-check, lint, build and a human review all missed for weeks.
 
 4. **Server components by default.** `"use client"` needs a reason that is
    stated in a comment: an event handler, browser API, or hook that genuinely

--- a/apps/web/app/(console)/login/page.tsx
+++ b/apps/web/app/(console)/login/page.tsx
@@ -49,7 +49,7 @@ export default async function LoginPage({ searchParams }: PageProps<"/login">) {
   return (
     // The console group no longer supplies a <main>; each screen places its
     // own, so the skip link lands on content rather than on chrome.
-    <main id="main" className="hero-atmosphere flex flex-1 items-center py-16 sm:py-24">
+    <main id="main" className="flex flex-1 items-center py-16 sm:py-24">
       <Container width="layout">
         {/*
           Left-aligned on the same rail the hero uses, and capped at a readable

--- a/apps/web/app/(site)/layout.tsx
+++ b/apps/web/app/(site)/layout.tsx
@@ -19,6 +19,12 @@ import { cn } from "@/lib/cn";
 export default function SiteLayout({ children }: LayoutProps<"/">) {
   return (
     <>
+      {/*
+        The page's light source. Here rather than in the root layout because
+        the console deliberately does not share the site's surface, and a
+        fixed decorative layer in the root would bleed into it.
+      */}
+      <div aria-hidden="true" className="page-light" />
       <SkipLink />
       <SiteNav />
       <main id="main" className="flex-1">

--- a/apps/web/app/(site)/page.tsx
+++ b/apps/web/app/(site)/page.tsx
@@ -50,14 +50,25 @@ export default async function HomePage() {
     <>
       {/*
         The hero owns the first viewport. The name is the logo, set at display
-        scale with its Vietnamese glyphs lit in signal amber — the identity in
-        one line — and the topology sits beside the thesis as supporting
+        scale in one ink, and the topology sits beside the thesis as supporting
         evidence rather than competing with the name for the top row.
+
+        The `hero-name-accent` spans below currently render no differently from
+        the rest of the name — see the note on that class in globals.css. They
+        are left in place because the diacritics are still the right thing to
+        single out; what they need is a treatment that is not colour.
       */}
-      <section className="hero-atmosphere relative flex min-h-[calc(100svh-4.25rem)] items-center py-20 sm:py-24">
+      <section className="relative flex min-h-[calc(100svh-4.25rem)] items-center py-20 sm:py-24">
         <Container width="layout">
           <Eyebrow className="hero-item">Backend · Data · AI</Eyebrow>
-          <h1 className="hero-item mt-5 font-display text-[clamp(3.25rem,9vw,7.5rem)] font-extrabold leading-[1.04] tracking-[-0.03em] text-foreground [animation-delay:80ms]">
+          {/*
+            Leading opens up until the name fits on one line. Vietnamese
+            stacks diacritics both ways — the nặng dot under "ạ" and the
+            breve over "ă" — so at 1.04 a wrapped name has the dot of one
+            line landing in the breve of the next. It only shows below `lg`,
+            where the name wraps, which is exactly where it must not.
+          */}
+          <h1 className="hero-item mt-5 font-display text-[clamp(3.25rem,9vw,7.5rem)] font-extrabold leading-[1.16] tracking-[-0.03em] text-foreground lg:leading-[1.04] [animation-delay:80ms]">
             Ph<span className="hero-name-accent">ạ</span>m{" "}
             <span className="hero-name-accent">Đă</span>ng Kh
             <span className="hero-name-accent">ô</span>i
@@ -77,7 +88,7 @@ export default async function HomePage() {
                 health check rather than a banner.
               */}
               <p className="hero-item mt-8 flex items-center gap-2.5 font-mono text-xs uppercase tracking-[0.18em] text-primary [animation-delay:280ms]">
-                <span aria-hidden="true" className="status-dot h-1.5 w-1.5 rounded-full bg-signal" />
+                <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-signal" />
                 Open to mid-level+ roles
               </p>
 

--- a/apps/web/app/(site)/page.tsx
+++ b/apps/web/app/(site)/page.tsx
@@ -8,7 +8,7 @@ import { StackDiagram } from "@/components/stack-diagram";
 import { buttonClasses } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
 import { Eyebrow } from "@/components/ui/eyebrow";
-import { getPosts, getProjects, getSkills } from "@/lib/api";
+import { getPosts, getSkills, readProjects } from "@/lib/api";
 import { isoDay } from "@/lib/format";
 import type { Skill } from "@/lib/types";
 
@@ -33,11 +33,16 @@ const WRITING_PREVIEW_COUNT = 3;
 
 export default async function HomePage() {
   // All three reads are independent, so let them overlap rather than waterfall.
-  const [projects, skills, posts] = await Promise.all([
-    getProjects(),
+  // The projects read keeps its outcome as well as its data: the hero's
+  // topology lights the API node from it, so an empty list caused by an outage
+  // and one caused by an empty database do not look the same.
+  const [projectsRead, skills, posts] = await Promise.all([
+    readProjects(),
     getSkills(),
     getPosts(),
   ]);
+
+  const projects = projectsRead.data;
 
   // The owner curates `featured` in the console; featured work gets the
   // case-row treatment, the rest a compact index. If nothing is flagged the
@@ -74,7 +79,7 @@ export default async function HomePage() {
             <span className="hero-name-accent">ô</span>i
           </h1>
 
-          <div className="mt-10 grid items-center gap-12 lg:mt-14 lg:grid-cols-2">
+          <div className="mt-8 grid items-center gap-10 lg:mt-10 lg:grid-cols-2 lg:gap-14">
             <div>
               <p className="hero-item max-w-xl text-lg text-muted-foreground sm:text-xl [animation-delay:180ms]">
                 I build the parts you do not see: APIs, schemas, queues and the
@@ -107,7 +112,11 @@ export default async function HomePage() {
               </div>
             </div>
 
-            <HeroTopology className="w-full max-w-xl justify-self-center lg:justify-self-end" />
+            <HeroTopology
+              projectCount={projects.length}
+              apiOk={projectsRead.ok}
+              className="hero-item w-full max-w-xl justify-self-center [animation-delay:440ms] lg:justify-self-end"
+            />
           </div>
         </Container>
       </section>
@@ -122,7 +131,10 @@ export default async function HomePage() {
           <EmptyState>No entries returned — the write-up queue is still draining.</EmptyState>
         ) : (
           <>
-            <div className="flex flex-col gap-20 lg:gap-28">
+            {/* No gap: each row carries its own top spacing, because a record
+                row separates itself with a rule and a spread needs more air
+                than a rule. */}
+            <div className="flex flex-col">
               {(featured.length > 0 ? featured : projects).map((project, i) => (
                 <CaseRow
                   key={project.id}
@@ -161,55 +173,62 @@ export default async function HomePage() {
         )}
       </Section>
 
-      <Section
-        id="writing"
-        width="layout"
-        eyebrow={`/writing · ${posts.length}`}
-        title="Notes from the build"
-      >
-        {recentPosts.length === 0 ? (
-          <EmptyState>Nothing published yet — drafts are still in review.</EmptyState>
-        ) : (
-          <>
-            <ul className="reveal-row divide-y divide-border/60 border-t border-border/60">
-              {recentPosts.map((post) => (
-                <li key={post.id}>
-                  <article className="group relative grid gap-1 py-6 sm:grid-cols-[8.5rem_1fr] sm:gap-6">
-                    <time
-                      dateTime={isoDay(post.published_at) ?? undefined}
-                      className="pt-1 font-mono text-xs uppercase tracking-wider text-muted-foreground"
-                    >
-                      {isoDay(post.published_at)}
-                    </time>
-                    <div>
-                      <h3 className="font-display text-xl font-semibold tracking-tight text-foreground">
-                        <Link
-                          href={`/blog/${post.slug}`}
-                          className="after:absolute after:inset-0 group-hover:text-primary"
-                        >
-                          {post.title}
-                        </Link>
-                      </h3>
-                      {post.excerpt ? (
-                        <p className="mt-1.5 max-w-2xl text-sm text-muted-foreground">
-                          {post.excerpt}
-                        </p>
-                      ) : null}
-                    </div>
-                  </article>
-                </li>
-              ))}
-            </ul>
+      {/*
+        Absent, not empty.
 
-            <Link
-              href="/blog"
-              className="mt-8 inline-flex min-h-11 items-center gap-2 font-mono text-xs uppercase tracking-[0.18em] text-primary transition-colors hover:text-foreground"
-            >
-              All posts <span aria-hidden="true">→</span>
-            </Link>
-          </>
-        )}
-      </Section>
+        This section used to render "Nothing published yet — drafts are still in
+        review." into 545px of otherwise blank page. An empty state earns its
+        space when the reader can act on it or when the emptiness is itself
+        information; here it is neither — it is a section announcing that it has
+        nothing to say, on the one page whose job is to be convincing in five
+        seconds. /blog is still in the nav and still has its own empty state for
+        anyone who goes looking.
+      */}
+      {recentPosts.length > 0 ? (
+        <Section
+          id="writing"
+          width="layout"
+          eyebrow={`/writing · ${posts.length}`}
+          title="Notes from the build"
+        >
+          <ul className="reveal-row divide-y divide-border/60 border-t border-border/60">
+            {recentPosts.map((post) => (
+              <li key={post.id}>
+                <article className="group relative grid gap-1 py-6 sm:grid-cols-[8.5rem_1fr] sm:gap-6">
+                  <time
+                    dateTime={isoDay(post.published_at) ?? undefined}
+                    className="pt-1 font-mono text-xs uppercase tracking-wider text-muted-foreground"
+                  >
+                    {isoDay(post.published_at)}
+                  </time>
+                  <div>
+                    <h3 className="font-display text-xl font-semibold tracking-tight text-foreground">
+                      <Link
+                        href={`/blog/${post.slug}`}
+                        className="after:absolute after:inset-0 group-hover:text-primary"
+                      >
+                        {post.title}
+                      </Link>
+                    </h3>
+                    {post.excerpt ? (
+                      <p className="mt-1.5 max-w-2xl text-sm text-muted-foreground">
+                        {post.excerpt}
+                      </p>
+                    ) : null}
+                  </div>
+                </article>
+              </li>
+            ))}
+          </ul>
+
+          <Link
+            href="/blog"
+            className="mt-8 inline-flex min-h-11 items-center gap-2 font-mono text-xs uppercase tracking-[0.18em] text-primary transition-colors hover:text-foreground"
+          >
+            All posts <span aria-hidden="true">→</span>
+          </Link>
+        </Section>
+      ) : null}
 
       <ContactSection />
     </>

--- a/apps/web/app/(site)/page.tsx
+++ b/apps/web/app/(site)/page.tsx
@@ -119,7 +119,12 @@ export default async function HomePage() {
           <>
             <div className="flex flex-col gap-20 lg:gap-28">
               {(featured.length > 0 ? featured : projects).map((project, i) => (
-                <CaseRow key={project.id} project={project} flip={i % 2 === 1} />
+                <CaseRow
+                  key={project.id}
+                  project={project}
+                  flip={i % 2 === 1}
+                  priority={i === 0}
+                />
               ))}
             </div>
 

--- a/apps/web/app/(site)/page.tsx
+++ b/apps/web/app/(site)/page.tsx
@@ -88,7 +88,12 @@ export default async function HomePage() {
                 health check rather than a banner.
               */}
               <p className="hero-item mt-8 flex items-center gap-2.5 font-mono text-xs uppercase tracking-[0.18em] text-primary [animation-delay:280ms]">
-                <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-signal" />
+                {/* Lit, with a halo: this is a live status, which is exactly
+                    what the hue is reserved for. */}
+                <span
+                  aria-hidden="true"
+                  className="h-1.5 w-1.5 rounded-full bg-live shadow-[0_0_0_3px_hsl(var(--live)/0.18)]"
+                />
                 Open to mid-level+ roles
               </p>
 

--- a/apps/web/app/api/admin/upload/route.ts
+++ b/apps/web/app/api/admin/upload/route.ts
@@ -1,0 +1,96 @@
+import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
+import { NextResponse } from "next/server";
+
+import { getAdminSession } from "@/lib/admin-guard";
+
+/**
+ * Where an admin's image upload gets its permission from.
+ *
+ * ## Why the browser uploads to Blob directly, and not through here
+ *
+ * This route never sees the file. It issues a short-lived token and the
+ * browser sends the bytes straight to Blob storage. The obvious design —
+ * POST the file to a route handler, which forwards it — dies on the first
+ * real screenshot: a serverless request body is capped around 4.5MB, and the
+ * failure arrives as an opaque 413 rather than anything a form can explain.
+ *
+ * So the token *is* the capability, and `onBeforeGenerateToken` is the
+ * security boundary. Everything below runs before a token exists.
+ *
+ * ## Why `getAdminSession` and not `requireAdmin`
+ *
+ * `requireAdmin` answers a failed check with a redirect, which is correct for
+ * a page and wrong here: `fetch` follows redirects, so the caller would get
+ * the sign-in *page* with a 200 on it and fail while parsing HTML as JSON.
+ * `getAdminSession` returns null instead, and null becomes a 401.
+ *
+ * Note that this is the console's own session cookie, not the API's opinion.
+ * That is the one place in this app where Next decides an authorisation
+ * question by itself rather than deferring to `require_admin` on the API —
+ * unavoidable, because Blob is a Vercel resource the API cannot mint tokens
+ * for. The blast radius is bounded by the constraints below: a stolen token
+ * can write an image under a random path in a public bucket, and nothing
+ * else. It cannot read, delete, or reach the API.
+ */
+
+/** Matches `allowedContentTypes`; kept as one list so the two cannot drift. */
+const ALLOWED_CONTENT_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/avif",
+];
+
+/**
+ * Generous for a screenshot, mean for anything else. The limit is enforced on
+ * the token rather than in the browser, because a check the client performs is
+ * a check an attacker skips.
+ */
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = (await request.json()) as HandleUploadBody;
+
+  try {
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async () => {
+        const session = await getAdminSession();
+        if (!session) throw new Error("Not authenticated");
+
+        return {
+          allowedContentTypes: ALLOWED_CONTENT_TYPES,
+          maximumSizeInBytes: MAX_UPLOAD_BYTES,
+          /*
+           * Two jobs. It stops a second upload of `hero.png` from silently
+           * replacing the first, and it means the URLs are not guessable —
+           * the bucket is public, so a predictable path is a listing.
+           */
+          addRandomSuffix: true,
+        };
+      },
+      /*
+       * Deliberately does nothing.
+       *
+       * This fires as a webhook *from* Blob back into the deployment, so it
+       * never runs against localhost. Persisting `image_url` here would build
+       * a feature that works in production and silently no-ops in
+       * development — the worst kind. The browser already receives the URL
+       * from `upload()`, so it puts it in the form field and the existing
+       * save action writes it with the rest of the record.
+       */
+      onUploadCompleted: async () => {},
+    });
+
+    return NextResponse.json(jsonResponse);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Upload failed";
+
+    // 401 for the auth case so the client can say "sign in again" rather than
+    // "something went wrong"; 400 for a rejected file.
+    const status = message === "Not authenticated" ? 401 : 400;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -49,6 +49,21 @@
   --color-signal: hsl(var(--signal));
 
   /*
+   * The one hue on the site, and it is not decoration — it marks what is
+   * *live*. Packets moving along a wire, a node that is up, the availability
+   * status. Static furniture stays ink; if a thing is lit, it is because
+   * something is happening there.
+   *
+   * Green rather than a brand colour picked from nowhere: this page's subject
+   * is services talking to each other, and green-is-healthy is the existing
+   * vocabulary of every dashboard that does that. The console already uses
+   * this exact hue for `c-dot-live`, so the two surfaces agree.
+   *
+   * It never sets a text colour. That rule has not moved.
+   */
+  --color-live: hsl(var(--live));
+
+  /*
    * One radius scale, derived from a single value. Cards, badges and buttons
    * previously each picked their own `rounded-*`, which is the kind of drift
    * that makes a set of components look like it came from three different
@@ -128,11 +143,14 @@
     --destructive-text: 0 72% 38%;
     --ring: 222 20% 30%;
     /*
-     * Marks — spine nodes, the status dot, the packets on the wire. Ink
-     * rather than a signal colour now: see the palette note at the top of
-     * this file for why the amber left.
+     * Marks that are *not* live — spine nodes, section junctions. Ink, so the
+     * lit ones below stand out by being the only thing with a hue.
      */
     --signal: 222 20% 22%;
+    /* Darker on paper than on ink: mid-green on white measures badly. */
+    --live: 158 72% 32%;
+    /* The soft light behind the hero, so the page is not a flat sheet. */
+    --depth: 158 40% 55%;
   }
 
   /*
@@ -158,6 +176,8 @@
     --destructive-text: 0 85% 75%;
     --ring: 222 12% 72%;
     --signal: 222 12% 90%;
+    --live: 152 68% 55%;
+    --depth: 152 60% 50%;
   }
 
   html {
@@ -182,6 +202,37 @@
     line-height: 1.7;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
+  }
+
+  /*
+   * One light source, behind the hero.
+   *
+   * Not the graph paper coming back: that was a repeating pattern across the
+   * whole page, competing with the content. This is a single soft radial that
+   * decays within the first viewport, and its only job is to stop the top of
+   * the page reading as a flat sheet of one colour. A dark interface with no
+   * light in it looks unfinished no matter how good the type is, and that is
+   * most of what "pure black" was complaining about.
+   *
+   * Fixed, not scrolled, so it behaves like a light in the room rather than a
+   * shape on the page — it never becomes an object you scroll past.
+   */
+  .page-light {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        60rem 40rem at 72% -5%,
+        hsl(var(--depth) / 0.1),
+        transparent 65%
+      ),
+      radial-gradient(
+        40rem 30rem at 8% 8%,
+        hsl(var(--depth) / 0.05),
+        transparent 60%
+      );
   }
 
   /*
@@ -227,6 +278,71 @@
   .wire-flow {
     stroke-dasharray: 3 9;
     animation: wire-flow 1.6s linear infinite;
+    /* Lit, because this is the thing on the diagram that is actually moving. */
+    stroke: hsl(var(--live));
+    filter: drop-shadow(0 0 3px hsl(var(--live) / 0.7));
+  }
+
+  /*
+   * The rails draw themselves, left to right, in the order a request would
+   * travel them.
+   *
+   * The graph used to fade in whole, which said "here is a picture of a
+   * system". Drawing it says "here is a system coming up", which is the
+   * hero's actual claim and costs one keyframe. `pathLength="1"` is set on
+   * the paths so the dash maths is 0-to-1 regardless of each curve's real
+   * length — otherwise every edge needs its own hand-measured dasharray.
+   */
+  @keyframes edge-draw {
+    from {
+      stroke-dashoffset: 1;
+    }
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
+
+  .edge-draw {
+    stroke-dasharray: 1;
+    animation: edge-draw 620ms var(--ease-enter) both;
+  }
+
+  /*
+   * A node arrives by scaling up from slightly small, from its own centre.
+   * `transform-box: fill-box` is the part that is easy to miss: without it an
+   * SVG child scales about the *viewport* origin and flies in from the corner.
+   */
+  @keyframes node-pop {
+    from {
+      opacity: 0;
+      scale: 0.86;
+    }
+  }
+
+  .node-pop {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: node-pop 420ms var(--ease-enter) both;
+  }
+
+  /*
+   * The API node keeps a slow breath after it lands — one element on the
+   * diagram that never settles, so the graph reads as running rather than
+   * paused. Deliberately the only infinite animation on the page, and it is
+   * on a decorative, aria-hidden mark rather than beside text.
+   */
+  @keyframes node-live {
+    0%,
+    100% {
+      opacity: 0.55;
+    }
+    50% {
+      opacity: 0.16;
+    }
+  }
+
+  .node-live {
+    animation: node-live 3.2s ease-in-out infinite;
   }
 
   /*

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -284,6 +284,93 @@
   }
 
   /*
+   * One request, running the path.
+   *
+   * The hero used to put a dashed `wire-flow` on every edge at once, which
+   * reads as "there is traffic" — ambient, and true of any system. A single
+   * dot that leaves the browser, disappears behind each service and comes back
+   * with an answer reads as *this* request, which is the hero's actual claim.
+   *
+   * `offset-path` does the moving, so the position is one declaration rather
+   * than hand-keyframed x/y per segment, and the dots are drawn before the
+   * node rectangles in the markup so opaque node fills occlude them — the
+   * packet visibly enters a service and comes out the other side.
+   *
+   * Both dots share one straight path across the row; the opacity keys are
+   * what separate them in time, so the response only starts once the request
+   * has arrived. Baking the pause into the keyframes rather than using
+   * `animation-delay` keeps the two loops locked together forever instead of
+   * drifting apart.
+   */
+  .packet-path .packet {
+    /*
+     * The whole chain as one path: right along the top, down the fold, left
+     * along the bottom. The two corners both fall *inside* a node box, so they
+     * are never seen — which is why they can be square.
+     */
+    offset-path: path("M110,45 L302,45 L302,165 L110,165");
+    /* A circle has no heading to align, and leaving this at `auto` makes the
+       element rotate about a point it does not care about. */
+    offset-rotate: 0deg;
+    /*
+     * Off by default, and only turned on inside the no-preference block below.
+     * A packet is pure motion — with the animation stopped there is no
+     * "resting state" it should hold, just a green dot parked on a wire
+     * claiming something is in flight when nothing is.
+     */
+    opacity: 0;
+  }
+
+  @keyframes packet-out {
+    0% {
+      offset-distance: 0%;
+      opacity: 0;
+    }
+    6%,
+    38% {
+      opacity: 1;
+    }
+    44%,
+    100% {
+      offset-distance: 100%;
+      opacity: 0;
+    }
+  }
+
+  @keyframes packet-back {
+    0%,
+    50% {
+      offset-distance: 100%;
+      opacity: 0;
+    }
+    56%,
+    88% {
+      opacity: 1;
+    }
+    94%,
+    100% {
+      offset-distance: 0%;
+      opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .packet-path .packet-out {
+      animation: packet-out 3.6s linear infinite;
+      /* Held until the last node's entrance has landed — a packet arriving at
+         a database that has not booted yet breaks the boot narrative. */
+      animation-delay: 900ms;
+      filter: drop-shadow(0 0 4px hsl(var(--live) / 0.8));
+    }
+
+    .packet-path .packet-back {
+      animation: packet-back 3.6s linear infinite;
+      animation-delay: 900ms;
+      filter: drop-shadow(0 0 4px hsl(var(--live) / 0.6));
+    }
+  }
+
+  /*
    * The rails draw themselves, left to right, in the order a request would
    * travel them.
    *
@@ -1025,6 +1112,63 @@
 }
 
 /* ==========================================================================
+ * The stack, scanned.
+ *
+ * The capabilities table was the most static block on the page: a card of
+ * chips that did nothing from the moment it rendered. It is also the one
+ * section whose content genuinely is a stack, ordered top to bottom the way a
+ * request descends through one — so the motion it gets is a scan running down
+ * that order, one layer lighting as it reaches the middle of the viewport.
+ *
+ * The reader drives it. Each layer is on its own `view()` timeline, so the
+ * light is a function of where that row is on screen rather than of a timer:
+ * scrolling back up runs the scan back up, and landing halfway down the page
+ * from a link starts it in the right place. There is no orchestration code,
+ * no observer and no library — one keyframe and a range.
+ *
+ * Same two guards as everything else here. `@supports` because a browser
+ * without scroll-driven animation must get the resting state, and the resting
+ * state is a plain ink tick at the left of each layer — which is a reasonable
+ * thing for a layer to have, not a broken version of something. And
+ * `prefers-reduced-motion` because the global block forces
+ * `animation-duration` to 0.01ms, which a scroll-driven animation reads as
+ * "already finished" and would pin every layer lit at once.
+ * ========================================================================== */
+
+@keyframes layer-scan {
+  0%,
+  100% {
+    background-color: hsl(var(--border));
+  }
+  50% {
+    background-color: hsl(var(--live));
+  }
+}
+
+@layer base {
+  .stack-layer::before {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    left: 0;
+    width: 2px;
+    background-color: hsl(var(--border));
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    @supports (animation-timeline: view()) {
+      .stack-layer::before {
+        animation: layer-scan linear both;
+        animation-timeline: view();
+        /* Peaks as the layer crosses the middle of the viewport, so the lit
+           row is always the one the reader is actually looking at. */
+        animation-range: cover 30% cover 70%;
+      }
+    }
+  }
+}
+
+/* ==========================================================================
  * The spine.
  *
  * The site's signature: one vertical data path that the page's sections dock
@@ -1061,15 +1205,37 @@
     background: hsl(var(--border) / 0.9);
   }
 
-  /* The lit path, drawn top-down as the section arrives. */
+  /*
+   * The lit path, drawn top-down as the section arrives — with the bright end
+   * at the *bottom*, which is where the reader is.
+   *
+   * This gradient used to run bright-to-dim downward, so the strongest point
+   * sat at the top of a section the reader had already passed and the leading
+   * edge faded out into nothing. Inverting it puts a lit head exactly at the
+   * scroll position and leaves an ink trail behind it: the same "static is
+   * ink, live is lit" rule the hero's packet follows, with the reader's own
+   * scrolling as the thing that is happening.
+   *
+   * The element is scaled rather than repositioned, so the gradient compresses
+   * with it and the head stays at the leading edge at every scroll position —
+   * no second element and no JavaScript to keep in sync.
+   */
   .spine-rail::after {
     content: "";
     position: absolute;
     inset: 0;
+    /*
+     * The green is held back to the last tenth on purpose. At a 60% stop the
+     * hue covered roughly 500px of a tall section's rail, which in dark mode
+     * put a long saturated line down the left edge of the page — colour
+     * describing everything the reader had already passed rather than the one
+     * place something is happening. Ink to 88%, then the head.
+     */
     background: linear-gradient(
       to bottom,
-      hsl(var(--signal) / 0.9),
-      hsl(var(--signal) / 0.25)
+      hsl(var(--signal) / 0.12),
+      hsl(var(--signal) / 0.45) 88%,
+      hsl(var(--live) / 0.85)
     );
     transform-origin: top;
   }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,10 +1,28 @@
 @import "tailwindcss";
 
 /*
- * "The System, Seen" — dark-first instrument palette. One warm signal-amber
- * accent in both modes (the old scheme was green in light, purple in dark —
- * two identities). Values are bare HSL channels so the `hsl(var(--x))`
- * indirection below still works. See docs/redesign.md for the full plan.
+ * "The System, Seen" — dark-first instrument palette, now monochrome.
+ *
+ * ## Why there is no accent colour
+ *
+ * This file used to carry one warm signal-amber accent in both modes, and
+ * before that a green/purple split. The amber went further than an accent
+ * should: it was the colour of the hero's Vietnamese diacritics, the status
+ * line, the "All posts" link and forty `text-primary` usages — colour sitting
+ * on *text* throughout. Reviewed on the deployed site, that read as ugly, and
+ * "near-black ground plus one bright accent" is also the single most
+ * recognisable AI-default look, which is not what a portfolio should announce.
+ *
+ * So: no accent hue at all. Hierarchy comes from type size, weight and
+ * spacing, and from the surface steps background → card → raised. The only
+ * colour on a page is the colour inside the project screenshots — the work
+ * supplies it, the chrome does not.
+ *
+ * The standing rule that replaced the old one: **colour never touches text.**
+ * `--primary` and `--signal` survive as names because every component already
+ * reads them, but they now resolve to ink and near-white rather than a hue.
+ * Values are bare HSL channels so the `hsl(var(--x))` indirection below still
+ * works. See docs/redesign.md for the original plan.
  */
 
 @theme {
@@ -72,22 +90,34 @@
 
 @layer base {
   /*
-   * Light mode: warm paper, not white — the amber accent needs a warm neutral
-   * to sit on, and a pure white page next to an amber mark reads clinical.
-   * --primary darkens to 30% lightness here because vivid amber as *text* on
-   * paper measures ~2.4:1; the vivid mark colour lives in --signal instead.
+   * Light mode: cool paper.
+   *
+   * These neutrals used to be warm — hue 40, a cream — and the stated reason
+   * was that "the amber accent needs a warm neutral to sit on". There is no
+   * amber any more, so the warmth was left justifying itself, and a warm
+   * off-white with no warm accent on it is just beige. It is also a named
+   * AI-default tell in its own right, which is the opposite of the point.
+   *
+   * So the greys are cool now, sharing the ink's hue (222) at low saturation.
+   * One hue family across both modes, and the paper reads as paper rather
+   * than as a colour choice nobody made on purpose.
    */
   :root {
-    --background: 40 20% 96%;
+    --background: 220 16% 97%;
     --foreground: 222 20% 11%;
     --card: 0 0% 100%;
-    --raised: 40 20% 99%;
-    --primary: 33 85% 30%; /* AA as text on the paper background (~5:1) */
-    --primary-foreground: 40 20% 98%;
-    --border: 40 12% 86%;
-    --muted: 40 15% 92%;
-    --muted-foreground: 222 10% 40%;
-    --accent: 40 15% 91%;
+    --raised: 220 20% 99%;
+    /*
+     * Monochrome. --primary is ink, not a hue: it fills the one loud control
+     * on a screen and marks the current link, and it is legible as text at
+     * ~14% lightness on this paper without being a colour.
+     */
+    --primary: 222 20% 14%;
+    --primary-foreground: 220 16% 98%;
+    --border: 220 13% 87%;
+    --muted: 220 14% 93%;
+    --muted-foreground: 222 10% 38%;
+    --accent: 220 14% 92%;
     --accent-foreground: 222 20% 11%;
     --destructive: 0 84.2% 60.2%;
     /*
@@ -96,17 +126,13 @@
      * palette carries two reds.
      */
     --destructive-text: 0 72% 38%;
-    --ring: 33 85% 30%;
-    /* The constant identity amber — marks only, never text. */
-    --signal: 38 90% 55%;
+    --ring: 222 20% 30%;
     /*
-     * The page grid's line colour, per mode rather than derived from
-     * --border with one shared alpha: the light border sits on a 96%
-     * background and the dark one on 6%, so a single opacity reads loud in
-     * one mode and invisible in the other.
+     * Marks — spine nodes, the status dot, the packets on the wire. Ink
+     * rather than a signal colour now: see the palette note at the top of
+     * this file for why the amber left.
      */
-    --grid-line: hsl(40 12% 86% / 0.5);
-    --hero-glow: hsl(38 90% 55% / 0.12);
+    --signal: 222 20% 22%;
   }
 
   /*
@@ -119,12 +145,8 @@
     --foreground: 222 18% 92%;
     --card: 222 20% 9%;
     --raised: 222 18% 13%;
-    --primary: 38 90% 60%;
-    /*
-     * Dark, not light: the amber is mid-lightness, so near-white on it would
-     * be light-on-light. Ink text on an amber fill reads like a hazard label —
-     * which is the correct register for the one loud control on a screen.
-     */
+    /* Near-white, so the one loud control is a bright plate with ink on it. */
+    --primary: 222 12% 93%;
     --primary-foreground: 222 24% 8%;
     --border: 222 14% 18%;
     --muted: 222 18% 12%;
@@ -134,10 +156,8 @@
     --destructive: 0 62.8% 45%;
     /* Light rather than dark, for the same reason the light mode's is dark. */
     --destructive-text: 0 85% 75%;
-    --ring: 38 90% 60%;
-    --signal: 38 90% 60%;
-    --grid-line: hsl(222 14% 18% / 0.5);
-    --hero-glow: hsl(38 90% 60% / 0.07);
+    --ring: 222 12% 72%;
+    --signal: 222 12% 90%;
   }
 
   html {
@@ -145,39 +165,23 @@
   }
 
   /*
-   * Engineering graph paper, page-wide.
+   * Flat. There used to be page-wide graph paper here — two 1px repeating
+   * gradients at 40px — plus a soft radial "atmosphere" behind the hero.
+   * Both are gone.
    *
-   * The flat background read as unfinished next to everything else on the
-   * page speaking in monitoring vocabulary — a dashboard's charts sit on
-   * gridlines. Two 1px repeating gradients cost nothing to composite, adapt
-   * to each mode through --grid-line, and give the opaque layers on top
-   * (cards, the tinted Skills band, the nav's blur) something to be layers
-   * *on*. Static by definition, so reduced motion is untouched.
+   * The grid was arguing with the spine: two decorative systems both saying
+   * "engineering", on a page that was already carrying nodes, status dots,
+   * mono eyebrows and a topology diagram. With the accent colour also
+   * removed, the remaining job is to let type and surface steps do the work,
+   * and a patterned ground actively fights that. Depth comes from
+   * background → card → raised, which is what those tokens are for.
    */
   body {
     background-color: hsl(var(--background));
-    background-image:
-      linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
-      linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
-    background-size: 40px 40px;
     color: hsl(var(--foreground));
     line-height: 1.7;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
-  }
-
-  /*
-   * A single soft radial in the primary tint, seated behind the topology's
-   * column. It gives the hero a light source — green in light mode, purple
-   * in dark — without introducing a second decorative system; the grid
-   * stays the only texture.
-   */
-  .hero-atmosphere {
-    background-image: radial-gradient(
-      48rem 32rem at 72% 34%,
-      var(--hero-glow),
-      transparent 70%
-    );
   }
 
   /*
@@ -252,26 +256,18 @@
   }
 
   /*
-   * The availability dot, in the vocabulary of a live-status indicator.
-   * 2.8s reads as calm telemetry, not urgency. Keyframe 0 is the fully
-   * visible state, so the single forced iteration under reduced motion
-   * leaves the dot resting visible at full size.
+   * The availability dot.
+   *
+   * This used to pulse forever at 2.8s, defended here as "calm telemetry".
+   * It is not telemetry: nothing about "open to mid-level+ roles" changes
+   * while you look at it, so the animation was borrowing the vocabulary of a
+   * live indicator to say something static. An infinite loop in the first
+   * viewport is also a permanent low-grade distraction that the reader cannot
+   * dismiss, and a pulsing dot is a well-known AI-interface tell.
+   *
+   * It is a dot now — drawn by utilities at the call site, so there is no
+   * rule left to put here. The sentence next to it carries the meaning.
    */
-  @keyframes status-pulse {
-    0%,
-    100% {
-      opacity: 1;
-      scale: 1;
-    }
-    50% {
-      opacity: 0.35;
-      scale: 0.7;
-    }
-  }
-
-  .status-dot {
-    animation: status-pulse 2.8s ease-in-out infinite;
-  }
 
   /*
    * Skill bars fill to their level as they scroll into view — a gauge
@@ -988,15 +984,14 @@
   }
 
   /*
-   * The accented glyphs of the owner's name, lit in signal amber — the name
-   * is the logo. A soft glow in dark mode only; on paper the ink does not
-   * bloom.
+   * The accented glyphs of the owner's name used to be lit in signal amber
+   * with a glow behind them in dark mode. That was the site's signature and
+   * it is the specific thing that was called out as ugly, so the colour is
+   * gone and the name is set in one ink.
+   *
+   * The class is kept rather than deleted because the idea is worth keeping:
+   * Vietnamese diacritics are a real piece of identity that no other
+   * portfolio can borrow. It just needs a mechanism that is not hue — weight,
+   * size or a drawn mark. Until then this deliberately does nothing.
    */
-  .hero-name-accent {
-    color: hsl(var(--signal));
-  }
-
-  .dark .hero-name-accent {
-    text-shadow: 0 0 28px hsl(var(--signal) / 0.45);
-  }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -66,6 +66,16 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
       // The script below adds `dark` before React hydrates, so the class on the
       // client never matches what the server rendered. That is the intent.
       suppressHydrationWarning
+      /*
+       * `scroll-behavior: smooth` in globals.css is there for in-page anchors:
+       * /#projects from the nav, and the skip link. Without this attribute Next
+       * applies it to *route* transitions too, so following a project link from
+       * the bottom of the home page scrolls the new page up from wherever the
+       * old one was standing instead of starting at the top. Declaring it marks
+       * the smoothness as deliberate, and is what the dev-server warning asks
+       * for.
+       */
+      data-scroll-behavior="smooth"
     >
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />

--- a/apps/web/components/case-row.tsx
+++ b/apps/web/components/case-row.tsx
@@ -30,7 +30,16 @@ const CASE_ROW_CHIPS = 5;
  * than a grid of tiles. The grid treats every project as the same size;
  * featured work is not the same size, and this is the layout saying so.
  */
-export function CaseRow({ project, flip }: { project: Project; flip?: boolean }) {
+export function CaseRow({
+  project,
+  flip,
+  priority,
+}: {
+  project: Project;
+  flip?: boolean;
+  /** True for the first row only — see ProjectMedia's `priority`. */
+  priority?: boolean;
+}) {
   const period = formatPeriod(project.started_on, project.ended_on);
 
   return (
@@ -46,6 +55,7 @@ export function CaseRow({ project, flip }: { project: Project; flip?: boolean })
           title={project.title}
           imageUrl={project.image_url}
           cover
+          priority={priority}
           className={cn(
             "aspect-video w-full transition-transform duration-500 group-hover:scale-[1.01]",
             flip && "lg:order-2",

--- a/apps/web/components/case-row.tsx
+++ b/apps/web/components/case-row.tsx
@@ -10,6 +10,21 @@ import type { Project } from "@/lib/types";
 import { ViewTransition } from "@/lib/view-transition";
 
 /**
+ * How many technology chips a case row shows before it stops counting.
+ *
+ * This row used to render every one, which meant eleven identical chips under
+ * EduPath and Food Forum and nine under Cenematic. Past about five they stop
+ * being read: they are all the same size, weight and colour, so the eye takes
+ * them as one grey texture and the two that actually matter are buried in it.
+ * A wall of chips also reads as a generated interface rather than an edited
+ * one — someone chose to list eleven things, or nobody chose anything.
+ *
+ * The remainder is shown as a count rather than dropped silently, and the
+ * detail page still lists the full stack, so nothing becomes unreachable.
+ */
+const CASE_ROW_CHIPS = 5;
+
+/**
  * A featured project as a full-width case row: media beside the argument for
  * it, alternating sides so the section reads as a sequence of spreads rather
  * than a grid of tiles. The grid treats every project as the same size;
@@ -62,12 +77,17 @@ export function CaseRow({ project, flip }: { project: Project; flip?: boolean })
         <p className="mt-4 max-w-xl text-muted-foreground">{project.description}</p>
 
         {project.technologies.length > 0 ? (
-          <ul className="mt-5 flex flex-wrap gap-1.5">
-            {project.technologies.map((tech) => (
+          <ul className="mt-5 flex flex-wrap items-center gap-1.5">
+            {project.technologies.slice(0, CASE_ROW_CHIPS).map((tech) => (
               <li key={tech} className={chipClasses}>
                 {tech}
               </li>
             ))}
+            {project.technologies.length > CASE_ROW_CHIPS ? (
+              <li className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+                +{project.technologies.length - CASE_ROW_CHIPS}
+              </li>
+            ) : null}
           </ul>
         ) : null}
 

--- a/apps/web/components/case-row.tsx
+++ b/apps/web/components/case-row.tsx
@@ -24,11 +24,95 @@ import { ViewTransition } from "@/lib/view-transition";
  */
 const CASE_ROW_CHIPS = 5;
 
+/*
+ * The three pieces both case-row layouts share.
+ *
+ * They are components rather than a copied class string because the capping
+ * rule above and the "which links exist" question are logic, not styling —
+ * duplicating them is how the two layouts would end up disagreeing about how
+ * many chips is too many.
+ */
+
+/** The heading, stretched over its row so the whole article is the target. */
+function ProjectTitle({ project }: { project: Project }) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <h3 className="font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+        <Link
+          href={`/projects/${project.slug}`}
+          // The ::after stretches this anchor over the row while the link text
+          // stays the title, so the accessible name is the project, not "row".
+          className="after:absolute after:inset-0 hover:text-primary"
+        >
+          {project.title}
+        </Link>
+      </h3>
+      <StatusBadge status={project.status} />
+    </div>
+  );
+}
+
+function TechChips({ technologies, className }: { technologies: string[]; className?: string }) {
+  if (technologies.length === 0) return null;
+
+  const shown = technologies.slice(0, CASE_ROW_CHIPS);
+  const remainder = technologies.length - shown.length;
+
+  return (
+    <ul className={cn("flex flex-wrap items-center gap-1.5", className)}>
+      {shown.map((tech) => (
+        <li key={tech} className={chipClasses}>
+          {tech}
+        </li>
+      ))}
+      {remainder > 0 ? (
+        <li className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+          +{remainder}
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+function ProjectLinks({ project, className }: { project: Project; className?: string }) {
+  if (!project.github_url && !project.live_url) return null;
+
+  return (
+    // z-10 keeps these above the title's stretched link so they stay
+    // independently clickable.
+    <div className={cn("relative z-10 flex gap-5", className)}>
+      {project.github_url ? <ExternalLink href={project.github_url}>Source</ExternalLink> : null}
+      {project.live_url ? <ExternalLink href={project.live_url}>Live</ExternalLink> : null}
+    </div>
+  );
+}
+
 /**
- * A featured project as a full-width case row: media beside the argument for
- * it, alternating sides so the section reads as a sequence of spreads rather
- * than a grid of tiles. The grid treats every project as the same size;
- * featured work is not the same size, and this is the layout saying so.
+ * A featured project, in one of two layouts picked by whether the record
+ * actually has a cover.
+ *
+ * ## Why the layout follows the data
+ *
+ * With a cover, this is a spread: the image beside the argument for it,
+ * alternating sides so the section reads as a sequence rather than a grid of
+ * tiles. The grid treats every project as the same size; featured work is not
+ * the same size, and the spread is the layout saying so.
+ *
+ * Without one, the spread is the wrong promise. Every project on this site
+ * currently has `image_url: null`, so the media column rendered a generated
+ * gradient — and four of them stacked meant roughly 40% of the page's area was
+ * an empty grey panel with a ghosted letter in it. A placeholder that large
+ * does not read as "a cover is coming", it reads as a broken image, and no
+ * amount of motion elsewhere rescues a page built mostly of them.
+ *
+ * So a project without a cover gets a record layout instead: the same content,
+ * arranged as mono fields beside prose, using the full width and about a third
+ * of the height. It is dense on purpose and it is not a degraded state — it is
+ * what a row of a table of work should look like.
+ *
+ * Uploading a cover in the console switches that row to the spread with no
+ * further change here, which is the point: the page is built for the images
+ * that are coming without pretending they have already arrived.
  */
 export function CaseRow({
   project,
@@ -42,10 +126,39 @@ export function CaseRow({
 }) {
   const period = formatPeriod(project.started_on, project.ended_on);
 
+  if (!project.image_url) {
+    return (
+      // A rule per row, so a run of these reads as a ledger of work rather than
+      // as paragraphs drifting in a column. The rule is also what lets the
+      // spacing between rows come down without them running together.
+      <article className="group relative grid gap-x-10 gap-y-3 border-t border-border/60 pt-10 lg:grid-cols-[13rem_1fr] lg:pt-12">
+        {/*
+          The field column: what this row *is*, in the site's mono voice. The
+          links live here too — down in the body they added a line of height to
+          every row and left this column two lines tall against a five-line
+          neighbour. Below `lg` the whole column stacks above the title, where
+          it reads as the eyebrow it already looks like.
+        */}
+        <div className="lg:pt-1">
+          <Eyebrow>/{project.slug}</Eyebrow>
+          {period ? <Eyebrow className="mt-1.5">{period}</Eyebrow> : null}
+          <ProjectLinks project={project} className="mt-3 flex-wrap gap-x-5 gap-y-0" />
+        </div>
+
+        <div>
+          <ProjectTitle project={project} />
+          {/* 3xl rather than 2xl: with the media panel gone this column is the
+              full width of the layout, and a 2xl measure left a third of the
+              row empty. */}
+          <p className="mt-3 max-w-3xl text-muted-foreground">{project.description}</p>
+          <TechChips technologies={project.technologies} className="mt-4" />
+        </div>
+      </article>
+    );
+  }
+
   return (
-    <article
-      className="group relative grid items-center gap-8 lg:grid-cols-2 lg:gap-14"
-    >
+    <article className="group relative grid items-center gap-8 pt-14 first:pt-0 lg:grid-cols-2 lg:gap-14 lg:pt-20">
       {/* Shared-element morph: this panel and the detail page's header carry
           the same transition name, so clicking through animates the panel
           into the header instead of cutting. */}
@@ -64,54 +177,14 @@ export function CaseRow({
       </ViewTransition>
 
       <div>
-        {/* The project addressed the way the spine addresses everything:
-            as a path. */}
         <Eyebrow>/{project.slug}</Eyebrow>
-
-        <div className="mt-3 flex flex-wrap items-center gap-3">
-          <h3 className="font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-            <Link
-              href={`/projects/${project.slug}`}
-              // The whole row is the target; the ::after stretches this anchor
-              // over it while the link text stays the title.
-              className="after:absolute after:inset-0 hover:text-primary"
-            >
-              {project.title}
-            </Link>
-          </h3>
-          <StatusBadge status={project.status} />
+        <div className="mt-3">
+          <ProjectTitle project={project} />
         </div>
-
         {period ? <Eyebrow className="mt-2">{period}</Eyebrow> : null}
-
         <p className="mt-4 max-w-xl text-muted-foreground">{project.description}</p>
-
-        {project.technologies.length > 0 ? (
-          <ul className="mt-5 flex flex-wrap items-center gap-1.5">
-            {project.technologies.slice(0, CASE_ROW_CHIPS).map((tech) => (
-              <li key={tech} className={chipClasses}>
-                {tech}
-              </li>
-            ))}
-            {project.technologies.length > CASE_ROW_CHIPS ? (
-              <li className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
-                +{project.technologies.length - CASE_ROW_CHIPS}
-              </li>
-            ) : null}
-          </ul>
-        ) : null}
-
-        {project.github_url || project.live_url ? (
-          // Above the stretched link so these stay independently clickable.
-          <div className="relative z-10 mt-4 flex gap-5">
-            {project.github_url ? (
-              <ExternalLink href={project.github_url}>Source</ExternalLink>
-            ) : null}
-            {project.live_url ? (
-              <ExternalLink href={project.live_url}>Live</ExternalLink>
-            ) : null}
-          </div>
-        ) : null}
+        <TechChips technologies={project.technologies} className="mt-5" />
+        <ProjectLinks project={project} className="mt-4" />
       </div>
     </article>
   );

--- a/apps/web/components/console/entity-form.tsx
+++ b/apps/web/components/console/entity-form.tsx
@@ -19,6 +19,7 @@
 import Link from "next/link";
 import { useActionState } from "react";
 
+import { ImageField } from "@/components/console/image-field";
 import { Button } from "@/components/ui/button";
 import { CheckboxField, SelectField, TextAreaField, TextField } from "@/components/ui/field";
 import { Notice } from "@/components/ui/notice";
@@ -149,6 +150,18 @@ function Control({
           error={error}
           rows={field.rows ?? 4}
           defaultValue={value}
+        />
+      );
+
+    case "image":
+      return (
+        <ImageField
+          name={field.name}
+          label={field.label}
+          hint={field.hint}
+          error={error}
+          defaultValue={value}
+          maxLength={field.maxLength}
         />
       );
 

--- a/apps/web/components/console/image-field.tsx
+++ b/apps/web/components/console/image-field.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/*
+ * A client component because it does the two things a server component cannot:
+ * read a File off an <input type="file">, and PUT its bytes at Blob storage.
+ *
+ * ## The URL box is the field. The picker is a convenience on top of it.
+ *
+ * The form this sits in works with scripting off — see the header of
+ * entity-form.tsx — and a file upload cannot. So the control that actually
+ * carries the value is a plain text input holding the URL, exactly as before;
+ * that is what has the field's `name`, that is what posts, and that is what the
+ * server reads. The picker just writes into it.
+ *
+ * With no JavaScript the picker is inert and the admin pastes a URL, which is
+ * precisely the behaviour this field had before uploading existed. Nothing
+ * regressed for that visitor.
+ */
+
+import { upload } from "@vercel/blob/client";
+import { useRef, useState } from "react";
+
+import { TextField } from "@/components/ui/field";
+import { cn } from "@/lib/cn";
+
+type Status =
+  | { state: "idle" }
+  | { state: "uploading" }
+  | { state: "failed"; message: string };
+
+export function ImageField({
+  name,
+  label,
+  hint,
+  error,
+  defaultValue,
+  maxLength,
+}: {
+  name: string;
+  label: string;
+  hint?: string;
+  error?: string;
+  defaultValue: string;
+  maxLength?: number;
+}) {
+  // The URL is state so the preview and the input stay in step after an
+  // upload. It starts uncontrolled-in-spirit from defaultValue, which is what
+  // carries a rejected edit's text back into the form.
+  const [url, setUrl] = useState(defaultValue);
+  const [status, setStatus] = useState<Status>({ state: "idle" });
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  async function onPick(file: File) {
+    setStatus({ state: "uploading" });
+
+    try {
+      const blob = await upload(file.name, file, {
+        access: "public",
+        handleUploadUrl: "/api/admin/upload",
+      });
+
+      setUrl(blob.url);
+      setStatus({ state: "idle" });
+    } catch (cause) {
+      /*
+       * The route answers 401 for a dead session and 400 for a rejected file,
+       * but the SDK surfaces both as an Error whose message is the body's
+       * `error`. Saying "sign in again" for the first is worth the string
+       * match: it is the one failure the admin can actually act on, and
+       * "upload failed" would send them hunting for a problem with the file.
+       */
+      const message = cause instanceof Error ? cause.message : "Upload failed";
+
+      setStatus({
+        state: "failed",
+        message: message.includes("Not authenticated")
+          ? "Your session expired. Open the console in a new tab to sign in, then try again."
+          : message,
+      });
+    } finally {
+      // Let the same file be picked twice — after a failure, the change event
+      // would not fire again without this.
+      if (fileInput.current) fileInput.current.value = "";
+    }
+  }
+
+  return (
+    <div>
+      <TextField
+        name={name}
+        label={label}
+        meta={
+          hint ? (
+            <span className="text-xs font-normal normal-case tracking-normal text-muted-foreground">
+              {hint}
+            </span>
+          ) : undefined
+        }
+        error={error}
+        value={url}
+        onChange={(event) => setUrl(event.target.value)}
+        type="text"
+        maxLength={maxLength}
+      />
+
+      <div className="mt-3 flex flex-wrap items-center gap-3">
+        {/*
+          A real <input type="file"> with a real <label> pointing at it, rather
+          than a button that calls .click(). The label is the click target and
+          the keyboard target, so this is focusable and operable without a
+          single extra handler.
+        */}
+        <label
+          className={cn(
+            "inline-flex min-h-11 cursor-pointer items-center rounded-[var(--radius-control)]",
+            "border border-border px-3.5 py-2.5 font-mono text-[11px] uppercase tracking-wider",
+            "text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground",
+            status.state === "uploading" && "pointer-events-none opacity-60",
+          )}
+        >
+          {status.state === "uploading" ? "Uploading…" : "Upload image"}
+          <input
+            ref={fileInput}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/avif"
+            className="sr-only"
+            disabled={status.state === "uploading"}
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) void onPick(file);
+            }}
+          />
+        </label>
+
+        {url ? (
+          /*
+           * A plain <img>, not next/image: this is an admin preview of a URL
+           * that may be anything the admin typed, and routing it through the
+           * optimiser would mean whitelisting arbitrary hosts in
+           * next.config.ts. The public site is where optimisation matters.
+           */
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={url}
+            alt=""
+            className="h-11 w-20 rounded-[var(--radius-control)] border border-border object-cover"
+          />
+        ) : null}
+      </div>
+
+      {/* role=status so a screen reader hears the outcome without moving focus. */}
+      <p role="status" className="sr-only">
+        {status.state === "uploading" ? "Uploading image" : ""}
+      </p>
+
+      {status.state === "failed" ? (
+        <p className="mt-2 text-sm text-destructive-text">{status.message}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/contact-section.tsx
+++ b/apps/web/components/contact-section.tsx
@@ -47,38 +47,62 @@ export function ContactSection() {
         someone. Letting each channel take its natural width fixes it and wraps
         gracefully at 375px.
       */}
-      <dl className="mb-10 flex max-w-2xl flex-wrap gap-x-10 gap-y-4">
-        {CHANNELS.map((channel) => (
-          <div key={channel.label}>
-            {/* eyebrowClasses, not a literal 11px: the footer renders these
-                same labels through it, and two sizes for one label is how a
-                scale stops being one. */}
-            <dt className={eyebrowClasses}>
-              {channel.label}
-            </dt>
-            <dd>
-              {isMailto(channel.href) ? (
-                // Not an ExternalLink: a mailto does not leave for another site
-                // and the ↗ affordance would be a lie about where it goes.
-                <a
-                  href={channel.href}
-                  // py-3 to match ExternalLink's tap target; these sit in the
-                  // same row and one being shorter than its neighbours is both
-                  // a miss on touch and visibly uneven.
-                  className="inline-flex py-3 text-sm text-muted-foreground transition-colors hover:text-primary"
-                >
-                  {channel.value}
-                </a>
-              ) : (
-                <ExternalLink href={channel.href}>{channel.value}</ExternalLink>
-              )}
-            </dd>
-          </div>
-        ))}
-      </dl>
+      {/*
+        Channels beside the form rather than stacked above it.
 
-      <div className="max-w-2xl">
-        <ContactForm />
+        Stacked, this section was 1065px tall — a screen and a bit for one form
+        and three links, most of it the gap between the two. Side by side the
+        form keeps its reading measure, the channels stop being a full-width
+        band of mostly air, and the whole block fits in a viewport. Below `lg`
+        it stacks again, which is the order it should be read in anyway: here
+        is how to reach me, here is the form.
+      */}
+      <div className="grid gap-10 lg:grid-cols-[1fr_20rem] lg:gap-16">
+        <div className="max-w-2xl lg:order-1">
+          <ContactForm />
+        </div>
+
+        {/*
+          A description list, because that is what this is: a stable key and its
+          value. The same mono-key / value shape the meta rows elsewhere use.
+        */}
+        <dl className="lg:order-2">
+          {CHANNELS.map((channel) => (
+            <div key={channel.label} className="border-t border-border/60 py-3 first:border-t-0 first:pt-0 lg:first:border-t lg:first:pt-3">
+              {/* eyebrowClasses, not a literal 11px: the footer renders these
+                  same labels through it, and two sizes for one label is how a
+                  scale stops being one. */}
+              <dt className={eyebrowClasses}>
+                {channel.label}
+              </dt>
+              <dd>
+                {isMailto(channel.href) ? (
+                  // Not an ExternalLink: a mailto does not leave for another
+                  // site and the ↗ affordance would be a lie about where it
+                  // goes.
+                  <a
+                    href={channel.href}
+                    // min-h-11 states the 44px tap target rather than arriving
+                    // at it by adding padding to a line-height — which is how
+                    // this silently became 36px when the row gained padding of
+                    // its own. ExternalLink beside it is already 44.
+                    //
+                    // No break-all, on purpose: in an earlier equal-column grid
+                    // the address was 6px wider than its cell and broke to
+                    // "dangkhoipham80@gmail.co" / "m", and an address split
+                    // across two lines is not one you can read back to someone.
+                    // The 20rem column is sized to hold it whole.
+                    className="inline-flex min-h-11 items-center text-sm text-muted-foreground transition-colors hover:text-primary"
+                  >
+                    {channel.value}
+                  </a>
+                ) : (
+                  <ExternalLink href={channel.href}>{channel.value}</ExternalLink>
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
       </div>
     </Section>
   );

--- a/apps/web/components/hero-topology.tsx
+++ b/apps/web/components/hero-topology.tsx
@@ -50,6 +50,14 @@ const EDGES = [
 const NODE_BOOT_DELAY_MS = [450, 525, 600, 675, 750];
 
 /*
+ * Each rail is drawn just before the node it arrives at pops in, so the
+ * sequence reads as one motion — the wire reaches the service, then the
+ * service appears — rather than as two separate animations that happen to
+ * overlap.
+ */
+const EDGE_DRAW_DELAY_MS = [240, 380, 470, 560];
+
+/*
  * When the wires start flowing. Kafka's entrance technically runs until
  * 1.15s, but the deceleration easing has it visually settled well before
  * that — 0.8s starts the first flow the moment the graph reads as complete,
@@ -67,26 +75,34 @@ export function HeroTopology({ className }: { className?: string }) {
       // as the architecture it depicts, not as an icon beside the text.
       className={cn("h-auto w-full max-w-lg lg:max-w-none", className)}
     >
-      {/* Static rails, so the graph still reads as connected when motion is off. */}
-      <g className="hero-item [animation-delay:350ms]">
-        {EDGES.map((edge) => (
+      {/*
+        The rails draw themselves in request order. `pathLength="1"` normalises
+        every curve so one dasharray works for all of them — see `.edge-draw`.
+        The base state is a fully drawn line, so with motion off (or without
+        animation support) this is exactly the static graph it replaced.
+      */}
+      <g>
+        {EDGES.map((edge, i) => (
           <path
             key={`rail-${edge.d}`}
             d={edge.d}
+            pathLength="1"
             fill="none"
             stroke="hsl(var(--border))"
             strokeWidth="1.5"
+            className="edge-draw"
+            style={{ animationDelay: `${EDGE_DRAW_DELAY_MS[i]}ms` }}
           />
         ))}
       </g>
 
-      <g className="hero-item [animation-delay:350ms]">
+      {/* The packets. `.wire-flow` supplies the lit stroke and its glow. */}
+      <g>
         {EDGES.map((edge) => (
           <path
             key={`flow-${edge.d}`}
             d={edge.d}
             fill="none"
-            stroke="hsl(var(--primary))"
             strokeWidth="2"
             strokeLinecap="round"
             className="wire-flow"
@@ -100,9 +116,29 @@ export function HeroTopology({ className }: { className?: string }) {
       {NODES.map((node, i) => (
         <g
           key={node.id}
-          className="topology-node hero-item"
+          className="topology-node node-pop"
           style={{ animationDelay: `${NODE_BOOT_DELAY_MS[i]}ms` }}
         >
+          {/*
+            A halo under the API node only. It is the one service on this
+            diagram that is *this* site's API, and giving exactly one node a
+            slow breath is what stops the graph reading as a still life. One
+            infinite animation, on a decorative mark, nowhere near text.
+          */}
+          {node.id === "api" ? (
+            <rect
+              x={node.x - 5}
+              y={node.y - 5}
+              width={NODE_WIDTH + 10}
+              height={NODE_HEIGHT + 10}
+              rx="13"
+              fill="none"
+              stroke="hsl(var(--live))"
+              strokeWidth="1"
+              className="node-live"
+            />
+          ) : null}
+
           <rect
             x={node.x}
             y={node.y}

--- a/apps/web/components/hero-topology.tsx
+++ b/apps/web/components/hero-topology.tsx
@@ -1,90 +1,129 @@
+import { eyebrowClasses } from "@/components/ui/eyebrow";
 import { cn } from "@/lib/cn";
 
 /**
- * The hero's thesis: this person builds systems where services talk to each
- * other.
+ * The hero's thesis, as an instrument rather than an illustration: the request
+ * path that served the page you are reading.
  *
- * Every node is real infrastructure from the projects on this page — FastAPI,
- * Postgres, Redis and Kafka all appear in EduPath and Food Forum. A rotating
- * geometric shape would have said nothing about backend engineering; a topology
- * says the whole thing at a glance.
+ * ## Why it changed
+ *
+ * This drawing used to show FastAPI fanning out to Postgres, Redis and Kafka.
+ * Those are real technologies from the projects further down the page, but they
+ * are not in *this* system — so the first thing a portfolio about honest
+ * systems engineering did was put a diagram in its hero of something that was
+ * not running. The nodes below are the four that actually serve this response,
+ * and the region bracket is the real reason the API lives in `iad`: it is next
+ * to the database and to Vercel's functions, because no browser ever calls it
+ * directly.
+ *
+ * ## What is live, and how it knows
+ *
+ * The API node is the only lit one, and it is lit because `apiOk` says the read
+ * that produced this page's content actually got an answer. `lib/api.ts` hands
+ * back a fallback on failure so the site stays up, which makes an empty list
+ * ambiguous — `Read.ok` is what disambiguates it. When the backend is asleep
+ * the node goes dim and the readout says so. A status light that is always on
+ * is not a status light.
  *
  * Inline SVG on the server: no canvas, no WebGL, no client component, no
- * hydration, nothing competing with LCP. All motion is CSS — the boot-order
- * entrance (`hero-enter`) and the packet flow on the edges — so
- * `prefers-reduced-motion` stops the lot through the global rule rather than
- * needing its own escape hatch.
+ * hydration, nothing competing with LCP. All motion is CSS, so
+ * `prefers-reduced-motion` stops it through the global rule in globals.css.
  *
- * Decorative by definition — the information is in the prose beside it — so the
- * whole graphic is hidden from assistive tech instead of narrating a diagram
- * nobody asked for.
+ * The drawing is decorative — the readout line below states the same fact in
+ * words — so the SVG is hidden from assistive tech rather than narrating a
+ * diagram nobody asked for.
  */
 
-type Node = { id: string; label: string; x: number; y: number };
+type Node = {
+  id: string;
+  label: string;
+  /** The provider underneath, which is what turns a box into a deployment. */
+  host?: string;
+  /** Which side of the node its host label sits on, to keep it off the wires. */
+  hostAbove?: boolean;
+  x: number;
+  y: number;
+};
 
-const NODE_WIDTH = 82;
-const NODE_HEIGHT = 30;
+const NODE_WIDTH = 104;
+const NODE_HEIGHT = 34;
 
+/*
+ * A serpentine rather than a straight row, and the reason is the packet.
+ *
+ * Four nodes in a line leaves only a ~30px gap between each pair, so a dot
+ * travelling behind them is hidden for 92% of its journey and reads as a
+ * flicker rather than as a request. Folding the chain puts long open runs
+ * between the services — the packet is visible for about three quarters of the
+ * path — and it fills the hero's column instead of stretching a thin strip
+ * across it. The order is still strictly the order a request travels.
+ */
 const NODES: Node[] = [
-  { id: "client", label: "Client", x: 6, y: 105 },
-  { id: "api", label: "FastAPI", x: 155, y: 105 },
-  { id: "postgres", label: "Postgres", x: 306, y: 30 },
-  { id: "redis", label: "Redis", x: 306, y: 105 },
-  { id: "kafka", label: "Kafka", x: 306, y: 180 },
+  { id: "browser", label: "Browser", x: 6, y: 28 },
+  { id: "next", label: "Next.js", host: "vercel", hostAbove: true, x: 250, y: 28 },
+  { id: "api", label: "FastAPI", host: "fly.io · iad", x: 250, y: 148 },
+  { id: "postgres", label: "Postgres", host: "neon · us-east-2", x: 6, y: 148 },
 ];
 
-/** Edges leave the right side of one node and arrive at the left of the next. */
+/** The open runs between services — the wires, minus what a node covers. */
 const EDGES = [
-  { d: "M88,120 L155,120", delay: "0s" },
-  { d: "M237,120 C272,120 276,45 306,45", delay: "0.35s" },
-  { d: "M237,120 L306,120", delay: "0.7s" },
-  { d: "M237,120 C272,120 276,195 306,195", delay: "1.05s" },
+  { d: "M110,45 L250,45" },
+  { d: "M302,62 L302,148" },
+  { d: "M250,165 L110,165" },
 ];
 
 /*
- * The boot order, one delay per node in NODES order: Client registers, the
- * API comes up, then its dependencies. Inline style rather than a Tailwind
- * arbitrary class because the values are indexed at render time and the
- * scanner would never see them.
+ * The boot order, one delay per node in NODES order: the browser asks, the
+ * renderer comes up, then the API, then its database. Inline style rather than
+ * a Tailwind arbitrary class because the values are indexed at render time and
+ * the scanner would never see them.
  */
-const NODE_BOOT_DELAY_MS = [450, 525, 600, 675, 750];
+const NODE_BOOT_DELAY_MS = [420, 500, 580, 660];
 
 /*
  * Each rail is drawn just before the node it arrives at pops in, so the
  * sequence reads as one motion — the wire reaches the service, then the
- * service appears — rather than as two separate animations that happen to
- * overlap.
+ * service appears — rather than as two animations that happen to overlap.
  */
-const EDGE_DRAW_DELAY_MS = [240, 380, 470, 560];
+const EDGE_DRAW_DELAY_MS = [300, 420, 540];
 
-/*
- * When the wires start flowing. Kafka's entrance technically runs until
- * 1.15s, but the deceleration easing has it visually settled well before
- * that — 0.8s starts the first flow the moment the graph reads as complete,
- * without a dead beat at the end of the boot.
- */
-const FLOW_START = "0.8s";
-
-export function HeroTopology({ className }: { className?: string }) {
+export function HeroTopology({
+  projectCount,
+  apiOk,
+  className,
+}: {
+  /** Records the projects read returned — the number in the readout. */
+  projectCount: number;
+  /** Whether that read was actually answered. Drives the lit node. */
+  apiOk: boolean;
+  className?: string;
+}) {
   return (
-    <svg
-      viewBox="0 0 400 240"
-      aria-hidden="true"
-      // Capped only while the hero is a single column. Once the two-column
-      // grid is active the diagram fills its column — at that scale it reads
-      // as the architecture it depicts, not as an icon beside the text.
-      className={cn("h-auto w-full max-w-lg lg:max-w-none", className)}
+    <figure
+      className={cn(
+        // A frame, so the drawing reads as a panel on an instrument rather
+        // than a sketch floating in the margin. bg-card against the page's
+        // bg-background, with the nodes filled bg-background again, so the
+        // services read as recessed into the panel in both themes.
+        "rounded-[var(--radius-card)] border border-border bg-card p-5 sm:p-6",
+        className,
+      )}
     >
-      {/*
-        The rails draw themselves in request order. `pathLength="1"` normalises
-        every curve so one dasharray works for all of them — see `.edge-draw`.
-        The base state is a fully drawn line, so with motion off (or without
-        animation support) this is exactly the static graph it replaced.
-      */}
-      <g>
+      {/* eyebrowClasses rather than <Eyebrow>: the label belongs to the figure,
+          so it has to be a <figcaption>, which is not one of the elements that
+          component renders. */}
+      <figcaption className={eyebrowClasses}>/request-path</figcaption>
+
+      <svg viewBox="0 0 360 208" aria-hidden="true" className="mt-4 h-auto w-full">
+        {/*
+          The rails draw themselves in request order. `pathLength="1"`
+          normalises every segment so one dasharray works for all of them — see
+          `.edge-draw`. The base state is a fully drawn line, so with motion off
+          this is exactly the static graph it replaced.
+        */}
         {EDGES.map((edge, i) => (
           <path
-            key={`rail-${edge.d}`}
+            key={edge.d}
             d={edge.d}
             pathLength="1"
             fill="none"
@@ -94,73 +133,102 @@ export function HeroTopology({ className }: { className?: string }) {
             style={{ animationDelay: `${EDGE_DRAW_DELAY_MS[i]}ms` }}
           />
         ))}
-      </g>
 
-      {/* The packets. `.wire-flow` supplies the lit stroke and its glow. */}
-      <g>
-        {EDGES.map((edge) => (
-          <path
-            key={`flow-${edge.d}`}
-            d={edge.d}
-            fill="none"
-            strokeWidth="2"
-            strokeLinecap="round"
-            className="wire-flow"
-            // Held until the last node's entrance lands — flow through a
-            // half-built graph would break the boot narrative.
-            style={{ animationDelay: `calc(${FLOW_START} + ${edge.delay})` }}
-          />
-        ))}
-      </g>
+        {/*
+          The request, and the answer coming back.
 
-      {NODES.map((node, i) => (
-        <g
-          key={node.id}
-          className="topology-node node-pop"
-          style={{ animationDelay: `${NODE_BOOT_DELAY_MS[i]}ms` }}
-        >
-          {/*
-            A halo under the API node only. It is the one service on this
-            diagram that is *this* site's API, and giving exactly one node a
-            slow breath is what stops the graph reading as a still life. One
-            infinite animation, on a decorative mark, nowhere near text.
-          */}
-          {node.id === "api" ? (
-            <rect
-              x={node.x - 5}
-              y={node.y - 5}
-              width={NODE_WIDTH + 10}
-              height={NODE_HEIGHT + 10}
-              rx="13"
-              fill="none"
-              stroke="hsl(var(--live))"
-              strokeWidth="1"
-              className="node-live"
-            />
-          ) : null}
-
-          <rect
-            x={node.x}
-            y={node.y}
-            width={NODE_WIDTH}
-            height={NODE_HEIGHT}
-            rx="8"
-            fill="hsl(var(--card))"
-            stroke="hsl(var(--border))"
-            strokeWidth="1.5"
-          />
-          <text
-            x={node.x + NODE_WIDTH / 2}
-            y={node.y + NODE_HEIGHT / 2}
-            textAnchor="middle"
-            dominantBaseline="central"
-            fill="hsl(var(--muted-foreground))"
-            className="font-mono text-[11px]"
-          >
-            {node.label}
-          </text>
+          Drawn before the nodes so it passes *behind* them: the packet
+          disappears under each service and re-emerges on the far side, which
+          is the one thing a static architecture diagram can never say. Both
+          dots ride the same straight path across the row via `offset-path`;
+          the timing that makes one an outbound request and the other a
+          response lives in the keyframes. See `.packet-out` in globals.css.
+        */}
+        <g className="packet-path">
+          <circle r="3.5" className="packet packet-out" fill="hsl(var(--live))" />
+          <circle r="3" className="packet packet-back" fill="hsl(var(--live))" />
         </g>
-      ))}
-    </svg>
+
+        {NODES.map((node, i) => (
+          <g
+            key={node.id}
+            className="topology-node node-pop"
+            style={{ animationDelay: `${NODE_BOOT_DELAY_MS[i]}ms` }}
+          >
+            {/*
+              A halo under the API node only, and only when the read that built
+              this page was answered. It is the one service on this diagram
+              that is this site's own backend, and giving exactly one node a
+              slow breath is what stops the graph reading as a still life. One
+              infinite animation, on a decorative mark, nowhere near text.
+            */}
+            {node.id === "api" && apiOk ? (
+              <rect
+                x={node.x - 5}
+                y={node.y - 5}
+                width={NODE_WIDTH + 10}
+                height={NODE_HEIGHT + 10}
+                rx="13"
+                fill="none"
+                stroke="hsl(var(--live))"
+                strokeWidth="1"
+                className="node-live"
+              />
+            ) : null}
+
+            <rect
+              x={node.x}
+              y={node.y}
+              width={NODE_WIDTH}
+              height={NODE_HEIGHT}
+              rx="8"
+              fill="hsl(var(--background))"
+              stroke="hsl(var(--border))"
+              strokeWidth="1.5"
+            />
+            <text
+              x={node.x + NODE_WIDTH / 2}
+              y={node.y + NODE_HEIGHT / 2}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fill="hsl(var(--foreground))"
+              className="font-mono text-[11px]"
+            >
+              {node.label}
+            </text>
+            {node.host ? (
+              <text
+                x={node.x + NODE_WIDTH / 2}
+                // Above or below, whichever side the wires are not on.
+                y={node.hostAbove ? node.y - 9 : node.y + NODE_HEIGHT + 15}
+                textAnchor="middle"
+                fill="hsl(var(--muted-foreground))"
+                className="font-mono text-[9px]"
+              >
+                {node.host}
+              </text>
+            ) : null}
+          </g>
+        ))}
+      </svg>
+
+      {/*
+        The same fact in words, and the reason the drawing is allowed to claim
+        anything: this is the call the page actually made. Lower-case mono
+        because it carries a path — the eyebrow treatment would render it
+        "GET /PROJECTS/", which reads as shouting rather than as a route.
+      */}
+      <p className="mt-4 border-t border-border/60 pt-3 font-mono text-xs text-muted-foreground">
+        {apiOk ? (
+          <>
+            GET /projects/ · 200 · {projectCount} record{projectCount === 1 ? "" : "s"}
+          </>
+        ) : (
+          // The site is built to survive this: lib/api.ts returns a fallback
+          // and the page renders. Saying so is better than a lit node lying.
+          <>GET /projects/ · no answer · serving fallback</>
+        )}
+      </p>
+    </figure>
   );
 }

--- a/apps/web/components/section.tsx
+++ b/apps/web/components/section.tsx
@@ -50,7 +50,12 @@ export function Section({
         // section-rule replaces the top border with a line that can be drawn
         // as the section arrives; see globals.css. Without scroll-driven
         // animation support it renders as exactly the border it replaced.
-        "section-rule relative py-24 sm:py-32 lg:py-40",
+        //
+        // py-40 at `lg` put 160px of nothing above and below every section —
+        // 320px per boundary, which on its own was roughly a screen and a half
+        // of the home page. The rule and the tint already mark where a section
+        // starts; the padding does not have to do it a third time.
+        "section-rule relative py-20 sm:py-24 lg:py-28",
         tinted && "bg-muted",
       )}
     >
@@ -83,7 +88,7 @@ export function Section({
           {description ? (
             <p className="reveal mt-4 max-w-2xl text-lg text-muted-foreground">{description}</p>
           ) : null}
-          <div className="mt-12">{children}</div>
+          <div className="mt-10">{children}</div>
         </div>
       </Container>
     </section>

--- a/apps/web/components/stack-diagram.tsx
+++ b/apps/web/components/stack-diagram.tsx
@@ -31,7 +31,10 @@ export function StackDiagram({ groups }: { groups: [string, Skill[]][] }) {
           <section
             key={category}
             className={cn(
-              "grid gap-3 p-5 sm:grid-cols-[9rem_1fr] sm:gap-6 sm:p-6",
+              // stack-layer is the scan: an ink tick at the left of every
+              // layer that lights as that layer crosses the viewport. See
+              // globals.css — it needs `relative` for the tick to anchor to.
+              "stack-layer relative grid gap-3 p-5 pl-6 sm:grid-cols-[9rem_1fr] sm:gap-6 sm:p-6 sm:pl-7",
               i > 0 && "border-t border-border/60",
             )}
           >

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -41,17 +41,27 @@ export function Badge({
 }
 
 /*
- * Status colours are spelled out per status rather than interpolated.
- * Tailwind scans source text for complete class names, so a template like
- * `bg-${colour}-500/15` produces no CSS at all — the class exists in the DOM
- * and does nothing.
+ * Status, without hue.
+ *
+ * These were four Tailwind palettes — green, blue, yellow, red — and they
+ * survived the amber only because the amber was louder. With the page
+ * monochrome they became the single most colourful thing on it, answering to
+ * no token in globals.css, and the `on_hold` yellow was literally the colour
+ * the redesign set out to remove.
+ *
+ * State is carried by the dot instead: filled, ringed, hollow, dim. That is a
+ * real encoding rather than decoration — the fill reads as "how far along",
+ * and it degrades honestly in greyscale and for anyone who cannot separate
+ * red from green, which the old version did not.
+ *
+ * The label is never colour-only, so the dot is redundant reinforcement
+ * rather than the sole carrier of meaning.
  */
-const STATUS_STYLES: Record<ProjectStatus, string> = {
-  // green-700 on the composited 15% green measured 4.33:1 in light mode.
-  completed: "bg-green-500/15 text-green-800 dark:text-green-300",
-  in_progress: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
-  on_hold: "bg-yellow-500/15 text-yellow-800 dark:text-yellow-300",
-  dropped: "bg-red-500/15 text-red-700 dark:text-red-300",
+const STATUS_DOTS: Record<ProjectStatus, string> = {
+  completed: "bg-foreground",
+  in_progress: "bg-foreground/40 ring-1 ring-foreground/70",
+  on_hold: "border border-muted-foreground/70",
+  dropped: "bg-muted-foreground/40",
 };
 
 const STATUS_LABELS: Record<ProjectStatus, string> = {
@@ -63,7 +73,14 @@ const STATUS_LABELS: Record<ProjectStatus, string> = {
 
 export function StatusBadge({ status }: { status: ProjectStatus }) {
   return (
-    <Badge className={cn("shrink-0", STATUS_STYLES[status])}>
+    <Badge
+      variant="outline"
+      className="shrink-0 gap-1.5 font-mono text-[11px] uppercase tracking-wider"
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", STATUS_DOTS[status])}
+      />
       {STATUS_LABELS[status] ?? status}
     </Badge>
   );

--- a/apps/web/components/ui/project-media.tsx
+++ b/apps/web/components/ui/project-media.tsx
@@ -1,18 +1,28 @@
+import Image from "next/image";
+
+import { isOptimisableImage } from "@/lib/blob";
 import { cn } from "@/lib/cn";
 
 /**
  * The image band on a project card.
  *
- * `image_url` has been in the content model since #17 and nothing rendered it.
- * The complication: no images are committed anywhere in this repo — the seeded
- * paths like `/assets/images/edupath.png` point at files that do not exist, so
- * today every one of them 404s.
+ * ## Three renderings, picked by what the record actually holds
  *
- * So the image is painted as a CSS background layered over a generated
- * gradient, rather than as an <img>. A background that fails to load simply
- * does not paint and the gradient shows through — no broken-image icon, no
- * layout shift, no `onError` handler and therefore no client component. When
- * real images do land, the same markup starts showing them with no change here.
+ * 1. **No image** — a designed generative cover (slug-derived gradient, ghost
+ *    initial, slug), but only where a `cover` was asked for.
+ * 2. **An uploaded image** — `next/image`, so it is resized, served as AVIF or
+ *    WebP, and lazy below the fold. This is the path the console's upload
+ *    button produces and the one that should be normal.
+ * 3. **Any other URL** — painted as a CSS background instead.
+ *
+ * That third case is not legacy tolerance, it is the site's rule about data it
+ * does not control. `image_url` is free text: an admin can paste a link to
+ * anything, and the seeded rows once pointed at `/assets/images/*.png` files
+ * that were never committed. Handing such a URL to `next/image` throws at
+ * render and takes the whole page down for one bad string. A background that
+ * fails to load simply does not paint, the gradient shows through, and there is
+ * no broken-image icon, no layout shift, and no `onError` handler — so no
+ * client component either.
  *
  * The gradient angle is derived from the slug so each project reads as its own
  * tile, but the colours stay on the site's palette — this is meant to look
@@ -32,11 +42,18 @@ export function ProjectMedia({
   title,
   imageUrl,
   cover = false,
+  priority = false,
   className,
 }: {
   slug: string;
   title: string;
   imageUrl: string | null;
+  /**
+   * Set on the first case row only. That panel is usually the page's LCP once
+   * real covers exist, and everything below it should stay lazy — marking them
+   * all `priority` would queue five full-width images against the hero.
+   */
+  priority?: boolean;
   /**
    * Render a designed generative cover when the record has no image. Off by
    * default: in a dense grid an identical box per card reads as a grid of
@@ -82,6 +99,43 @@ export function ProjectMedia({
     );
   }
 
+  const tile =
+    "relative flex items-end overflow-hidden rounded-[var(--radius-control)] border border-border";
+
+  // The caption both branches share: the title, restated over the panel. It is
+  // aria-hidden because the card's own heading is directly below.
+  const caption = (
+    <span
+      aria-hidden="true"
+      className="relative z-10 p-3 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground"
+    >
+      {title}
+    </span>
+  );
+
+  if (isOptimisableImage(imageUrl)) {
+    return (
+      <div className={cn(tile, "aspect-[16/7] bg-muted", className)} role="presentation">
+        <Image
+          src={imageUrl}
+          // Decorative here: the title is the heading beside this panel, and
+          // repeating it would make a screen reader say everything twice.
+          alt=""
+          fill
+          /*
+           * The panel is half the layout at `lg` and full width below it.
+           * Without this, next/image assumes 100vw everywhere and ships a
+           * desktop-width file to fill a 700px column.
+           */
+          sizes="(min-width: 1024px) 46rem, 100vw"
+          priority={priority}
+          className="object-cover"
+        />
+        {caption}
+      </div>
+    );
+  }
+
   // Later layers paint on top. The image sits above the gradient, so it wins
   // when it loads and is invisible when it does not.
   const backgroundImage = [
@@ -91,21 +145,11 @@ export function ProjectMedia({
 
   return (
     <div
-      className={cn(
-        "relative flex aspect-[16/7] items-end overflow-hidden rounded-[var(--radius-control)] border border-border bg-cover bg-center",
-        className,
-      )}
+      className={cn(tile, "aspect-[16/7] bg-cover bg-center", className)}
       style={{ backgroundImage }}
-      // The title is already the card's heading right below this; announcing it
-      // again here would just make screen readers say everything twice.
       role="presentation"
     >
-      <span
-        aria-hidden="true"
-        className="p-3 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground"
-      >
-        {title}
-      </span>
+      {caption}
     </div>
   );
 }

--- a/apps/web/components/ui/project-media.tsx
+++ b/apps/web/components/ui/project-media.tsx
@@ -102,15 +102,53 @@ export function ProjectMedia({
   const tile =
     "relative flex items-end overflow-hidden rounded-[var(--radius-control)] border border-border";
 
-  // The caption both branches share: the title, restated over the panel. It is
-  // aria-hidden because the card's own heading is directly below.
+  /*
+   * The caption both branches share: the title, restated over the panel. It is
+   * aria-hidden because the card's own heading is directly below.
+   *
+   * ## The scrim is not decoration
+   *
+   * This used to be `text-muted-foreground` sitting directly on the image. That
+   * is fine on the dark photo you happen to test with and fails on everything
+   * else: measured on a white cover it came out at 2.33:1, against the 4.5:1
+   * this size of text needs. The covers being uploaded are screenshots of web
+   * apps, which are mostly light — so the failing case is the normal one, and
+   * it was invisible while every record had `image_url: null`.
+   *
+   * Over an image the caption stops following the theme, because the photo is
+   * its background rather than the page: light text on a dark scrim in both
+   * modes. `black`/`white` rather than tokens is deliberate and is not the
+   * literal-instead-of-token bug — there is no "darken an arbitrary
+   * photograph" surface in the palette, and a scrim that flipped with the
+   * theme would be unreadable in one of them.
+   */
   const caption = (
-    <span
-      aria-hidden="true"
-      className="relative z-10 p-3 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground"
-    >
-      {title}
-    </span>
+    <>
+      <span
+        aria-hidden="true"
+        /*
+         * `bg-linear-to-t`, not `bg-gradient-to-t`. Tailwind v4 renamed the
+         * gradient utilities, and the v3 name emits no `background-image` at
+         * all — the element was there, styled, and completely invisible, which
+         * is the same silent failure as `rounded-[--radius-card]`. Verified by
+         * reading `backgroundImage` off getComputedStyle, not by reading the
+         * class name.
+         *
+         * `inset-0` rather than `bottom-0 h-1/2`: a percentage height inside an
+         * aspect-ratio box resolved to zero, so the span measured 0x0. The
+         * gradient is transparent across the top half anyway, so covering the
+         * whole tile paints the same thing without depending on how the
+         * parent's height was arrived at.
+         */
+        className="pointer-events-none absolute inset-0 bg-linear-to-t from-black/85 via-black/35 via-18% to-transparent to-36%"
+      />
+      <span
+        aria-hidden="true"
+        className="relative z-10 p-3 font-mono text-xs uppercase tracking-[0.18em] text-white/90 [text-shadow:0_1px_2px_rgb(0_0_0/0.5)]"
+      >
+        {title}
+      </span>
+    </>
   );
 
   if (isOptimisableImage(imageUrl)) {

--- a/apps/web/lib/admin-guard.ts
+++ b/apps/web/lib/admin-guard.ts
@@ -35,6 +35,37 @@ import {
 export type AdminSession = { user: CurrentUser; accessToken: string };
 
 /**
+ * Resolve the caller's admin session, or null. Never redirects.
+ *
+ * ## Why this exists separately from requireAdmin
+ *
+ * `requireAdmin` answers with a *redirect*, which is right for a page — a
+ * signed-out visitor should meet the sign-in screen. It is wrong for anything
+ * a `fetch` calls. A route handler that redirects hands the caller a 307 to
+ * `/login` and, since `fetch` follows redirects by default, the JSON parse
+ * downstream fails on a page of HTML. The upload route needs a plain 401, so
+ * it needs a check that returns rather than throws a redirect.
+ *
+ * Unlike `requireAdmin` this does not attempt token renewal. Renewal is a
+ * redirect through /auth/refresh — the one thing a route handler cannot do —
+ * so an expired session is simply "no session" here, and the client re-auths
+ * by navigating.
+ */
+export async function getAdminSession(): Promise<AdminSession | null> {
+  const jar = await cookies();
+  const accessToken = jar.get(ACCESS_COOKIE)?.value;
+  if (!accessToken) return null;
+
+  const result = await fetchCurrentUser(accessToken);
+  if (!result.ok) return null;
+
+  // Signed in is not the same as allowed.
+  if (!result.data.roles.includes("admin")) return null;
+
+  return { user: result.data, accessToken };
+}
+
+/**
  * Whether the caller already holds a usable admin session.
  *
  * Used by the sign-in screen to send someone straight to /admin rather than
@@ -43,13 +74,7 @@ export type AdminSession = { user: CurrentUser; accessToken: string };
  * bounce between /login and /admin.
  */
 export async function hasLiveSession(): Promise<boolean> {
-  const jar = await cookies();
-  const accessToken = jar.get(ACCESS_COOKIE)?.value;
-  if (!accessToken) return false;
-
-  const result = await fetchCurrentUser(accessToken);
-
-  return result.ok && result.data.roles.includes("admin");
+  return (await getAdminSession()) !== null;
 }
 
 /**

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -65,12 +65,24 @@ export const CONTENT_TAGS = {
 
 export type ContentTag = (typeof CONTENT_TAGS)[keyof typeof CONTENT_TAGS];
 
-async function getJson<T>(
+/**
+ * A read, plus whether the API actually answered it.
+ *
+ * Every reader below returns a fallback on failure, which is what keeps the
+ * site up when the backend is asleep — and which also makes an empty list
+ * ambiguous: it means "nothing published" and "nothing reachable" equally. The
+ * home page's topology claims one of its nodes is *live*, and a claim like that
+ * has to be answerable. `ok` is that answer, and it is the only thing that
+ * separates the two cases.
+ */
+export type Read<T> = { data: T; ok: boolean };
+
+async function readJson<T>(
   path: string,
   fallback: T,
   isExpectedShape: ShapeCheck,
   tag: ContentTag,
-): Promise<T> {
+): Promise<Read<T>> {
   const url = `${API_URL}/api/v1${path}`;
 
   try {
@@ -86,26 +98,49 @@ async function getJson<T>(
       // A 404 on a detail route is the caller's business, not an outage; it is
       // reported the same way here and distinguished by the caller's fallback.
       console.error(`[api] ${response.status} ${response.statusText} for ${url}`);
-      return fallback;
+      return { data: fallback, ok: false };
     }
 
     const data = await response.json();
 
     if (!isExpectedShape(data)) {
       console.error(`[api] unexpected shape from ${url}:`, data);
-      return fallback;
+      return { data: fallback, ok: false };
     }
 
-    return data as T;
+    return { data: data as T, ok: true };
   } catch (error) {
     // Covers DNS failure, connection refused, and the timeout above.
     console.error(`[api] request to ${url} failed:`, error);
-    return fallback;
+    return { data: fallback, ok: false };
   }
+}
+
+/** The shape almost every caller wants: the data, and no opinion about why. */
+async function getJson<T>(
+  path: string,
+  fallback: T,
+  isExpectedShape: ShapeCheck,
+  tag: ContentTag,
+): Promise<T> {
+  const { data } = await readJson(path, fallback, isExpectedShape, tag);
+  return data;
 }
 
 export async function getProjects(): Promise<Project[]> {
   return getJson<Project[]>("/projects/", [], isList, CONTENT_TAGS.projects);
+}
+
+/**
+ * The projects read, with the outcome kept.
+ *
+ * Only the home page needs this: it draws the request path that served the
+ * page, and the API node on that drawing is lit or dim depending on whether
+ * this very read succeeded. Everywhere else wants `getProjects` — a sitemap has
+ * nothing to say about reachability.
+ */
+export async function readProjects(): Promise<Read<Project[]>> {
+  return readJson<Project[]>("/projects/", [], isList, CONTENT_TAGS.projects);
 }
 
 export async function getProject(slug: string): Promise<Project | null> {

--- a/apps/web/lib/blob.test.ts
+++ b/apps/web/lib/blob.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { BLOB_HOSTNAME, isOptimisableImage } from "./blob";
+
+/*
+ * This guard decides what next/image is allowed to fetch, so the interesting
+ * cases are the ones that *look* like the blob host without being it. A
+ * substring check would pass most of them.
+ */
+describe("isOptimisableImage", () => {
+  it("accepts an https URL on the project's blob host", () => {
+    expect(isOptimisableImage(`https://${BLOB_HOSTNAME}/cover-abc123.png`)).toBe(true);
+  });
+
+  it("rejects another host that merely mentions the blob host", () => {
+    expect(isOptimisableImage(`https://evil.example/?x=${BLOB_HOSTNAME}`)).toBe(false);
+    expect(isOptimisableImage(`https://evil.example/${BLOB_HOSTNAME}/a.png`)).toBe(false);
+  });
+
+  it("rejects a subdomain prefix attack", () => {
+    // `hostname` is compared whole, so this is not the configured host even
+    // though it ends with a string that contains it.
+    expect(isOptimisableImage(`https://${BLOB_HOSTNAME}.evil.example/a.png`)).toBe(false);
+  });
+
+  it("rejects a userinfo trick", () => {
+    // The host here is evil.example; everything before the @ is credentials.
+    expect(isOptimisableImage(`https://${BLOB_HOSTNAME}@evil.example/a.png`)).toBe(false);
+  });
+
+  it("rejects plain http on the right host", () => {
+    expect(isOptimisableImage(`http://${BLOB_HOSTNAME}/a.png`)).toBe(false);
+  });
+
+  it("rejects the values this field actually used to hold", () => {
+    // The seeded rows pointed at files that were never committed, and the
+    // field is free text, so both of these are real inputs.
+    expect(isOptimisableImage("/assets/images/edupath.png")).toBe(false);
+    expect(isOptimisableImage("")).toBe(false);
+    expect(isOptimisableImage("not a url at all")).toBe(false);
+  });
+});

--- a/apps/web/lib/blob.ts
+++ b/apps/web/lib/blob.ts
@@ -1,0 +1,44 @@
+/**
+ * Where uploaded images live, in one place.
+ *
+ * Imported by *both* `next.config.ts` and the components that render an image,
+ * because the two have to agree: the config decides which hosts next/image will
+ * fetch, and a component that hands next/image an unlisted host gets a 400 and
+ * renders nothing. Declaring the hostname twice is how those drift apart.
+ *
+ * No imports of its own, and nothing Next-specific, so the config file can load
+ * it without dragging the app's module graph into the build config.
+ */
+
+/**
+ * This project's Vercel Blob store, from `vercel blob get-store` ("Base URL").
+ *
+ * Deliberately one exact host rather than `**.public.blob.vercel-storage.com`:
+ * that wildcard turns `/_next/image` into an open proxy for every Blob store on
+ * the platform.
+ */
+export const BLOB_HOSTNAME = "8nvvdsrnxea4lvva.public.blob.vercel-storage.com";
+
+/**
+ * Whether next/image is allowed to touch this URL.
+ *
+ * `image_url` is a free-text field — the admin can paste a link to anything,
+ * and older rows may point at hosts that no longer exist. Passing one of those
+ * to next/image is not a soft failure: it throws at render, which would take
+ * out the whole page for one bad string, and this site's rule is that a page
+ * renders even when the data behind it does not.
+ *
+ * So callers ask first and fall back to an unoptimised treatment when the
+ * answer is no. Parsing rather than string-matching, because
+ * `https://evil.example/?x=8nvvdsrnxea4lvva.public.blob.vercel-storage.com`
+ * passes `includes()` and is not this host.
+ */
+export function isOptimisableImage(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === BLOB_HOSTNAME;
+  } catch {
+    // Not an absolute URL at all — a relative path, or something mistyped.
+    return false;
+  }
+}

--- a/apps/web/lib/content-schema.ts
+++ b/apps/web/lib/content-schema.ts
@@ -34,6 +34,12 @@ export type FieldKind =
   /** Markdown, edited as plain text. Rendered server-side; see lib/markdown.ts. */
   | "markdown"
   | "url"
+  /**
+   * An image URL, with a file picker that uploads to Blob and fills it in.
+   * Still a URL underneath — the text input is the field, so the form keeps
+   * working with scripting off. See components/console/image-field.tsx.
+   */
+  | "image"
   /** An API `date` column: sent as `YYYY-MM-DD`. */
   | "date"
   /** An API `datetime` column, but only the day is meaningful. See toPayload. */
@@ -144,7 +150,13 @@ export const ENTITIES: EntitySpec[] = [
         hint: "The body of the detail page.",
       },
       SLUG,
-      { name: "image_url", label: "Image URL", kind: "url", maxLength: 500 },
+      {
+        name: "image_url",
+        label: "Cover image",
+        kind: "image",
+        maxLength: 500,
+        hint: "The panel beside this project on the home page, and its detail header.",
+      },
       { name: "github_url", label: "Source URL", kind: "url", maxLength: 500 },
       { name: "live_url", label: "Live URL", kind: "url", maxLength: 500 },
       { name: "technologies", label: "Technologies", kind: "list" },
@@ -196,7 +208,7 @@ export const ENTITIES: EntitySpec[] = [
       },
       SLUG,
       { name: "tags", label: "Tags", kind: "list" },
-      { name: "cover_image", label: "Cover image URL", kind: "url", maxLength: 500 },
+      { name: "cover_image", label: "Cover image", kind: "image", maxLength: 500 },
       PUBLISHED,
       {
         name: "published_at",
@@ -225,7 +237,7 @@ export const ENTITIES: EntitySpec[] = [
       { name: "skills", label: "Skills", kind: "list" },
       { name: "credential_id", label: "Credential ID", kind: "text", maxLength: 100 },
       { name: "credential_url", label: "Credential URL", kind: "url", maxLength: 500 },
-      { name: "image_url", label: "Image URL", kind: "url", maxLength: 500 },
+      { name: "image_url", label: "Image", kind: "image", maxLength: 500 },
       PUBLISHED,
     ],
   },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
+import { BLOB_HOSTNAME } from "./lib/blob";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    /*
+     * One host: this project's Blob store. See lib/blob.ts for why it is not
+     * the `**.public.blob.vercel-storage.com` wildcard, and for the matching
+     * guard the components use before handing a URL to next/image.
+     */
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: BLOB_HOSTNAME,
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@shikijs/rehype": "^4.4.3",
+    "@vercel/blob": "^2.8.0",
     "clsx": "^2.1.1",
     "next": "16.3.0",
     "react": "19.2.8",

--- a/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
+++ b/apps/web/tests/e2e/site-survives-a-dead-api.spec.ts
@@ -19,10 +19,12 @@ const PAGES = [
   {
     path: "/",
     heading: "Phạm Đăng Khôi",
+    // The writing section is deliberately absent rather than empty here — see
+    // the test below. Projects and capabilities still explain themselves, so
+    // the page continues to say that it is empty on purpose rather than broken.
     empty: [
       "No entries returned — the write-up queue is still draining.",
       "No capabilities published yet.",
-      "Nothing published yet — drafts are still in review.",
     ],
   },
   {
@@ -80,6 +82,24 @@ test.describe("pages built with no API behind them", () => {
     // all.
     await expect(page.getByText("/selected-work · 0")).toBeVisible();
     await expect(page.getByText("/capabilities · 0")).toBeVisible();
+  });
+
+  test("the home page drops the writing section rather than advertising an empty one", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // With no posts this section used to render "Nothing published yet" into
+    // 545px of blank page — a section whose only content was the admission
+    // that it had none, on the page that has five seconds to be convincing.
+    // Absent is the intended state, so it is asserted rather than left to
+    // whichever way the markup happens to fall.
+    await expect(page.locator("#writing")).toHaveCount(0);
+    await expect(page.getByText("Nothing published yet")).toHaveCount(0);
+
+    // But not hidden: /blog is still reachable and still explains itself, so
+    // dropping the preview loses nobody the content.
+    await expect(page.getByRole("link", { name: "Blog" })).toBeVisible();
   });
 
   test("the contact form is still usable when the content API is gone", async ({ page }) => {

--- a/docs/redesign.md
+++ b/docs/redesign.md
@@ -166,6 +166,25 @@ after Phase 5.
   opaque fills occlude it: it visibly enters a service and comes out the far
   side, which is the one thing a static architecture diagram cannot say.
 
+- **2026-08-20 — text over imagery stops following the theme.** Found by
+  temporarily injecting covers locally to exercise the spread layout, which had
+  never rendered on this site. The caption sat straight on the image in
+  `text-muted-foreground` — 2.33:1 on a white cover, against the 4.5:1 it needs,
+  and the covers being uploaded are screenshots of web apps, so the failing case
+  is the normal one. Over an image the caption is now light text on a dark scrim
+  in **both** modes, because its background is the photograph rather than the
+  page. `black`/`white` rather than tokens is deliberate: there is no "darken an
+  arbitrary photograph" surface in the palette, and a scrim that flipped with the
+  theme would be unreadable in one of them.
+
+  Two silent failures in the scrim itself are worth remembering. `bg-gradient-to-t`
+  emits **no** `background-image` under Tailwind v4, which renamed the utilities
+  to `bg-linear-*` — present, positioned, invisible, exactly like
+  `rounded-[--radius-card]`. And `bottom-0 h-1/2` measured 0×0, because a
+  percentage height inside an aspect-ratio box resolves to zero. Both were caught
+  by reading `getComputedStyle`, neither by reading the class name. That is now
+  three separate instances of the same lesson in this file.
+
 - **2026-08-20 — the case row's layout follows the data.** Every project has
   `image_url: null`, and the row reserved half the page for a generated gradient
   regardless. Four of those stacked put roughly 40% of the page's area into empty

--- a/docs/redesign.md
+++ b/docs/redesign.md
@@ -140,6 +140,75 @@ after Phase 5.
 
 ## Decisions log
 
+- **2026-08-20 — the hero stopped illustrating and started reporting.** The
+  topology drew FastAPI fanning out to Postgres, Redis and Kafka. Those are real
+  technologies from the projects below, but none of Redis or Kafka is in *this*
+  system — so a portfolio arguing for honest systems engineering opened with a
+  diagram of something that was not running.
+
+  It is now the four services that actually serve the response — Browser →
+  Next.js on Vercel → FastAPI on `fly.io/iad` → Postgres on `neon/us-east-2`,
+  checked against `fly.toml` rather than memory — with a readout line under it
+  reporting the call the page really made: `GET /projects/ · 200 · 5 records`.
+
+  The API node is lit **only if that read was answered**. `lib/api.ts` returns a
+  fallback on failure so the site stays up, which makes an empty list ambiguous
+  between "nothing published" and "nothing reachable"; `readJson` now keeps the
+  outcome and `readProjects()` hands it to the page. When the backend is asleep
+  the node goes dim and the readout says `no answer · serving fallback`. A status
+  light that is always on is not a status light.
+
+  Two shape decisions fell out of building it. The chain is folded into a
+  serpentine because four nodes in a row leaves ~30px gaps, and a packet
+  travelling behind them was hidden for 92% of its journey — it read as a
+  flicker. Folded, the open runs dominate and the packet is visible about three
+  quarters of the time. And the packet is drawn *before* the nodes so their
+  opaque fills occlude it: it visibly enters a service and comes out the far
+  side, which is the one thing a static architecture diagram cannot say.
+
+- **2026-08-20 — the case row's layout follows the data.** Every project has
+  `image_url: null`, and the row reserved half the page for a generated gradient
+  regardless. Four of those stacked put roughly 40% of the page's area into empty
+  grey panels, which do not read as "a cover is coming" but as broken images.
+
+  A project without a cover now gets a record layout — mono fields beside prose,
+  full width, about a third of the height — and a rule per row, so a run of them
+  reads as a ledger of work. Uploading a cover switches that row back to the
+  spread with no other change. The owner is uploading real screenshots in prod;
+  the page is built for them without pretending they have arrived. Generated
+  per-project artwork was considered and rejected: the fix for "no real images"
+  is real images, not better fakes.
+
+- **2026-08-20 — motion below the fold, in one vocabulary.** All the previous
+  motion was in the hero. The rule for what was added: lit things travel along
+  paths, and every one of them is driven by the reader rather than a timer.
+
+  The spine's lit path was running bright-to-dim *downward*, so its strongest
+  point sat at the top of a section already passed. Inverted, the head is at the
+  scroll position and the trail behind it is ink. The green is held to the last
+  12% of the gradient — at a 60% stop it covered ~500px of a tall section's rail
+  and put a long saturated line down the page, which is colour describing where
+  the reader has been rather than where something is happening.
+
+  The capabilities table, the most static block on the page, gained a scan: each
+  layer's left tick lights as that layer crosses the middle of the viewport, in
+  stack order. Both sit behind the same `@supports` + `prefers-reduced-motion`
+  guards as everything else, with ink resting states.
+
+  Verified rather than assumed: `document.getAnimations()` shows 41 running;
+  cancelling all of them leaves nothing content-bearing invisible, and under
+  emulated `prefers-reduced-motion: reduce` nothing runs and nothing hides. The
+  two hero packets are deliberately `opacity: 0` when motion is off — a packet
+  is pure motion, and parked on a wire it would claim something is in flight.
+
+- **2026-08-20 — density: 6.6 screens → 4.67.** Section padding was `py-40` at
+  `lg`, 320px of nothing per boundary; it is `py-28` now, since the rule and the
+  tint already mark where a section starts. The contact block was 1065px for one
+  form and three links — channels moved beside the form and it is 861px. The
+  `/writing` section is **absent** when there are no posts rather than rendering
+  "Nothing published yet" into 545px of blank page; an e2e test pins that, and
+  `/blog` still explains itself for anyone who goes looking.
+
 - **2026-08-20 — the amber is gone, and so is the grid.** Reviewed on the
   deployed site, the verdict was that the yellow *text* and the graph-paper
   background were ugly. Both were removed and the palette is now monochrome:

--- a/docs/redesign.md
+++ b/docs/redesign.md
@@ -140,8 +140,35 @@ after Phase 5.
 
 ## Decisions log
 
-- **Amber replaces both green and purple.** One accent across modes; the old
-  scheme had no single identity.
+- **2026-08-20 — the amber is gone, and so is the grid.** Reviewed on the
+  deployed site, the verdict was that the yellow *text* and the graph-paper
+  background were ugly. Both were removed and the palette is now monochrome:
+  no accent hue at all, hierarchy from type and surface steps, and the only
+  colour on a page is whatever is inside a project screenshot.
+
+  The standing rule is now **colour never touches text**. `--primary` and
+  `--signal` survive as token names because every component reads them, but
+  they resolve to ink and near-white.
+
+  Three things fell out of that decision rather than being asked for:
+
+  - The **status badges** were four Tailwind hues (green/blue/yellow/red) and
+    became the loudest thing on the page once the amber stopped drowning them.
+    They now carry state in the *dot* — filled, ringed, hollow, dim — which
+    also survives greyscale and red/green colour blindness, which the old
+    version did not.
+  - **Light mode was a warm cream**, justified as somewhere for the amber to
+    sit. With no amber it was just beige — and "AI beige" is a named
+    AI-interface tell. The neutrals are cool now, sharing the ink's hue.
+  - The **availability dot pulsed forever**, defended above as "calm
+    telemetry". Nothing about it was telemetry; it was an infinite loop in the
+    first viewport saying something static. It is a plain dot.
+
+  Also capped case-row technology chips at five plus a count. Eleven identical
+  chips read as one grey texture, not as eleven facts.
+
+- ~~**Amber replaces both green and purple.**~~ Superseded by the entry above.
+  One accent across modes; the old scheme had no single identity.
 - **No WebGL/three.js.** Depth from surface steps, glow, and pointer tilt;
   LCP and taste both prefer it.
 - **No scroll-hijacking (Lenis etc.).** Native scroll + CSS scroll-driven

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@shikijs/rehype':
         specifier: ^4.4.3
         version: 4.4.3
+      '@vercel/blob':
+        specifier: ^2.8.0
+        version: 2.8.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -921,6 +924,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/blob@2.8.0':
+    resolution: {integrity: sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/cli-config@0.2.3':
+    resolution: {integrity: sha512-Ggh0Wmi92TUkUexmSUPkkDtvJmbjUr7IvF5T3FkSsWrXXs3GFzOujfxFpECdJZpux1JG4SWDv9BT4w++TDgD6A==}
+
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==}
+    engines: {node: '>= 18'}
+
+  '@vercel/oidc@3.8.4':
+    resolution: {integrity: sha512-FGNvVZ5pgX9FaBqkPt6VkYFZ6bWAMDzYi7nxW+1Xt+Z4fn5PuTULVwsxjKc+0uKhysyWBQmvsmM50Oh6C2/oMA==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -1016,6 +1034,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1378,6 +1399,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -1469,6 +1494,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -1551,6 +1580,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1586,6 +1619,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -1634,6 +1671,9 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -1657,6 +1697,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -1695,6 +1739,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1947,6 +1994,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2039,6 +2089,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
@@ -2094,6 +2148,10 @@ packages:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2130,6 +2188,10 @@ packages:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -2139,6 +2201,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   own-keys@1.0.2:
     resolution: {integrity: sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==}
@@ -2279,6 +2345,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2370,6 +2440,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2420,6 +2493,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -2454,6 +2531,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2530,6 +2611,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2681,6 +2766,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2693,6 +2786,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3457,6 +3553,30 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vercel/blob@2.8.0':
+    dependencies:
+      '@vercel/oidc': 3.8.4
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.28.0
+
+  '@vercel/cli-config@0.2.3':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/oidc@3.8.4':
+    dependencies:
+      '@vercel/cli-config': 0.2.3
+      '@vercel/cli-exec': 1.0.1
+      jose: 5.10.0
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3591,6 +3711,10 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -4090,6 +4214,18 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   expect-type@1.4.0: {}
 
   extend@3.0.2: {}
@@ -4184,6 +4320,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
+  get-stream@6.0.1: {}
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -4273,6 +4411,8 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  human-signals@2.1.0: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -4312,6 +4452,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@2.0.5: {}
 
   is-bun-module@2.0.0:
     dependencies:
@@ -4360,6 +4502,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-node-process@1.2.0: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -4381,6 +4525,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -4422,6 +4568,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4701,6 +4849,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
@@ -4899,6 +5049,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-fn@2.1.0: {}
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
@@ -4952,6 +5104,10 @@ snapshots:
 
   node-releases@2.0.53: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -4996,6 +5152,10 @@ snapshots:
 
   obug@2.1.4: {}
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -5012,6 +5172,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  os-paths@4.4.0: {}
 
   own-keys@1.0.2:
     dependencies:
@@ -5179,6 +5341,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rolldown@1.2.3:
@@ -5335,6 +5499,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
@@ -5408,6 +5574,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@2.0.0: {}
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.8):
@@ -5428,6 +5596,8 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 
@@ -5519,6 +5689,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@6.28.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -5691,6 +5863,15 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
@@ -5698,6 +5879,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@4.1.11: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
Eight commits. The branch's earlier half took the colour off the text and built
image upload; the last three make the home page worth looking at and fix a
contrast bug that upload was about to walk into.

## The home page

**The hero reports instead of illustrating.** It drew FastAPI fanning out to
Postgres, Redis and Kafka. Neither Redis nor Kafka is in this system, so a
portfolio arguing for honest systems engineering opened with a diagram of
something that was not running. It is now the four services that actually serve
the response — Browser → Next.js/Vercel → FastAPI/`fly.io·iad` →
Postgres/`neon·us-east-2`, checked against `fly.toml` rather than memory — under
a readout of the call the page really made: `GET /projects/ · 200 · 5 records`.

The API node is lit **only if that read was answered**. `lib/api.ts` returns a
fallback on failure, which makes an empty list ambiguous between "nothing
published" and "nothing reachable"; `readJson` keeps the outcome now and
`readProjects()` hands it to the page. When the backend is asleep the node goes
dim and the readout says `no answer · serving fallback`. A status light that is
always on is not a status light.

The chain is folded into a serpentine because four nodes in a row leaves ~30px
gaps, and a packet travelling behind them was measured hidden for 92% of its
journey — it read as a flicker, not a request. Folded, the open runs dominate.
The packets are drawn *before* the node rects so the opaque fills occlude them:
the request visibly enters a service and comes out the far side.

**Case rows follow the data.** Every project has `image_url: null`, and the row
reserved half the page for a generated gradient regardless — four stacked put
roughly 40% of the page's area into empty grey panels, which do not read as "a
cover is coming" but as broken images. A project without a cover now gets a
record layout with a rule per row, so a run of them reads as a ledger of work.
Uploading a cover switches that row back to the spread with no other change.

**Motion below the fold, in one vocabulary** — lit things travel along paths,
and the reader drives all of it. The spine's lit path ran bright-to-*dim*
downward, putting its strongest point on a section already passed; inverted, the
head sits at the scroll position and the trail behind it is ink. The green is
held to the last 12% of the gradient — at a 60% stop it covered ~500px of a tall
section's rail, which is colour describing where the reader has *been*. The
capabilities table gained a scan that lights each layer in stack order.

**Density: 6.63 screens → 4.67.** Section padding was `py-40` at `lg`, 320px of
nothing per boundary. Contact is two columns and 861px rather than 1065px. The
`/writing` section is now **absent** when there are no posts rather than
rendering "Nothing published yet" into 545px of blank page.

## A bug this branch was about to ship

The caption over a project cover sat directly on the image in
`text-muted-foreground` — **2.33:1 on a white cover**, against the 4.5:1 it
needs. The failing case is the normal one: the covers being uploaded are
screenshots of web apps, which are mostly light. It was invisible because the
branch has never rendered on this site, so it was found by temporarily injecting
covers locally to exercise the spread layout.

Fixing it surfaced two silent failures worth knowing about:

- **`bg-gradient-to-t` emits no `background-image` under Tailwind v4**, which
  renamed the utilities to `bg-linear-*`. Present, positioned, invisible —
  the same failure mode as `rounded-[--radius-card]`.
- **`bottom-0 h-1/2` measured 0×0**, because a percentage height inside an
  aspect-ratio box resolves to zero.

Both were caught by reading `getComputedStyle`, neither by reading the class
name. Now 6.4:1 on a pure-white cover, darkening confined to the bottom third.

## Behaviour change to review deliberately

`site-survives-a-dead-api` asserted the `/writing` empty state that this PR
removes. That test is updated and a **new one pins the absence** rather than
just relaxing the old assertion — but it is a contract change, not a test fix,
so it wants a human opinion.

## Verification

`impeccable detect --json` → `[]`, with the tool proven alive on a deliberate
`bg-clip-text` canary first. Type-check, lint, 112 unit, 59 e2e, production
build green with `/` still prerendered. 1440 + 375 in both themes: no horizontal
overflow, all non-stretched tap targets ≥44px.

Motion verified rather than assumed: `document.getAnimations()` shows 41
running; cancelling all of them leaves nothing content-bearing invisible, and
under emulated `prefers-reduced-motion: reduce` nothing runs and nothing hides.
The two hero packets are deliberately `opacity: 0` when motion is off — a packet
is pure motion, and parked on a wire it would claim something is in flight.

No `apps/api` changes, so merging does not trigger the Fly deploy job.

## Two things that are NOT done

1. **The `frontend-reviewer` pass never ran.** Two attempts died in under a
   second on `API Error: Usage credits required for 1M context`, with zero
   tokens and zero tool calls; overriding the model did not help, because the
   requirement comes from the session. What is above is self-verification of
   measurable things — it is not a second pair of eyes on whether the record
   rows are *good* rather than merely dense. `docs/redesign.md` Phase 6 keeps
   that box unticked.
2. **There is still not one real image on the site.** The layout is now built
   and tested for the covers that are coming; it does not pretend they arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
